### PR TITLE
Attempt to select UTF-8 code page in manifest.

### DIFF
--- a/EDMarketConnector.manifest
+++ b/EDMarketConnector.manifest
@@ -19,6 +19,8 @@
 	<asmv3:application>
 		<asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
 			<dpiAware>true</dpiAware>
+			<!-- Declare that we want to use the UTF-8 code page -->
+			<activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
 		</asmv3:windowsSettings>
 	</asmv3:application>
 	<dependency>


### PR DESCRIPTION
Given the workaround we found for #711 talks about applications that are NOT unicode aware I looked into how to tell Windows that you *are*.

This small change should do that.