### PR TITLE
Fix/616 station system text links

### DIFF
--- a/plugins/eddb.py
+++ b/plugins/eddb.py
@@ -22,6 +22,7 @@
 #    any of the above in the interim.
 #
 
+# TODO: Test with all combinations of Inara an EDSM APIs/sending on and off
 
 import sys
 import requests

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -11,6 +11,8 @@
 #  4) Ensure the EDSM API call(back) for setting the image at end of system
 #    text is always fired.  i.e. CAPI cmdr_data() processing.
 
+# TODO: Test with all combinations of Inara an EDSM APIs/sending on and off
+
 import json
 import requests
 import sys

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -2,6 +2,8 @@
 # Inara sync
 #
 
+# TODO: Test with all combinations of Inara an EDSM APIs/sending on and off
+
 from collections import OrderedDict
 import json
 import requests


### PR DESCRIPTION
This has not only fixed the bug in the Inara plugin (which was due to it relying on some behaviour in the eddb plugin that got tucked into a conditional), but has switched Inara to direct URLs, rather than relying on the Inara API responses.  So it works even if you don't set an Inara API key now.

Also slightly changed the EDSM and EDDB plugins to match the logic.  The EDSM one has some TODO items in a comment at the top.