### PR TITLE
Restore 'EDMC -v' to announcing newer versions.

### DIFF
--- a/EDMC.py
+++ b/EDMC.py
@@ -71,11 +71,14 @@ try:
                            item.find('title').text) for item in feed.findall('channel/item')])
             lastversion = sorted(items, key=versioncmp)[-1]
             if versioncmp(lastversion) > versioncmp(appversion):
-                latest = ' (%s is available)' % items[lastversion]
+                latest = items[lastversion]
         except Exception as e:
             sys.stderr.write('Exception in version check: {}'.format(str(e)))
             #pass	# Quietly suppress timeouts etc.
-        print(appversion)
+        if latest:
+            print('{CURRENT} ({UPDATE} is available)'.format(CURRENT=appversion, UPDATE=latest))
+        else:
+            print(appversion)
         sys.exit(EXIT_SUCCESS)
 
     if args.j:


### PR DESCRIPTION
I got too enthusiastic in 3ff77c3c54dea4bf36d957cd2dbd5b1b02dcb094 when
I removed the "cut it down to A.BC" code.  This restores the old output,
but using a less confusing if/else.

close #604