### PR TITLE
Added line to Linux installation instructions to tell Ubuntu 20.04 us…

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Windows:
 
 Linux:
 
+* For Ubuntu 20.04 and other Linux flavours that have EOL'd python2, switch to the python3 branch and follow the below instructions on this page, but in that branch.
 * Requires Python2.7 and the Python “iniparse”, “requests” and "tkinter" modules.
   - On Debian-based systems install these with `sudo apt-get install python-iniparse python-requests python-tk` .
   - On Arch, install these with `sudo pacman -S python2 python2-requests tk; sudo easy_install-2.7 iniparse` .


### PR DESCRIPTION
…ers to use python3 branch to avoid confusion.