### PR TITLE
Ensure 'found' plugins have correct logging from core code

### DIFF
--- a/EDMCLogging.py
+++ b/EDMCLogging.py
@@ -241,7 +241,7 @@ class EDMCContextFilter(logging.Filter):
         return frame
 
     @classmethod
-    def munge_module_name(cls, frame_info: inspect.FrameInfo, module_name: str) -> str:
+    def munge_module_name(cls, frame_info: inspect.Traceback, module_name: str) -> str:
         """
         Adjust module_name based on the file path for the given frame.
 

--- a/EDMCLogging.py
+++ b/EDMCLogging.py
@@ -68,7 +68,7 @@ class Logger:
         self.logger_channel = logging.StreamHandler()
         self.logger_channel.setLevel(loglevel)
 
-        self.logger_formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(module)s.%(qualname)s:%(lineno)d: %(class)s: %(message)s')  # noqa: E501
+        self.logger_formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(module)s.%(qualname)s:%(lineno)d: %(message)s')  # noqa: E501
         self.logger_formatter.default_time_format = '%Y-%m-%d %H:%M:%S'
         self.logger_formatter.default_msec_format = '%s.%03d'
 

--- a/EDMCLogging.py
+++ b/EDMCLogging.py
@@ -68,7 +68,7 @@ class Logger:
         self.logger_channel = logging.StreamHandler()
         self.logger_channel.setLevel(loglevel)
 
-        self.logger_formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(module)s.%(qualname)s:%(lineno)d: %(class)s: %(message)s')  # noqa: E501
+        self.logger_formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(module)s.%(qualname)s:%(lineno)d: %(class)s: %(message)s')  # noqa: E501
         self.logger_formatter.default_time_format = '%Y-%m-%d %H:%M:%S'
         self.logger_formatter.default_msec_format = '%s.%03d'
 

--- a/EDMCLogging.py
+++ b/EDMCLogging.py
@@ -208,9 +208,14 @@ class EDMCContextFilter(logging.Filter):
             # Is this a 'found' plugin calling us?
             file_name = pathlib.Path(frame_info.filename).expanduser()
             plugin_dir = pathlib.Path(config.plugin_dir).expanduser()
+            internal_plugin_dir = pathlib.Path(config.internal_plugin_dir).expanduser()
+
             if file_name.parent.parent == plugin_dir:
                 # Pre-pend 'plugins.<plugin folder>.' to module
                 module_name = f'<plugins>.{file_name.parent.name}.{module_name}'
+
+            elif file_name.parent == internal_plugin_dir:
+                module_name = f'plugins.{module_name}'
 
             # https://docs.python.org/3.7/library/inspect.html#the-interpreter-stack
             del frame

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -1033,7 +1033,7 @@ if __name__ == "__main__":
     logger = EDMCLogging.Logger(appname).get_logger()
 
     # TODO: unittests in place of these
-    # logger.debug('Test from __main__')
+    logger.debug('Test from __main__')
     # test_logging()
     class A(object):
         class B(object):

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -1033,7 +1033,7 @@ if __name__ == "__main__":
     logger = EDMCLogging.Logger(appname).get_logger()
 
     # TODO: unittests in place of these
-    logger.debug('Test from __main__')
+    # logger.debug('Test from __main__')
     # test_logging()
     class A(object):
         class B(object):

--- a/plug.py
+++ b/plug.py
@@ -17,7 +17,7 @@ import myNotebook as nb  # noqa: N813
 from config import config, appname
 import EDMCLogging
 
-logger = EDMCLogging.EDMCLoggerAdapter(logging.getLogger(appname), {'from': __name__})
+logger = logging.getLogger(appname)
 
 # Dashboard Flags constants
 FlagsDocked = 1 << 0  # on a landing pad

--- a/plug.py
+++ b/plug.py
@@ -17,7 +17,7 @@ import myNotebook as nb  # noqa: N813
 from config import config, appname
 import EDMCLogging
 
-logger = logging.getLogger(appname)
+logger = EDMCLogging.EDMCLoggerAdapter(logging.getLogger(appname), {'from': __name__})
 
 # Dashboard Flags constants
 FlagsDocked = 1 << 0  # on a landing pad


### PR DESCRIPTION
1. Log messages propagate up Parent.Child chains, so we don't need a channel on the plugin logger.
1. But it still needs the filter to define qualname and class for formatting.