### PR TITLE
Fix/edmc eddn import

### DIFF
--- a/EDMC.py
+++ b/EDMC.py
@@ -3,6 +3,7 @@
 # Command-line interface. Requires prior setup through the GUI.
 #
 
+
 import argparse
 import json
 import logging
@@ -16,7 +17,6 @@ from typing import Any, Optional
 import collate
 import commodity
 import companion
-import eddn
 import EDMCLogging
 import edshipyard
 import l10n
@@ -29,6 +29,13 @@ from config import appcmdname, appversion, config
 from monitor import monitor
 from update import EDMCVersion, Updater
 
+sys.path.append(config.internal_plugin_dir)
+# This import must be after the sys.path.append.
+# The sys.path.append has to be after `import sys` and `from config import config`
+# isort: off
+import eddn  # noqa: E402
+# isort: on
+
 # workaround for https://github.com/EDCD/EDMarketConnector/issues/568
 os.environ["EDMC_NO_UI"] = "1"
 
@@ -37,7 +44,6 @@ l10n.Translations.install_dummy()
 logger = EDMCLogging.Logger(appcmdname).get_logger()
 logger.setLevel(logging.INFO)
 
-sys.path.append(config.internal_plugin_dir)
 
 SERVER_RETRY = 5  # retry pause for Companion servers [s]
 EXIT_SUCCESS, EXIT_SERVER, EXIT_CREDENTIALS, EXIT_VERIFICATION, EXIT_LAGGING, EXIT_SYS_ERR, EXIT_ARGS = range(7)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,6 @@ isort==5.5.2
 flake8-isort==4.0.0
 flake8-json==19.8.0
 flake8-noqa==1.0.5
-flake8-pep3101==1.3.0
 flake8-polyfill==1.0.2
 flake8-use-fstring==1.1
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,21 +1,24 @@
 # Static analysis tools
 flake8==3.8.3
 flake8-annotations-coverage==0.0.4
-flake8-cognitive-complexity==0.0.2
+flake8-cognitive-complexity==0.1.0
 flake8-comprehensions==3.2.3
-flake8-polyfill==1.0.2
-flake8-json
-flake8-isort==3.0.1
-pep8-naming==0.11.1
-flake8-noqa==1.0.5
 flake8-docstrings==1.5.0
+isort==5.5.2
+flake8-isort==4.0.0
+flake8-json==19.8.0
+flake8-noqa==1.0.5
+flake8-pep3101==1.3.0
+flake8-polyfill==1.0.2
 flake8-use-fstring==1.1
 
+pep8-naming==0.11.1
+
 # Code formatting tools
-autopep8==1.5.3
+autopep8==1.5.4
 
 # HTML changelogs
-grip==4.5.2
+grip>=4.5.2
 
 # Packaging
 # This isn't available via 'pip install', so has to be commented out in order for


### PR DESCRIPTION
Put `import eddn` in the correct place. Enforce with isort comments. Upgraded flake8/isort/etc to match.