### PR TITLE
Enhancement/remove keyring

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,5 +1,6 @@
 import numbers
 import sys
+import warnings
 from os import getenv, makedirs, mkdir, pardir
 from os.path import expanduser, dirname, exists, isdir, join, normpath
 from sys import platform
@@ -367,25 +368,13 @@ class Config(object):
     # Common
 
     def get_password(self, account):
-        try:
-            import keyring
-            return keyring.get_password(self.identifier, account)
-        except ImportError:
-            return None
+        warnings.warn("password subsystem is no longer supported", DeprecationWarning)
 
     def set_password(self, account, password):
-        try:
-            import keyring
-            keyring.set_password(self.identifier, account, password)
-        except ImportError:
-            pass
+        warnings.warn("password subsystem is no longer supported", DeprecationWarning)
 
     def delete_password(self, account):
-        try:
-            import keyring
-            keyring.delete_password(self.identifier, account)
-        except:
-            pass	# don't care - silently fail
+        warnings.warn("password subsystem is no longer supported", DeprecationWarning)
 
 # singleton
 config = Config()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 certifi==2019.9.11
-keyring==19.2.0
 requests>=2.11.1
 watchdog>=0.8.3
 # argh==0.26.2 watchdog dep

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ if sys.platform=='darwin':
                   'optimize': 2,
                   'packages': [
                       'requests',
-                      'keyring.backends',
                       'sqlite3',	# Included for plugins
                   ],
                   'includes': [
@@ -119,7 +118,6 @@ elif sys.platform=='win32':
                   'optimize': 2,
                   'packages': [
                       'requests',
-                      'keyring.backends',
                       'sqlite3',	# Included for plugins
                   ],
                   'includes': [


### PR DESCRIPTION
Removed keyring dependency
    
This removes all dependencies on the keyring lib, updates the requirements.txt to reflect that, and ensures that setup.py does not
attempt to package it.
    
Any use of the "old" keyring code will now return None and warn about its deprecation.