### PR TITLE
Rewrote inara queue system

### DIFF
--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -85,7 +85,7 @@ STATION_UNDOCKED: str = '×'  # "Station" name to display when not docked = U+00
 
 class Credentials(NamedTuple):
     """
-    Credentials holds an inara API payload
+    Credentials holds the set of credentials required to identify an inara API payload to inara
     """
     cmdr: str
     fid: str
@@ -1211,7 +1211,7 @@ def try_send_data(url: str, data: Mapping[str, Any]):
     :param data: the payload
     """
     for i in range(3):
-        logger.debug(f"sending data to API, retry #{i}")
+        logger.debug(f"sending data to API, attempt #{i}")
         try:
             if send_data(url, data):
                 break

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -2,31 +2,28 @@
 # Inara sync
 #
 
-from collections import OrderedDict, defaultdict
-import json
-from typing import Any, AnyStr, Callable, Deque, Dict, List, Mapping, NamedTuple, Optional, OrderedDict as OrderedDictT, \
-    Sequence, TYPE_CHECKING, Tuple, Union
 import dataclasses
-
-import requests
+import json
+import logging
 import sys
 import time
+import tkinter as tk
+# For new impl
+from collections import OrderedDict, defaultdict, deque
 from operator import itemgetter
 from queue import Queue
 from threading import Lock, Thread
-import logging
+from typing import TYPE_CHECKING, Any, AnyStr, Callable, Deque, Dict, List, Mapping, NamedTuple, Optional
+from typing import OrderedDict as OrderedDictT
+from typing import Sequence, Union
 
-import tkinter as tk
-from ttkHyperlinkLabel import HyperlinkLabel
-import myNotebook as nb
+import requests
 
-from config import appname, applongname, appversion, config
+import myNotebook as nb  # noqa: N813
 import plug
 import timeout_session
-
-# For new impl
-from collections import deque
-
+from config import applongname, appname, appversion, config
+from ttkHyperlinkLabel import HyperlinkLabel
 
 logger = logging.getLogger(appname)
 

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -632,7 +632,7 @@ def journal_entry(cmdr: str, is_beta: bool, system: str, station: str, entry: Di
 
         # Selling / swapping ships
         if event_name == 'ShipyardNew':
-            add_event(
+            new_add_event(
                 'addCommanderShip',
                 entry['timestamp'],
                 {'shipType': entry['ShipType'], 'shipGameID': entry['NewShipID']}


### PR DESCRIPTION
This replaces the list+queue system that the inara plugin originally
used with a deque based one.

The main differences here are that the list the worker thread uses to
send to inara and the list that events are added to is the same, with
the worker thread making a duplicate and clearing the original each time
it sends events (losing events if it fails to upload three times).

The format of the data has changed as well, from simple tuples to
NamedTuple classes that provide some extra type safety and sanity when
accessing fields.

The event queue itself is actually multiple queues, one per
API/FID/CMDR_name triplicate, thus allowing multiple commander switches
while we're running without causing any weird issues