### PR TITLE
monitor.py: Don't record '' or ' ' as ShipName

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -399,7 +399,8 @@ class EDLogs(FileSystemEventHandler):
                   not 'buggy' in self.canonicalise(entry['Ship'])):
                 self.state['ShipID'] = entry['ShipID']
                 self.state['ShipIdent'] = entry['ShipIdent']
-                self.state['ShipName']  = entry['ShipName']
+                if entry['ShipName'] and entry['ShipName'] not in ('', ' '):
+                    self.state['ShipName']  = entry['ShipName']
                 self.state['ShipType']  = self.canonicalise(entry['Ship'])
                 self.state['HullValue'] = entry.get('HullValue')	# not present on exiting Outfitting
                 self.state['ModulesValue'] = entry.get('ModulesValue')	#   "

--- a/monitor.py
+++ b/monitor.py
@@ -399,8 +399,14 @@ class EDLogs(FileSystemEventHandler):
                   not 'buggy' in self.canonicalise(entry['Ship'])):
                 self.state['ShipID'] = entry['ShipID']
                 self.state['ShipIdent'] = entry['ShipIdent']
+
+                # Newly purchased ships can show a ShipName of "" initially,
+                # and " " after a game restart/relog.
+                # Players *can* also purposefully set " " as the name, but anyone
+                # doing that gets to live with EDMC showing ShipType instead.
                 if entry['ShipName'] and entry['ShipName'] not in ('', ' '):
                     self.state['ShipName']  = entry['ShipName']
+
                 self.state['ShipType']  = self.canonicalise(entry['Ship'])
                 self.state['HullValue'] = entry.get('HullValue')	# not present on exiting Outfitting
                 self.state['ModulesValue'] = entry.get('ModulesValue')	#   "


### PR DESCRIPTION
Doing so causes the ShipType to not be used in the UI, so you get a
'link' with just a space for the text.

Any user who purposefully sets their ship's name to a single space
can live with seeing the model name instead.  Yes, I checked, the game
allows it.