### PR TITLE
Add the new languages to the installed files.

### DIFF
--- a/EDMarketConnector.wxs
+++ b/EDMarketConnector.wxs
@@ -262,7 +262,13 @@
 							<File KeyPath="yes" Source="SourceDir\L10n\ru.strings" />
 						</Component>
 						<Component Guid="*">
+							<File KeyPath="yes" Source="SourceDir\L10n\sl.strings" />
+						</Component>
+						<Component Guid="*">
 							<File KeyPath="yes" Source="SourceDir\L10n\sr-Latn.strings" />
+						</Component>
+						<Component Guid="*">
+							<File KeyPath="yes" Source="SourceDir\L10n\sr-Latn-BA.strings" />
 						</Component>
 						<Component Guid="*">
 							<File KeyPath="yes" Source="SourceDir\L10n\uk.strings" />
@@ -561,7 +567,9 @@
 			<ComponentRef Id="ru.strings" />
 			<ComponentRef Id="select.pyd" />
 			<ComponentRef Id="ships.p" />
+			<ComponentRef Id="sl.strings" />
 			<ComponentRef Id="sr_Latn.strings" />
+			<ComponentRef Id="sr_Latn_BA.strings" />
 			<ComponentRef Id="snd_good.wav" />
 			<ComponentRef Id="snd_bad.wav" />
 			<ComponentRef Id="sqlite3.dll" />

--- a/docs/Translations.md
+++ b/docs/Translations.md
@@ -73,19 +73,42 @@ Adding a New Language
 ===
 To add a new language to the app:
 
-1. open [EDMarketConnector - Miscellaneous Manage Languages](https://marginal.oneskyapp.com/admin/project/languages/project/52710)
-1. Search for the language.
-1. Ensure you have the correct one if there are variants.
-1. Click the `+` on the right hand side to add the language.
+1. Add it to the OneSkyApp project:
+    1. open [EDMarketConnector - Miscellaneous Manage Languages](https://marginal.oneskyapp.com/admin/project/languages/project/52710)
+    1. Search for the language.
+    1. Ensure you have the correct one if there are variants.
+    1. Click the `+` on the right hand side to add the language.
 
-Remember that until there are translations all strings will default to the English version (actually the key, which is always specified in English).
+    Remember that until there are translations all strings will default to the English version (actually the key, which is always specified in English).
 
-You will also want to add it to the installer.  This is simple enough, only requiring you add a number to an array in `EDMarketConnector.wxs`.
+1. You need to get the new `.string` file added to the files the installer will install:
+    1. Edit `EDMarketConnector.wxs` to add an appropriate section to the:
+    
+            `<Directory Id="L10n" Name="L10n">`
+       section, e.g.:
+       
+                <Component Guid="*">
+		            <File KeyPath="yes" Source="SourceDir\L10n\sr-Latn-BA.strings" />
+                </Component>`
+    1. You also need to add a line in the:
+    
+            <Feature Id='Complete' Level='1'>
+    
+        section, e.g.:
+    
+                <ComponentRef Id="sr_Latn_BA.strings" />
+        Note how the `-` characters have been changed to `_`.  If needs be run the build process once and look out for
+        lines like:
+     
+                \EDMarketConnector\EDMarketConnector.wxs(264) : error LGHT0204 : ICE21: Component: 'sr_Latn_BA.strings' does not belong to any Feature.
+        to see what the applicable string is.
 
-1. In `EDMarketConnector.wxs` find the line beginning `Languages="1033,`, e.g.
+1. You will also want to add it to the installer's languages.  This is simple enough, only requiring you add a number to an array in `EDMarketConnector.wxs`.
 
-		Languages="1033,1029,1031,1034,1035,1036,1038,1040,1041,1043,1045,1046,1049,1058,1062,2052,2070,2074,6170,0" />
-1. Now you'll need to consult the latest [[MS-LCID]: Windows Language Code Identifier (LCID) Reference](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/70feba9f-294e-491e-b6eb-56532684c37f) for the correct numerical code to add to the list.
-1. Convert the hexadecimal Language ID to the equivalent in decimal.
-1. Add the new decimal value as the last but one value in the list, keeping the `,0` at the end.
-1. Update the comment on the next line to reflect what you added.
+    1. In `EDMarketConnector.wxs` find the line beginning `Languages="1033,`, e.g.
+
+    		Languages="1033,1029,1031,1034,1035,1036,1038,1040,1041,1043,1045,1046,1049,1058,1062,2052,2070,2074,6170,0" />
+    1. Now you'll need to consult the latest [[MS-LCID]: Windows Language Code Identifier (LCID) Reference](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/70feba9f-294e-491e-b6eb-56532684c37f) for the correct numerical code to add to the list.
+    1. Convert the hexadecimal Language ID to the equivalent in decimal.
+    1. Add the new decimal value as the last but one value in the list, keeping the `,0` at the end.
+    1. Update the comment on the next line to reflect what you added.


### PR DESCRIPTION
This both fixes the new 'sl' and 'sr-Latin-BA' strings files to be included in a new install *and* documents the necessary steps to do so in docs/Translations.md.

closes #547 