### PR TITLE
Send empty market data over EDDN

### DIFF
--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -142,20 +142,23 @@ class EDDN:
         if r.status_code != requests.codes.ok:
 
             # Check if EDDN is still objecting to an empty commodities list
-            if (r.status_code == 400
+            if (
+                    r.status_code == 400
                     and msg['$schemaRef'] == 'https://eddn.edcd.io/schemas/commodity/3'
                     and msg['message']['commodities'] == []
-                    and r.text == "FAIL: [<ValidationError: '[] is too short'>]"):
+                    and r.text == "FAIL: [<ValidationError: '[] is too short'>]"
+            ):
                 logger.trace("EDDN is still objecting to empty commodities data")
                 return  # We want to silence warnings otherwise
 
-            logger.debug(f'''Status from POST wasn't OK:
+            logger.debug(
+                f'''Status from POST wasn't OK:
 Status\t{r.status_code}
 URL\t{r.url}
 Headers\t{r.headers}
 Content:\n{r.text}
 Msg:\n{msg}'''
-                         )
+            )
 
         r.raise_for_status()
 

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -140,19 +140,22 @@ class EDDN:
 
         r = self.session.post(self.UPLOAD, data=json.dumps(to_send), timeout=self.TIMEOUT)
         if r.status_code != requests.codes.ok:
+
+            # Check if EDDN is still objecting to an empty commodities list
+            if r.status_code == 400 \
+                    and msg['$schemaRef'] == 'https://eddn.edcd.io/schemas/commodity/3' \
+                    and msg['message']['commodities'] == [] \
+                    and r.text == "FAIL: [<ValidationError: '[] is too short'>]":
+                logger.trace("EDDN is still objecting to empty commodities data")
+                return  # We want to silence warnings otherwise
+
             logger.debug(f'''Status from POST wasn't OK:
 Status\t{r.status_code}
 URL\t{r.url}
 Headers\t{r.headers}
 Content:\n{r.text}
-Msg:\n{msg}''')
-
-            # Check if EDDN is still objecting to an empty commodities list
-            if r.status_code == 400 \
-                and msg['$schemaRef'] == 'https://eddn.edcd.io/schemas/commodity/3' \
-                and this.commodities == [] \
-                and r.text == "FAIL: [<ValidationError: '[] is too short'>]":
-                logger.trace("EDDN is still objecting to empty commodities data")
+Msg:\n{msg}'''
+                         )
 
         r.raise_for_status()
 

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -142,10 +142,10 @@ class EDDN:
         if r.status_code != requests.codes.ok:
 
             # Check if EDDN is still objecting to an empty commodities list
-            if r.status_code == 400 \
-                    and msg['$schemaRef'] == 'https://eddn.edcd.io/schemas/commodity/3' \
-                    and msg['message']['commodities'] == [] \
-                    and r.text == "FAIL: [<ValidationError: '[] is too short'>]":
+            if (r.status_code == 400
+                    and msg['$schemaRef'] == 'https://eddn.edcd.io/schemas/commodity/3'
+                    and msg['message']['commodities'] == []
+                    and r.text == "FAIL: [<ValidationError: '[] is too short'>]"):
                 logger.trace("EDDN is still objecting to empty commodities data")
                 return  # We want to silence warnings otherwise
 

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -409,7 +409,13 @@ Msg:\n{msg}'''
             ('demandBracket', commodity['DemandBracket']),
         ]) for commodity in items), key=lambda c: c['name'])
 
-        if commodities and this.commodities != commodities:  # Don't send empty commodities list - schema won't allow it
+        # This used to have a check `commodities and ` at the start so as to
+        # not send an empty commodities list, as the EDDN Schema doesn't allow
+        # it (as of 2020-09-28).
+        # BUT, Fleet Carriers can go from having buy/sell orders to having
+        # none and that really does need to be recorded over EDDN so that, e.g.
+        # EDDB can update in a timely manner.
+        if this.commodities != commodities:
             self.send(cmdr, {
                 '$schemaRef': f'https://eddn.edcd.io/schemas/commodity/3{"/test" if is_beta else ""}',
                 'message': OrderedDict([
@@ -722,6 +728,7 @@ def journal_entry(  # noqa: C901
 
     elif (config.getint('output') & config.OUT_MKT_EDDN and not state['Captain'] and
             entry['event'] in ('Market', 'Outfitting', 'Shipyard')):
+        # Market.json, Outfitting.json or Shipyard.json to process
 
         try:
             if this.marketId != entry['MarketID']:


### PR DESCRIPTION
Fleet Carriers can easily go from having some sell/buy orders to having none.  Thus we *do* need to send empty commodities lists if that's what we see, so that EDDB and the like can update properly.

We then catch the specific error so as to reduce logging/exception output.