### PR TITLE
Add flake8-isort for import order

### DIFF
--- a/.pyproject.toml
+++ b/.pyproject.toml
@@ -1,2 +1,0 @@
-[tool.autopep8]
-max_line_length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.autopep8]
+max_line_length = 120
+
+[tool.isort]
+multi_line_output = 5
+line_length = 119

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ flake8-comprehensions==3.2.3
 flake8-pep3101==1.3.0
 flake8-polyfill==1.0.2
 flake8-json
+flake8-isort==3.0.1
 pep8-naming==0.11.1
 
 # Code formatting tools


### PR DESCRIPTION
[isort](https://pypi.org/project/isort/5.3.0/) is an automated import sorter, which by default orders similarly to pycharm (stdlib grouped, then third party, then first party, with spaces between). `flake8-isort` is a flake8 plugin that leverages isort to provide warning level lint messages.

The options added are for hanging grouped indent on multiple lines: 
```py
from xxx import (
a, b, c, d, e, f, g
h, i, j, k, # and so on
)
```
and for the line length limit to 119 (120 makes autopep8 argue with it)

This PR also renames `.pyproject.toml` to `pyproject.toml`, as that is the *correct* name as listed in [PEP 518](https://www.python.org/dev/peps/pep-0518/)
