### PR TITLE
TODO: Investigate 'wrong head' on an A_D PR check

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -75,6 +75,7 @@ jobs:
         BASE_REF: ${{github.base_ref}}
 
       run: |
+        # TODO: Add some output of current head/log
         # Explicitly check for some errors
         # E9 - Runtime (syntax and the like)
         # F63 - 'tests' checking


### PR DESCRIPTION
```
 Lint with flake8
3s
    BASE_REF: develop
Run # Explicitly check for some errors
  # Explicitly check for some errors
  # E9 - Runtime (syntax and the like)
  # F63 - 'tests' checking
  # F7 - syntax errors
  # F82 - undefined checking
  git diff "refs/remotes/${BASE_REPO_OWNER}/${BASE_REF}" -- | flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --diff
  # Can optionally add `--exit-zero` to the flake8 arguments so that
  # this doesn't fail the build.
  git diff "refs/remotes/${BASE_REPO_OWNER}/${BASE_REF}" -- | flake8 . --count --statistics --diff
  shell: /bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.7.8/x64
    BASE_REPO_URL: https://github.com/EDCD/EDMarketConnector
    BASE_REPO_OWNER: EDCD
    BASE_REF: develop
0
EDMCLogging.py:120:5: CCR001 Cognitive complexity is too high (24 > 15)
plug.py:179:13: F841 local variable 'e' is assigned to but never used
plug.py:200:13: F841 local variable 'e' is assigned to but never used
plugins/inara.py:7:1: F401 'typing.Union' imported but unused
plugins/inara.py:26:42: E261 at least two spaces before inline comment
plugins/inara.py:30:34: E261 at least two spaces before inline comment
plugins/inara.py:32:21: E261 at least two spaces before inline comment
plugins/inara.py:33:25: E261 at least two spaces before inline comment
plugins/inara.py:34:21: E261 at least two spaces before inline comment
plugins/inara.py:37:17: E261 at least two spaces before inline comment
plugins/inara.py:40:23: E261 at least two spaces before inline comment
```

Despite:

```
$ git remote -v | grep A_D
A_D     git@github.com:A-UNDERSCORE-D/EDMarketConnector.git (fetch)
A_D     git@github.com:A-UNDERSCORE-D/EDMarketConnector.git (push)
$ git fetch A_D
$ git checkout fix/request-hangs-threads
Already on 'fix/request-hangs-threads'
Your branch is up to date with 'A-UNDERSCORE-D/fix/request-hangs-threads'.
$ git diff refs/remotes/origin/develop | flake8 --count --statistics --diff
0
```