### PR TITLE
Fixed issues with super long links for shipyards

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -671,6 +671,10 @@ class AppWindow(object):
                 hotkeymgr.play_bad()
 
     def shipyard_url(self, shipname):
+        if not bool(config.getint("use_alt_shipyard_open")):
+            return plug.invoke(config.get('shipyard_provider'), 'EDSY', 'shipyard_url', monitor.ship(), monitor.is_beta)
+
+        # Avoid file length limits if possible
         provider = config.get('shipyard_provider') or 'EDSY'
         target = plug.invoke(config.get('shipyard_provider'), 'EDSY', 'shipyard_url', monitor.ship(), monitor.is_beta)
         file_name = join(config.app_dir, "last_shipyard.html")

--- a/ttkHyperlinkLabel.py
+++ b/ttkHyperlinkLabel.py
@@ -112,36 +112,36 @@ class HyperlinkLabel(platform == 'darwin' and tk.Label or ttk.Label, object):
 
 
 def openurl(url):
-    # if platform == 'win32':
-    #     # On Windows webbrowser.open calls os.startfile which calls ShellExecute which can't handle long arguments,
-    #     # so discover and launch the browser directly.
-    #     # https://blogs.msdn.microsoft.com/oldnewthing/20031210-00/?p=41553
+    if platform == 'win32':
+        # On Windows webbrowser.open calls os.startfile which calls ShellExecute which can't handle long arguments,
+        # so discover and launch the browser directly.
+        # https://blogs.msdn.microsoft.com/oldnewthing/20031210-00/?p=41553
 
-    #     try:
-    #         hkey = OpenKeyEx(HKEY_CURRENT_USER, r'Software\Microsoft\Windows\Shell\Associations\UrlAssociations\https\UserChoice')
-    #         (value, typ) = QueryValueEx(hkey, 'ProgId')
-    #         CloseKey(hkey)
-    #         if value in ['IE.HTTP', 'AppXq0fevzme2pys62n3e0fbqa7peapykr8v']:
-    #             # IE and Edge can't handle long arguments so just use webbrowser.open and hope
-    #             # https://blogs.msdn.microsoft.com/ieinternals/2014/08/13/url-length-limits/
-    #             cls = None
-    #         else:
-    #             cls = value
-    #     except:
-    #         cls  = 'https'
+        try:
+            hkey = OpenKeyEx(HKEY_CURRENT_USER, r'Software\Microsoft\Windows\Shell\Associations\UrlAssociations\https\UserChoice')
+            (value, typ) = QueryValueEx(hkey, 'ProgId')
+            CloseKey(hkey)
+            if value in ['IE.HTTP', 'AppXq0fevzme2pys62n3e0fbqa7peapykr8v']:
+                # IE and Edge can't handle long arguments so just use webbrowser.open and hope
+                # https://blogs.msdn.microsoft.com/ieinternals/2014/08/13/url-length-limits/
+                cls = None
+            else:
+                cls = value
+        except:
+            cls  = 'https'
 
-    #     if cls:
-    #         try:
-    #             hkey = OpenKeyEx(HKEY_CLASSES_ROOT, r'%s\shell\open\command' % cls)
-    #             (value, typ) = QueryValueEx(hkey, None)
-    #             CloseKey(hkey)
-    #             if 'iexplore' not in value.lower():
-    #                 if '%1' in value:
-    #                     subprocess.Popen(buf.value.replace('%1', url))
-    #                 else:
-    #                     subprocess.Popen('%s "%s"' % (buf.value, url))
-    #                 return
-    #         except:
-    #             pass
+        if cls:
+            try:
+                hkey = OpenKeyEx(HKEY_CLASSES_ROOT, r'%s\shell\open\command' % cls)
+                (value, typ) = QueryValueEx(hkey, None)
+                CloseKey(hkey)
+                if 'iexplore' not in value.lower():
+                    if '%1' in value:
+                        subprocess.Popen(buf.value.replace('%1', url))
+                    else:
+                        subprocess.Popen('%s "%s"' % (buf.value, url))
+                    return
+            except:
+                pass
 
     webbrowser.open(url)

--- a/ttkHyperlinkLabel.py
+++ b/ttkHyperlinkLabel.py
@@ -112,36 +112,36 @@ class HyperlinkLabel(platform == 'darwin' and tk.Label or ttk.Label, object):
 
 
 def openurl(url):
-    if platform == 'win32':
-        # On Windows webbrowser.open calls os.startfile which calls ShellExecute which can't handle long arguments,
-        # so discover and launch the browser directly.
-        # https://blogs.msdn.microsoft.com/oldnewthing/20031210-00/?p=41553
+    # if platform == 'win32':
+    #     # On Windows webbrowser.open calls os.startfile which calls ShellExecute which can't handle long arguments,
+    #     # so discover and launch the browser directly.
+    #     # https://blogs.msdn.microsoft.com/oldnewthing/20031210-00/?p=41553
 
-        try:
-            hkey = OpenKeyEx(HKEY_CURRENT_USER, r'Software\Microsoft\Windows\Shell\Associations\UrlAssociations\https\UserChoice')
-            (value, typ) = QueryValueEx(hkey, 'ProgId')
-            CloseKey(hkey)
-            if value in ['IE.HTTP', 'AppXq0fevzme2pys62n3e0fbqa7peapykr8v']:
-                # IE and Edge can't handle long arguments so just use webbrowser.open and hope
-                # https://blogs.msdn.microsoft.com/ieinternals/2014/08/13/url-length-limits/
-                cls = None
-            else:
-                cls = value
-        except:
-            cls  = 'https'
+    #     try:
+    #         hkey = OpenKeyEx(HKEY_CURRENT_USER, r'Software\Microsoft\Windows\Shell\Associations\UrlAssociations\https\UserChoice')
+    #         (value, typ) = QueryValueEx(hkey, 'ProgId')
+    #         CloseKey(hkey)
+    #         if value in ['IE.HTTP', 'AppXq0fevzme2pys62n3e0fbqa7peapykr8v']:
+    #             # IE and Edge can't handle long arguments so just use webbrowser.open and hope
+    #             # https://blogs.msdn.microsoft.com/ieinternals/2014/08/13/url-length-limits/
+    #             cls = None
+    #         else:
+    #             cls = value
+    #     except:
+    #         cls  = 'https'
 
-        if cls:
-            try:
-                hkey = OpenKeyEx(HKEY_CLASSES_ROOT, r'%s\shell\open\command' % cls)
-                (value, typ) = QueryValueEx(hkey, None)
-                CloseKey(hkey)
-                if 'iexplore' not in value.lower():
-                    if '%1' in value:
-                        subprocess.Popen(buf.value.replace('%1', url))
-                    else:
-                        subprocess.Popen('%s "%s"' % (buf.value, url))
-                    return
-            except:
-                pass
+    #     if cls:
+    #         try:
+    #             hkey = OpenKeyEx(HKEY_CLASSES_ROOT, r'%s\shell\open\command' % cls)
+    #             (value, typ) = QueryValueEx(hkey, None)
+    #             CloseKey(hkey)
+    #             if 'iexplore' not in value.lower():
+    #                 if '%1' in value:
+    #                     subprocess.Popen(buf.value.replace('%1', url))
+    #                 else:
+    #                     subprocess.Popen('%s "%s"' % (buf.value, url))
+    #                 return
+    #         except:
+    #             pass
 
     webbrowser.open(url)


### PR DESCRIPTION
This works by creating a temp file at config.app_dir and storing the
link in there, followed by directing the local browser to open the file.

HTML meta tags are then used to direct the browser to refresh to a URL
of our choosing (which is HTML escaped, just in case someone tries
something clever)

This should work everywhere, and on any browser (as the file:// format
is defined at https://tools.ietf.org/html/rfc1738 which was posted in
1994).

The URI used (`file://localhost/path`) ensures that we only ever
ask for a localhost file at our path.

The HTML format should be completely compliant with all major browsers
as well, ensuring that behaviour is consistent (assuming they support
HTML meta tags)

The commented out windows specific code is left there for now, it should be removed before merging