### PR TITLE
Fixed system link updating on FSDTarget

### DIFF
--- a/plugins/eddb.py
+++ b/plugins/eddb.py
@@ -77,9 +77,11 @@ def prefs_changed(cmdr, is_beta):
 
 
 def journal_entry(cmdr, is_beta, system, station, entry, state):
-    # Always update, even if we're not the *current* system or station provider.
-    this.system_address = entry.get('SystemAddress') or this.system_address
-    this.system = entry.get('StarSystem') or this.system
+    # Always update our system address even if we're not currently the provider for system or station, but dont update
+    # on events that contain "future" data, such as FSDTarget
+    if entry['event'] in ('Location', 'Docked', 'CarrierJump', 'FSDJump'):
+        this.system_address = entry.get('SystemAddress') or this.system_address
+        this.system = entry.get('StarSystem') or this.system
 
     # We need pop == 0 to set the value so as to clear 'x' in systems with
     # no stations.

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -217,9 +217,11 @@ def credentials(cmdr):
 
 
 def journal_entry(cmdr, is_beta, system, station, entry, state):
-    # Always update, even if we're not the *current* system or station provider.
-    this.system_address = entry.get('SystemAddress') or this.system_address
-    this.system = entry.get('StarSystem') or this.system
+    # Always update our system address even if we're not currently the provider for system or station, but dont update
+    # on events that contain "future" data, such as FSDTarget
+    if entry['event'] in ('Location', 'Docked', 'CarrierJump', 'FSDJump'):
+        this.system_address = entry.get('SystemAddress') or this.system_address
+        this.system = entry.get('StarSystem') or this.system
 
     # We need pop == 0 to set the value so as to clear 'x' in systems with
     # no stations.

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -231,9 +231,11 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
     elif entry['event'] in ['ShipyardNew', 'ShipyardSwap'] or (entry['event'] == 'Location' and entry['Docked']):
         this.suppress_docked = True
 
-    # Always update, even if we're not the *current* system or station provider.
-    this.system_address = entry.get('SystemAddress') or this.system_address
-    this.system = entry.get('StarSystem') or this.system
+    # Always update our system address even if we're not currently the provider for system or station, but dont update
+    # on events that contain "future" data, such as FSDTarget
+    if entry['event'] in ('Location', 'Docked', 'CarrierJump', 'FSDJump'):
+        this.system_address = entry.get('SystemAddress') or this.system_address
+        this.system = entry.get('StarSystem') or this.system
 
     # We need pop == 0 to set the value so as to clear 'x' in systems with
     # no stations.


### PR DESCRIPTION

FSDTarget contains the target system under `SystemAddress`, meaning that
any time you selected a star other than the current one, plugins'
`this.system_address` was updated to that target, rather than the
current system. Said updating causes the links provided from system_url
to reflect that update (for providers that support ID64s).

This changes the journal_entry behaviour to only update
`this.system_address` when the event is any of Location, Docked,
or FSDJump, all of which contain only the current system.