### PR TITLE
Use manifests for UTF-8, including in EDMC.py

### DIFF
--- a/EDMC.manifest
+++ b/EDMC.manifest
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
+<assembly xmlns='urn:schemas-microsoft-com:asm.v1' manifestVersion='1.0' xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" >
+	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+		<security>
+			<requestedPrivileges>
+				<requestedExecutionLevel level='asInvoker' uiAccess='false' />
+			</requestedPrivileges>
+		</security>
+	</trustInfo>
+	<!-- https://docs.microsoft.com/en-us/windows/win32/sysinfo/targeting-your-application-at-windows-8-1 -->
+	<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+		<application>
+			<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>	<!-- Windows 10 -->
+			<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>	<!-- Windows 8.1 -->
+			<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>	<!-- Windows 8 -->
+			<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>	<!-- Windows 7 -->
+		</application>
+	</compatibility>
+	<asmv3:application>
+		<asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+			<!-- Declare that we want to use the UTF-8 code page -->
+			<activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+		</asmv3:windowsSettings>
+	</asmv3:application>
+	<dependency>
+	</dependency>
+	<dependency>
+		<dependentAssembly>
+			<assemblyIdentity
+				type="win32"
+				name="Microsoft.Windows.Common-Controls"
+				version="6.0.0.0"
+				processorArchitecture="*"
+				publicKeyToken="6595b64144ccf1df"
+				language="*" />
+		</dependentAssembly>
+	</dependency>
+</assembly>

--- a/EDMC.py
+++ b/EDMC.py
@@ -6,6 +6,7 @@
 
 import argparse
 import json
+import locale
 import logging
 import os
 import re
@@ -13,6 +14,9 @@ import sys
 from os.path import getmtime, join
 from time import sleep, time
 from typing import Any, Optional
+
+# workaround for https://github.com/EDCD/EDMarketConnector/issues/568
+os.environ["EDMC_NO_UI"] = "1"
 
 import collate
 import commodity
@@ -36,14 +40,31 @@ sys.path.append(config.internal_plugin_dir)
 import eddn  # noqa: E402
 # isort: on
 
-# workaround for https://github.com/EDCD/EDMarketConnector/issues/568
-os.environ["EDMC_NO_UI"] = "1"
-
-l10n.Translations.install_dummy()
-
 logger = EDMCLogging.Logger(appcmdname).get_logger()
 logger.setLevel(logging.INFO)
 
+logger.debug(f'Startup v{appversion} : Running on Python v{sys.version}')
+logger.debug(f'''Platform: {sys.platform}
+argv[0]: {sys.argv[0]}
+exec_prefix: {sys.exec_prefix}
+executable: {sys.executable}
+sys.path: {sys.path}'''
+             )
+
+
+def log_locale(prefix: str) -> None:
+    logger.debug(f'''Locale: {prefix}
+Locale LC_COLLATE: {locale.getlocale(locale.LC_COLLATE)}
+Locale LC_CTYPE: {locale.getlocale(locale.LC_CTYPE)}
+Locale LC_MONETARY: {locale.getlocale(locale.LC_MONETARY)}
+Locale LC_NUMERIC: {locale.getlocale(locale.LC_NUMERIC)}
+Locale LC_TIME: {locale.getlocale(locale.LC_TIME)}'''
+                 )
+
+
+log_locale('Initial Locale')
+
+l10n.Translations.install_dummy()
 
 SERVER_RETRY = 5  # retry pause for Companion servers [s]
 EXIT_SUCCESS, EXIT_SERVER, EXIT_CREDENTIALS, EXIT_VERIFICATION, EXIT_LAGGING, EXIT_SYS_ERR, EXIT_ARGS = range(7)

--- a/EDMC.py
+++ b/EDMC.py
@@ -43,14 +43,6 @@ import eddn  # noqa: E402
 logger = EDMCLogging.Logger(appcmdname).get_logger()
 logger.setLevel(logging.INFO)
 
-logger.debug(f'Startup v{appversion} : Running on Python v{sys.version}')
-logger.debug(f'''Platform: {sys.platform}
-argv[0]: {sys.argv[0]}
-exec_prefix: {sys.exec_prefix}
-executable: {sys.executable}
-sys.path: {sys.path}'''
-             )
-
 
 def log_locale(prefix: str) -> None:
     logger.debug(f'''Locale: {prefix}
@@ -61,8 +53,6 @@ Locale LC_NUMERIC: {locale.getlocale(locale.LC_NUMERIC)}
 Locale LC_TIME: {locale.getlocale(locale.LC_TIME)}'''
                  )
 
-
-log_locale('Initial Locale')
 
 l10n.Translations.install_dummy()
 
@@ -133,7 +123,15 @@ def main():
                 sys.exit(EXIT_ARGS)
             logger.setLevel(args.loglevel)
 
-        logger.debug('Startup')
+        logger.debug(f'Startup v{appversion} : Running on Python v{sys.version}')
+        logger.debug(f'''Platform: {sys.platform}
+argv[0]: {sys.argv[0]}
+exec_prefix: {sys.exec_prefix}
+executable: {sys.executable}
+sys.path: {sys.path}'''
+                     )
+
+        log_locale('Initial Locale')
 
         if args.j:
             logger.debug('Import and collate from JSON dump')

--- a/EDMCLogging.py
+++ b/EDMCLogging.py
@@ -10,13 +10,14 @@ strings.
 import inspect
 import logging
 import logging.handlers
+import os
 import pathlib
 import tempfile
 # So that any warning about accessing a protected member is only in one place.
 from sys import _getframe as getframe
 from typing import Tuple
 
-from config import appname, config
+from config import appcmdname, appname, config
 
 # TODO: Tests:
 #
@@ -325,6 +326,17 @@ class EDMCContextFilter(logging.Filter):
                     module_name = f'plugins.{name_path}.{module_name}'
 
         return module_name
+
+
+def get_main_logger() -> logging.Logger:
+    """Return the correct logger for how the program is being run."""
+
+    if not os.getenv("EDMC_NO_UI"):
+        # GUI app being run
+        return logging.getLogger(appname)
+    else:
+        # Must be the CLI
+        return logging.getLogger(appcmdname)
 
 
 # Singleton

--- a/EDMCLogging.py
+++ b/EDMCLogging.py
@@ -123,7 +123,7 @@ class Logger:
         return self.logger_channel
 
 
-def get_plugin_logger(name: str, loglevel: int = _default_loglevel) -> logging.Logger:
+def get_plugin_logger(plugin_name: str, loglevel: int = _default_loglevel) -> logging.Logger:
     """
     Return a logger suitable for a plugin.
 
@@ -144,7 +144,12 @@ def get_plugin_logger(name: str, loglevel: int = _default_loglevel) -> logging.L
     :param loglevel: Optional logLevel for this Logger.
     :return: logging.Logger instance, all set up.
     """
-    plugin_logger = logging.getLogger(name)
+    if not os.getenv('EDMC_NO_UI'):
+        base_logger_name = appname
+    else:
+        base_logger_name = appcmdname
+
+    plugin_logger = logging.getLogger(f'{base_logger_name}.{plugin_name}')
     plugin_logger.setLevel(loglevel)
 
     plugin_logger.addFilter(EDMCContextFilter())

--- a/companion.py
+++ b/companion.py
@@ -9,7 +9,6 @@ protocol used for the callback.
 import base64
 import csv
 import hashlib
-import logging
 import numbers
 import os
 import random
@@ -26,9 +25,10 @@ from typing import TYPE_CHECKING, Any, Dict, List, NewType, Union
 import requests
 
 from config import appname, appversion, config
+from EDMCLogging import get_main_logger
 from protocol import protocolhandler
 
-logger = logging.getLogger(appname)
+logger = get_main_logger()
 
 if TYPE_CHECKING:
     _ = lambda x: x  # noqa: E731 # to make flake8 stop complaining that the hacked in _ method doesnt exist

--- a/plug.py
+++ b/plug.py
@@ -203,12 +203,8 @@ def load_plugins(master):
                 # Create a logger for this 'found' plugin.  Must be before the
                 # load.py is loaded.
                 import EDMCLogging
-                if not os.getenv('EDMC_NO_UI'):
-                    base_logger_name = appname
-                else:
-                    base_logger_name = appcmdname
-                plugin_logger = EDMCLogging.get_plugin_logger(f'{base_logger_name}.{name}')
 
+                plugin_logger = EDMCLogging.get_plugin_logger(name)
                 found.append(Plugin(name, os.path.join(config.plugin_dir, name, 'load.py'), plugin_logger))
             except Exception as e:
                 logger.exception(f'Failure loading found Plugin "{name}"')

--- a/plug.py
+++ b/plug.py
@@ -13,7 +13,7 @@ import tkinter as tk
 
 import myNotebook as nb  # noqa: N813
 
-from config import config, appname
+from config import appcmdname, appname, config
 from EDMCLogging import get_main_logger
 import logging
 
@@ -203,7 +203,11 @@ def load_plugins(master):
                 # Create a logger for this 'found' plugin.  Must be before the
                 # load.py is loaded.
                 import EDMCLogging
-                plugin_logger = EDMCLogging.get_plugin_logger(f'{appname}.{name}')
+                if not os.getenv('EDMC_NO_UI'):
+                    base_logger_name = appname
+                else:
+                    base_logger_name = appcmdname
+                plugin_logger = EDMCLogging.get_plugin_logger(f'{base_logger_name}.{name}')
 
                 found.append(Plugin(name, os.path.join(config.plugin_dir, name, 'load.py'), plugin_logger))
             except Exception as e:

--- a/plug.py
+++ b/plug.py
@@ -9,15 +9,15 @@ import sys
 import operator
 import threading  # noqa: F401 - We don't use it, but plugins might
 from typing import Optional
-import logging
 import tkinter as tk
 
 import myNotebook as nb  # noqa: N813
 
 from config import config, appname
+from EDMCLogging import get_main_logger
 import logging
 
-logger = logging.getLogger(appname)
+logger = get_main_logger()
 
 # Dashboard Flags constants
 FlagsDocked = 1 << 0  # on a landing pad

--- a/prefs.py
+++ b/prefs.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import logging
 from os.path import dirname, expanduser, expandvars, exists, isdir, join, normpath
 from sys import platform
 import webbrowser

--- a/prefs.py
+++ b/prefs.py
@@ -9,16 +9,15 @@ from tkinter import colorchooser as tkColorChooser
 from ttkHyperlinkLabel import HyperlinkLabel
 import myNotebook as nb
 
-from config import appname, applongname, config, appversion
+from config import applongname, config, appversion
 from hotkey import hotkeymgr
 from l10n import Translations
 from monitor import monitor
 from theme import theme
 
 import plug
-import logging
-logger = logging.getLogger(appname)
-from EDMCLogging import edmclogger
+from EDMCLogging import edmclogger, get_main_logger
+logger = get_main_logger()
 
 ###########################################################################
 # Versioned preferences, so we know whether to set an 'on' default on

--- a/setup.py
+++ b/setup.py
@@ -172,6 +172,7 @@ setup(
                  'version': BASEVERSION,
                  'product_version': VERSION,
                  'copyright': COPYRIGHT,
+                 'other_resources': [(24, 1, open(APPCMDNAME+'.manifest').read())],
              } ],
     data_files = DATA_FILES,
     options = OPTIONS,


### PR DESCRIPTION
This should be both executables now using UTF-8 codepage by default.

* Also adds start DEBUG logging to EDMC.py (after --loglevel is handled).
* Tweaks the way non-main modules get a logger, use EDMCLogging.get_main_logger() as it will handle telling the difference between EDMarketConnector and EDMC.
* Tweaks the pluging logger creation in plug.py so it's ready in case EDMC.py starts loading plugins.