### PR TITLE
Dont crash when journal_dir is None

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -122,7 +122,9 @@ class EDLogs(FileSystemEventHandler):
 
         if journal_dir is None:
             journal_dir = ''
-
+        
+        # TODO(A_D): this is ignored for type checking due to all the different types config.get returns
+        # When that is refactored, remove the magic comment
         logdir = expanduser(journal_dir)  # type: ignore # config is weird
 
         if not logdir or not isdir(logdir):

--- a/monitor.py
+++ b/monitor.py
@@ -118,9 +118,14 @@ class EDLogs(FileSystemEventHandler):
 
     def start(self, root):
         self.root = root
-        logdir = expanduser(config.get('journaldir') or config.default_journal_dir)  # type: ignore # config is weird
+        journal_dir = config.get('journaldir') or config.default_journal_dir
 
-        if not logdir or not isdir(logdir):  # type: ignore # config does weird things in its get
+        if journal_dir is None:
+            journal_dir = ''
+
+        logdir = expanduser(journal_dir)  # type: ignore # config is weird
+
+        if not logdir or not isdir(logdir):
             self.stop()
             return False
 


### PR DESCRIPTION
Ensures that journal_dir is always at least an empty string.

Fixes #639