### PR TITLE
Remove all use of defunct 'anonymous' option

### DIFF
--- a/commodity.py
+++ b/commodity.py
@@ -48,10 +48,7 @@ def export(data, kind=COMMODITY_DEFAULT, filename=None):
         cmdr = data['commander']['name'].strip()
 
         header_cmdr = cmdr
-        if config.getint('anonymous'):
-            header_cmdr = hashlib.md5(cmdr.encode('utf-8')).hexdigest()
-
-        elif sep in cmdr:
+        if sep in cmdr:
             header_cmdr = f'"{cmdr}"'
 
         rowheader = sep.join((header_cmdr, data['lastSystem']['name'], data['lastStarport']['name']))

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -91,13 +91,7 @@ class EDDN(object):
         self.replayfile = None
 
     def send(self, cmdr, msg):
-        if config.getint('anonymous'):
-            uploaderID = config.get('uploaderID')
-            if not uploaderID:
-                uploaderID = uuid.uuid4().hex
-                config.set('uploaderID', uploaderID)
-        else:
-            uploaderID = cmdr
+        uploaderID = cmdr
 
         msg = OrderedDict([
             ('$schemaRef', msg['$schemaRef']),

--- a/td.py
+++ b/td.py
@@ -30,7 +30,16 @@ def export(data):
 
     # Format described here: https://bitbucket.org/kfsone/tradedangerous/wiki/Price%20Data
     h = open(filename, 'wb')	# codecs can't automatically handle line endings, so encode manually where required
-    h.write(('#! trade.py import -\n# Created by %s %s on %s%s.\n#\n#    <item name>             <sellCR> <buyCR>   <demand>   <stock>  <timestamp>\n\n@ %s/%s\n' % (applongname, appversion, platform=='darwin' and "Mac OS" or system(), not config.getint('anonymous') and ' for Cmdr '+data['commander']['name'].strip() or '', data['lastSystem']['name'].strip(), data['lastStarport']['name'].strip())).encode('utf-8'))
+    h.write('#! trade.py import -\n# Created by {appname} {appversion} on {platform} for Cmdr {cmdr}.\n'
+            '#\n#    <item name>             <sellCR> <buyCR>   <demand>   <stock>  <timestamp>\n\n'
+            '@ {system}/{starport}\n'.format(
+                appname=applongname,
+                appversion=appversion,
+                platform=platform == 'darwin' and "Mac OS" or system(),
+                cmdr=data['commander']['name'].strip(),
+                system=data['lastSystem']['name'].strip(),
+                starport=data['lastStarport']['name'].strip()
+    ).encode('utf-8'))
 
     # sort commodities by category
     bycategory = defaultdict(list)


### PR DESCRIPTION
The UI for setting the 'anonymous' option was removed in
f17f5d3f257e2359d4728ce8c296d70dc5e7609f ("PKCE OAuth2 access to cAPI").
Since then there's been no way for a user to set, or unset, this option
(and the associated custom uploaderID).  However anyone with the registry keys
still set would have had them take effect.

This commit removes the last bits of code that were making use of it.

Note that the EDDN Relay anonymises all uploaderID values, so no listener
has been seeing the 'raw' values for a long time now.

close #575