### PR TITLE
Fixed updating inara cargo only on major events

### DIFF
--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -413,14 +413,10 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
             # and our flood limit isnt covered, queue an update
             should_poll = this.cargo != cargo and time.time() - this.last_update_time > FLOOD_LIMIT_SECONDS
             
-            if should_poll:
-                print("[{}] INARA: should_poll is true".format(time.asctime()))
-
             # Send event(s) to Inara
             if entry['event'] == 'ShutDown' or len(this.events) > old_events or should_poll:
 
                 # Send cargo and materials if changed
-                # cargo = [ OrderedDict([('itemName', k), ('itemCount', state['Cargo'][k])]) for k in sorted(state['Cargo']) ]
                 if this.cargo != cargo:
                     add_event('setCommanderInventoryCargo', entry['timestamp'], cargo)
                     this.cargo = cargo

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -50,6 +50,9 @@ this.loadout = None
 this.fleet = None
 this.shipswap = False	# just swapped ship
 
+this.last_update_time = time.time()  # last time since we updated (set to now because we're going to update quickly)
+FLOOD_LIMIT_SECONDS = 45  # minimum time between sending non-major cargo triggered messages
+
 
 # Main window clicks
 this.system_link = None
@@ -404,12 +407,20 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
             if config.get('station_provider') == 'Inara':
                 this.station_link['url'] = this.station or this.system
 
+            cargo = [OrderedDict([('itemName', k), ('itemCount', state['Cargo'][k])]) for k in sorted(state['Cargo'])]
+
+            # if our cargo differers from last we checked, we're at a station,
+            # and our flood limit isnt covered, queue an update
+            should_poll = this.cargo != cargo and time.time() - this.last_update_time > FLOOD_LIMIT_SECONDS
+            
+            if should_poll:
+                print("[{}] INARA: should_poll is true".format(time.asctime()))
 
             # Send event(s) to Inara
-            if entry['event'] == 'ShutDown' or len(this.events) > old_events:
+            if entry['event'] == 'ShutDown' or len(this.events) > old_events or should_poll:
 
                 # Send cargo and materials if changed
-                cargo = [ OrderedDict([('itemName', k), ('itemCount', state['Cargo'][k])]) for k in sorted(state['Cargo']) ]
+                # cargo = [ OrderedDict([('itemName', k), ('itemCount', state['Cargo'][k])]) for k in sorted(state['Cargo']) ]
                 if this.cargo != cargo:
                     add_event('setCommanderInventoryCargo', entry['timestamp'], cargo)
                     this.cargo = cargo
@@ -803,6 +814,8 @@ def call(callback=None):
     if not this.events:
         return
 
+    this.last_update_time = time.time()
+    
     data = OrderedDict([
         ('header', OrderedDict([
             ('appName', applongname),

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -50,7 +50,7 @@ this.loadout = None
 this.fleet = None
 this.shipswap = False	# just swapped ship
 
-this.last_update_time = time.time()  # last time since we updated (set to now because we're going to update quickly)
+this.last_update_time = time.time()  # last time we updated (set to now because we're going to update quickly)
 FLOOD_LIMIT_SECONDS = 45  # minimum time between sending non-major cargo triggered messages
 
 


### PR DESCRIPTION
This works by checking on _any_ event the status of the cargo vs the
current stored version. If the live cargo differs from the updated
cargo, _and_ we have not sent any update in the past 45 seconds (as this
would have contained the cargo anyway), we queue an actual send to the
API.

This unfortunately isn't checked only when docked, but on the plus side
miners will be happy to have their cargo updated relatively often.

Fixes #477. Possibly not quite what they wanted, but its about as close
as this will get