### PR TITLE
Run flake8 for status on all pull requests

### DIFF
--- a/.github/workflows/push-and-pr-checks.yml
+++ b/.github/workflows/push-and-pr-checks.yml
@@ -5,10 +5,12 @@
 #
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Push-Checks
+name: Push and PR Checks
 
 on:
   push:
+    branches: [ develop ]
+  pull_request:
     branches: [ develop ]
 
 jobs:


### PR DESCRIPTION
This doubles up the work the annotate workflow does, but should always work, unlike the annotations and fork PRs.