### PR TITLE
Fix WinSparkle options to be under EDCD key

### DIFF
--- a/config.py
+++ b/config.py
@@ -200,13 +200,17 @@ class Config(object):
                 raise Exception()
 
             # set WinSparkle defaults - https://github.com/vslavik/winsparkle/wiki/Registry-Settings
+            edcdhkey = HKEY()
+            if RegCreateKeyEx(HKEY_CURRENT_USER, r'Software\EDCD\EDMarketConnector', 0, None, 0, KEY_ALL_ACCESS, None, ctypes.byref(edcdhkey), ctypes.byref(disposition)):
+                raise Exception()
+
             sparklekey = HKEY()
-            if not RegCreateKeyEx(self.hkey, 'WinSparkle', 0, None, 0, KEY_ALL_ACCESS, None, ctypes.byref(sparklekey), ctypes.byref(disposition)):
+            if not RegCreateKeyEx(edcdhkey, 'WinSparkle', 0, None, 0, KEY_ALL_ACCESS, None, ctypes.byref(sparklekey), ctypes.byref(disposition)):
                 if disposition.value == REG_CREATED_NEW_KEY:
                     buf = ctypes.create_unicode_buffer('1')
                     RegSetValueEx(sparklekey, 'CheckForUpdates', 0, 1, buf, len(buf)*2)
-                    buf = ctypes.create_unicode_buffer(str(update_interval))
-                    RegSetValueEx(sparklekey, 'UpdateInterval', 0, 1, buf, len(buf)*2)
+                buf = ctypes.create_unicode_buffer(str(update_interval))
+                RegSetValueEx(sparklekey, 'UpdateInterval', 0, 1, buf, len(buf)*2)
                 RegCloseKey(sparklekey)
 
             if not self.get('outdir') or not isdir(self.get('outdir')):


### PR DESCRIPTION
 * When I changed 'company_name' in setup.py to 'EDCD' this caused WinSparkle to
   store, and look for, its keys there.
 * There's code in config.py that attempts to set some WinSparkle options, only
   if they weren't already there.  This is hardcoded to use the old 'Marginal'
   Registry Key.

So, explicitly do this WinSparkle setup under 'EDCD', and *always* set the
update_interval value to match what we expect.  Leave the 'CheckForUpdates'
under the 'is it already here?' check so that we respect the user's choice.