### PR TITLE
Switched to using a timer for inara updates

### DIFF
--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -103,7 +103,8 @@ def plugin_app(parent):
 
 def plugin_stop():
     # Send any unsent events
-    call(force=True)
+    call()
+    time.sleep(0.1)  # Sleep for 100ms to allow call to go out, and to force a context switch to our other threads
     # Signal thread to close and wait for it
     this.queue.put(None)
     this.thread.join()

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -459,10 +459,6 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
             logger.debug('Adding events', exc_info=e)
             return str(e)
 
-        #
-        # Events that don't need to be sent immediately but will be sent on the next mandatory event
-        #
-
         # Send credits and stats to Inara on startup only - otherwise may be out of date
         if entry['event'] == 'LoadGame':
             add_event('setCommanderCredits', entry['timestamp'],

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -861,6 +861,7 @@ def add_event(name, timestamp, data):
 def call_timer(wait=FLOOD_LIMIT_SECONDS):
     while this.timer_run:
         time.sleep(wait)
+        print("INARA: TICK")
         if this.timer_run:  # check again in here just in case we're closing and the stars align
             call()
 
@@ -873,7 +874,7 @@ def call(callback=None, force=False):
         return
 
     this.last_update_time = time.time()
-    
+    print(f"INARA: {time.asctime()}sending {len(this.events)} entries to inara (call)")
     data = OrderedDict([
         ('header', OrderedDict([
             ('appName', applongname),
@@ -895,6 +896,8 @@ def worker():
             return	# Closing
         else:
             (url, data, callback) = item
+
+        print(f"INARA: {time.asctime()}sending {len(data['events'])} entries to inara (worker)")
 
         retrying = 0
         while retrying < 3:

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -4,6 +4,7 @@
 
 from collections import OrderedDict
 import json
+from typing import Any, Union
 import requests
 import sys
 import time
@@ -26,7 +27,7 @@ FAKE = ['CQC', 'Training', 'Destination']	# Fake systems that shouldn't be sent 
 CREDIT_RATIO = 1.05		# Update credits if they change by 5% over the course of a session
 
 
-this = sys.modules[__name__]	# For holding module globals
+this: Any = sys.modules[__name__]	# For holding module globals
 this.session = requests.Session()
 this.queue = Queue()	# Items to be sent to Inara by worker thread
 this.lastlocation = None	# eventData from the last Commander's Flight Log event
@@ -50,7 +51,8 @@ this.fleet = None
 this.shipswap = False	# just swapped ship
 
 this.last_update_time = time.time()  # last time we updated (set to now because we're going to update quickly)
-FLOOD_LIMIT_SECONDS = 45  # minimum time between sending non-major cargo triggered messages
+FLOOD_LIMIT_SECONDS = 30  # minimum time between sending events
+this.timer_run = True
 
 
 # Main window clicks
@@ -85,6 +87,10 @@ def plugin_start3(plugin_dir):
     this.thread = Thread(target = worker, name = 'Inara worker')
     this.thread.daemon = True
     this.thread.start()
+
+    this.timer_thread = Thread(target=call_timer, name='Inara timer')
+    this.timer_thread.daemon = True
+    this.timer_thread.start()
     return 'Inara'
 
 def plugin_app(parent):
@@ -95,11 +101,13 @@ def plugin_app(parent):
 
 def plugin_stop():
     # Send any unsent events
-    call()
+    call(force=True)
     # Signal thread to close and wait for it
     this.queue.put(None)
     this.thread.join()
     this.thread = None
+
+    this.timer_run = False
 
 def plugin_prefs(parent, cmdr, is_beta):
 
@@ -188,7 +196,7 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
 
     # Send any unsent events when switching accounts
     if cmdr and cmdr != this.cmdr:
-        call()
+        call(force=True)
 
     this.cmdr = cmdr
     this.FID = state['FID']
@@ -245,8 +253,6 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
 
     if config.getint('inara_out') and not is_beta and not this.multicrew and credentials(cmdr):
         try:
-            old_events = len(this.events)	# Will only send existing events if we add a new event below
-
             # Dump starting state to Inara
 
             if (this.newuser or
@@ -305,6 +311,8 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
 
                     this.loadout = make_loadout(state)
                     add_event('setCommanderShipLoadout', entry['timestamp'], this.loadout)
+          
+                call()  # Call here just to be sure that if we can send, we do, otherwise it'll get it in the next tick
 
 
             # Promotions
@@ -437,23 +445,17 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
             # if our cargo differers from last we checked, we're at a station,
             # and our flood limit isnt covered, queue an update
             should_poll = this.cargo != cargo and time.time() - this.last_update_time > FLOOD_LIMIT_SECONDS
-            
-            # Send event(s) to Inara
-            if entry['event'] == 'ShutDown' or len(this.events) > old_events or should_poll:
 
-                # Send cargo and materials if changed
-                if this.cargo != cargo:
-                    add_event('setCommanderInventoryCargo', entry['timestamp'], cargo)
-                    this.cargo = cargo
-                materials = []
-                for category in ['Raw', 'Manufactured', 'Encoded']:
-                    materials.extend([ OrderedDict([('itemName', k), ('itemCount', state[category][k])]) for k in sorted(state[category]) ])
-                if this.materials != materials:
-                    add_event('setCommanderInventoryMaterials', entry['timestamp'],  materials)
-                    this.materials = materials
-
-                # Queue a call to Inara
-                call()
+            # Send cargo and materials if changed
+            if this.cargo != cargo:
+                add_event('setCommanderInventoryCargo', entry['timestamp'], cargo)
+                this.cargo = cargo
+            materials = []
+            for category in ['Raw', 'Manufactured', 'Encoded']:
+                materials.extend([ OrderedDict([('itemName', k), ('itemCount', state[category][k])]) for k in sorted(state[category]) ])
+            if this.materials != materials:
+                add_event('setCommanderInventoryMaterials', entry['timestamp'],  materials)
+                this.materials = materials
 
         except Exception as e:
             logger.debug('Adding events', exc_info=e)
@@ -856,10 +858,18 @@ def add_event(name, timestamp, data):
         ('eventData', data),
     ]))
 
+def call_timer(wait=FLOOD_LIMIT_SECONDS):
+    while this.timer_run:
+        time.sleep(wait)
+        if this.timer_run:  # check again in here just in case we're closing and the stars align
+            call()
 
 # Queue a call to Inara, handled in Worker thread
-def call(callback=None):
+def call(callback=None, force=False):
     if not this.events:
+        return
+
+    if (time.time() - this.last_update_time) <= FLOOD_LIMIT_SECONDS and not force:      
         return
 
     this.last_update_time = time.time()


### PR DESCRIPTION
This adds a new thread that will run in a loop sending inara events once
ever 30 seconds. The old method of sending once for "special" events has
been removed.

**THIS IS UNTESTED** it needs testing before it is merged