### PR TITLE
Use a strict regex for matching Journal*.log files

### DIFF
--- a/EDMC.py
+++ b/EDMC.py
@@ -80,7 +80,7 @@ try:
         # Get state from latest Journal file
         try:
             logdir = config.get('journaldir') or config.default_journal_dir
-            logfiles = sorted([x for x in os.listdir(logdir) if x.startswith('Journal') and x.endswith('.log')],
+            logfiles = sorted([x for x in os.listdir(logdir) if re.search('^Journal(Beta)?\.[0-9]{12}\.[0-9]{2}\.log$', x)],
                               key=lambda x: x.split('.')[1:])
             logfile = join(logdir, logfiles[-1])
             with open(logfile, 'r') as loghandle:

--- a/monitor.py
+++ b/monitor.py
@@ -129,7 +129,7 @@ class EDLogs(FileSystemEventHandler):
         # Latest pre-existing logfile - e.g. if E:D is already running. Assumes logs sort alphabetically.
         # Do this before setting up the observer in case the journal directory has gone away
         try:
-            logfiles = sorted([x for x in listdir(self.currentdir) if x.startswith('Journal') and x.endswith('.log')],
+            logfiles = sorted([x for x in listdir(self.currentdir) if re.search('^Journal(Beta)?\.[0-9]{12}\.[0-9]{2}\.log$', x)],
                               key=lambda x: x.split('.')[1:])
             self.logfile = logfiles and join(self.currentdir, logfiles[-1]) or None
         except:
@@ -188,7 +188,7 @@ class EDLogs(FileSystemEventHandler):
 
     def on_created(self, event):
         # watchdog callback, e.g. client (re)started.
-        if not event.is_directory and basename(event.src_path).startswith('Journal') and basename(event.src_path).endswith('.log'):
+        if not event.is_directory and re.search('^Journal(Beta)?\.[0-9]{12}\.[0-9]{2}\.log$', basename(event.src_path)):
             self.logfile = event.src_path
 
     def worker(self):
@@ -248,7 +248,7 @@ class EDLogs(FileSystemEventHandler):
             else:
                 # Poll
                 try:
-                    logfiles = sorted([x for x in listdir(self.currentdir) if x.startswith('Journal') and x.endswith('.log')],
+                    logfiles = sorted([x for x in listdir(self.currentdir) if re.search('^Journal(Beta)?\.[0-9]{12}\.[0-9]{2}\.log$', x)],
                                       key=lambda x: x.split('.')[1:])
                     newlogfile = logfiles and join(self.currentdir, logfiles[-1]) or None
                 except:


### PR DESCRIPTION
A user accidentally copied a Journal file into the same directory, resulting in
a "Journal.<datetime>.<serial> - Copy.log" file.  EDMC 3.99.0.0 then picked this
up and re-sent events to EDDN, EDSM, Inara.

So, let's be strict about the filenames we consider to be valid, live, Journal
files.

 * Journal files have one basic form: Journal.YYMMDDHHMMSS.XX.log
 * In addition the word 'Beta' can be inserted just after 'Journal'

So regex '^Journal(Beta)?\.[0-9]{12}\.[0-9]{2}\.log$' matches both and nothing
else.

Test: The "copy to same directory" that originally triggered this.  EDMC no
      longer 'sees' the copy.
Test: Copied a Journal file out, renamed it to later date/time, copied that
      back in.  EDMC saw it correctly as a new file.

NB: Didn't test the "no emitter" version at monitor.py:251, but no reason to
    think it won't also work.

closes #546