### PR TITLE
Implements 'Help > About' menu item

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,6 +9,7 @@ appname = 'EDMarketConnector'
 applongname = 'E:D Market Connector'
 appcmdname = 'EDMC'
 appversion = '3.5.1.0'
+copyright = u'© 2015-2019 Jonathan Harris, 2020 EDCD'
 
 update_feed = 'https://raw.githubusercontent.com/EDCD/EDMarketConnector/releases/edmarketconnector.xml'
 update_interval = 8*60*60

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import shutil
 import sys
 from tempfile import gettempdir
 
-from config import appname as APPNAME, applongname as APPLONGNAME, appcmdname as APPCMDNAME, appversion as VERSION
+from config import appname as APPNAME, applongname as APPLONGNAME, appcmdname as APPCMDNAME, appversion as VERSION, copyright as COPYRIGHT
 from config import update_feed, update_interval
 
 
@@ -96,7 +96,7 @@ if sys.platform=='darwin':
                       ],
                       'LSMinimumSystemVersion': '10.10',
                       'NSAppleScriptEnabled': True,
-                      'NSHumanReadableCopyright': u'© 2015-2019 Jonathan Harris, 2020 EDCD',
+                      'NSHumanReadableCopyright': COPYRIGHT,
                       'SUEnableAutomaticChecks': True,
                       'SUShowReleaseNotes': True,
                       'SUAllowsAutomaticUpdates': False,
@@ -156,7 +156,7 @@ setup(
                  'company_name': 'EDCD',	# WinSparkle
                  'product_name': APP,           # WinSparkle
                  'version': VERSION,
-                 'copyright': u'© 2015-2019 Jonathan Harris, 2020 EDCD',
+                 'copyright': COPYRIGHT,
                  'other_resources': [(24, 1, open(APPNAME+'.manifest').read())],
              } ],
     console = [ {'dest_base': APPCMDNAME,
@@ -164,7 +164,7 @@ setup(
                  'company_name': 'EDCD',
                  'product_name': APPNAME,
                  'version': VERSION,
-                 'copyright': u'© 2015-2019 Jonathan Harris, 2020 EDCD',
+                 'copyright': COPYRIGHT,
              } ],
     data_files = DATA_FILES,
     options = OPTIONS,


### PR DESCRIPTION
 * Re-uses the 'About {APP}' that was defined because the MacOS version
   always had an 'About' bit.
 * As a side effect of wanting the copyright string in the popup this is
   now defined in config.py, and setup.py has been adjusted to also take
   it from there.
 * The About popup includes a link to the release notes, contingent on
   the git tag existing on github.
 * Only one instance of the popup is allowed at once.
 * There's still a 'TODO' for moving 'Check for updates' into this
   popup.

Closes #509