### PR TITLE
Use tkinter.filedialog on win32, because we now fix locale encoding

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -1046,6 +1046,15 @@ Locale LC_NUMERIC: {locale.getlocale(locale.LC_NUMERIC)}
 Locale LC_TIME: {locale.getlocale(locale.LC_TIME)}'''
 )
 
+    # Change locale to a utf8 one
+    # First make sure the local is actually set as per locale's idea of defaults
+    locale.setlocale(locale.LC_ALL, '')
+    # Now find out the current locale, mostly the language
+    locale_startup = locale.getlocale(locale.LC_ALL)
+    # Now set that same language, but utf8 encoding (it was probably cp1252
+    # or equivalent for other languages).
+    locale.setlocale(locale.LC_ALL, (locale_startup[0], 'utf8'))
+
     # TODO: unittests in place of these
     # logger.debug('Test from __main__')
     # test_logging()

--- a/prefs.py
+++ b/prefs.py
@@ -498,30 +498,13 @@ class PreferencesDialog(tk.Toplevel):
         self.outdir_entry['state']      = local and 'readonly' or tk.DISABLED
 
     def filebrowse(self, title, pathvar):
-        if platform != 'win32':
-            import tkinter.filedialog
-            d = tkinter.filedialog.askdirectory(parent=self, initialdir=expanduser(pathvar.get()), title=title, mustexist=tk.TRUE)
-        else:
-            def browsecallback(hwnd, uMsg, lParam, lpData):
-                # set initial folder
-                if uMsg==BFFM_INITIALIZED and lpData:
-                    ctypes.windll.user32.SendMessageW(hwnd, BFFM_SETSELECTION, 1, lpData);
-                return 0
-
-            browseInfo = BROWSEINFO()
-            browseInfo.lpszTitle = title
-            browseInfo.ulFlags = BIF_RETURNONLYFSDIRS|BIF_USENEWUI
-            browseInfo.lpfn = BrowseCallbackProc(browsecallback)
-            browseInfo.lParam = pathvar.get().startswith('~') and join(config.home, pathvar.get()[2:]) or pathvar.get()
-            ctypes.windll.ole32.CoInitialize(None)
-            pidl = ctypes.windll.shell32.SHBrowseForFolderW(ctypes.byref(browseInfo))
-            if pidl:
-                path = ctypes.create_unicode_buffer(MAX_PATH)
-                ctypes.windll.shell32.SHGetPathFromIDListW(pidl, path)
-                ctypes.windll.ole32.CoTaskMemFree(pidl)
-                d = path.value
-            else:
-                d = None
+        import tkinter.filedialog
+        d = tkinter.filedialog.askdirectory(
+            parent=self,
+            initialdir=expanduser(pathvar.get()),
+            title=title,
+            mustexist=tk.TRUE
+        )
 
         if d:
             pathvar.set(d)


### PR DESCRIPTION
There'll be more cleanup that can be done as a consequence of this.  Other places that want a file/directory dialogue, and all of the ctypes stuff that sets things up.

But for now let's just do this and test it.