### PR TITLE
Catch where station modules from CAPI is an empty list.

### DIFF
--- a/companion.py
+++ b/companion.py
@@ -534,7 +534,7 @@ class Session(object):
         """Perform CAPI /profile endpoint query for station data."""
         data = self.query(URL_QUERY)
         if not data['commander'].get('docked'):
-            return None
+            return data
 
         services = data['lastStarport'].get('services', {})
 

--- a/companion.py
+++ b/companion.py
@@ -530,7 +530,7 @@ class Session(object):
         """Perform general CAPI /profile endpoint query."""
         return self.query(URL_QUERY)
 
-    def station(self) -> Union[CAPIData, None]:
+    def station(self) -> CAPIData:
         """Perform CAPI /profile endpoint query for station data."""
         data = self.query(URL_QUERY)
         if not data['commander'].get('docked'):

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -286,7 +286,7 @@ Msg:\n{msg}''')
             # Set a safe value
             ships = {'shipyard_list': {}, 'unavailable_list': []}
 
-        return (modules, ships)
+        return modules, ships
 
     def export_outfitting(self, data: Mapping[str, Any], is_beta: bool) -> None:
         """
@@ -296,7 +296,7 @@ Msg:\n{msg}''')
         :param data: dict containing the outfitting data
         :param is_beta: whether or not we're currently in beta mode
         """
-        (modules, ships) = self.safe_modules_and_ships(data)
+        modules, ships = self.safe_modules_and_ships(data)
 
         # Horizons flag - will hit at least Int_PlanetApproachSuite other than at engineer bases ("Colony"),
         # prison or rescue Megaships, or under Pirate Attack etc
@@ -339,7 +339,7 @@ Msg:\n{msg}''')
         :param data: dict containing the shipyard data
         :param is_beta: whether or not we are in beta mode
         """
-        (modules, ships) = self.safe_modules_and_ships(data)
+        modules, ships = self.safe_modules_and_ships(data)
 
         horizons: bool = is_horizons(
             data['lastStarport'].get('economies', {}),

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -271,8 +271,13 @@ Msg:\n{msg}''')
         :param is_beta: whether or not we're currently in beta mode
         """
         modules: Dict[str, Any] = data['lastStarport'].get('modules')
-        if modules is None:
-            logger.debug('modules was None')
+        if modules is None or isinstance(modules, list):
+            if modules is None:
+                logger.debug('modules was None')
+            elif modules == []:
+                logger.debug('modules is empty list')
+            else:
+                logger.error(f'modules is non-empty list: {modules!r}')
             modules = {}
 
         ships: Dict[str, Any] = data['lastStarport'].get('ships')
@@ -322,8 +327,13 @@ Msg:\n{msg}''')
         :param is_beta: whether or not we are in beta mode
         """
         modules: Dict[str, Any] = data['lastStarport'].get('modules')
-        if modules is None:
-            logger.debug('modules was None')
+        if modules is None or isinstance(modules, list):
+            if modules is None:
+                logger.debug('modules was None')
+            elif modules == []:
+                logger.debug('modules is empty list')
+            else:
+                logger.error(f'modules is non-empty list: {modules!r}')
             modules = {}
 
         ships: Dict[str, Any] = data['lastStarport'].get('ships')

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -11,9 +11,9 @@ from collections import OrderedDict
 from os import SEEK_SET
 from os.path import join
 from platform import system
-from typing import TYPE_CHECKING, Any, AnyStr, Dict, Iterator, List, Mapping, MutableMapping, Optional
+from typing import TYPE_CHECKING, Any, AnyStr, Dict, Iterator, List, Mapping, MutableMapping, Optional, Tuple
 from typing import OrderedDict as OrderedDictT
-from typing import Sequence, TextIO, Tuple
+from typing import Sequence, TextIO
 
 import requests
 
@@ -262,6 +262,32 @@ Msg:\n{msg}''')
 
         this.commodities = commodities
 
+    def safe_modules_and_ships(self, data: Mapping[str, Any]) -> Tuple[Dict, Dict]:
+        modules: Dict[str, Any] = data['lastStarport'].get('modules')
+        if modules is None or not isinstance(modules, dict):
+            if modules is None:
+                logger.debug('modules was None.  FC or Damaged Station?')
+            elif isinstance(modules, list):
+                if len(modules) == 0:
+                    logger.debug('modules is empty list. Damaged Station?')
+                else:
+                    logger.error(f'modules is non-empty list: {modules!r}')
+            else:
+                logger.error(f'modules was not None, a list, or a dict! type = {type(modules)}')
+            # Set a safe value
+            modules = {}
+
+        ships: Dict[str, Any] = data['lastStarport'].get('ships')
+        if ships is None or not isinstance(ships, dict):
+            if ships is None:
+                logger.debug('ships was None')
+            else:
+                logger.error(f'ships was neither None nor a Dict! Type = {type(ships)}')
+            # Set a safe value
+            ships = {'shipyard_list': {}, 'unavailable_list': []}
+
+        return (modules, ships)
+
     def export_outfitting(self, data: Mapping[str, Any], is_beta: bool) -> None:
         """
         export_outfitting updates EDDN with the current (lastStarport) station's outfitting options, if any.
@@ -270,20 +296,7 @@ Msg:\n{msg}''')
         :param data: dict containing the outfitting data
         :param is_beta: whether or not we're currently in beta mode
         """
-        modules: Dict[str, Any] = data['lastStarport'].get('modules')
-        if modules is None or isinstance(modules, list):
-            if modules is None:
-                logger.debug('modules was None')
-            elif modules == []:
-                logger.debug('modules is empty list')
-            else:
-                logger.error(f'modules is non-empty list: {modules!r}')
-            modules = {}
-
-        ships: Dict[str, Any] = data['lastStarport'].get('ships')
-        if ships is None:
-            logger.debug('ships was None')
-            ships = {'shipyard_list': {}, 'unavailable_list': []}
+        (modules, ships) = self.safe_modules_and_ships(data)
 
         # Horizons flag - will hit at least Int_PlanetApproachSuite other than at engineer bases ("Colony"),
         # prison or rescue Megaships, or under Pirate Attack etc
@@ -326,20 +339,7 @@ Msg:\n{msg}''')
         :param data: dict containing the shipyard data
         :param is_beta: whether or not we are in beta mode
         """
-        modules: Dict[str, Any] = data['lastStarport'].get('modules')
-        if modules is None or isinstance(modules, list):
-            if modules is None:
-                logger.debug('modules was None')
-            elif modules == []:
-                logger.debug('modules is empty list')
-            else:
-                logger.error(f'modules is non-empty list: {modules!r}')
-            modules = {}
-
-        ships: Dict[str, Any] = data['lastStarport'].get('ships')
-        if ships is None:
-            logger.debug('ships was None')
-            ships = {'shipyard_list': {}, 'unavailable_list': []}
+        (modules, ships) = self.safe_modules_and_ships(data)
 
         horizons: bool = is_horizons(
             data['lastStarport'].get('economies', {}),


### PR DESCRIPTION
Out of paranoia we're also checking if it's a non-empty list and logging that as an error if encountered.  It should be a dictionary!

I'll check if the ships code should also be this paranoid.