### PR TITLE
Added killswitch library

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -1243,6 +1243,50 @@ Locale LC_TIME: {locale.getlocale(locale.LC_TIME)}'''
                  )
 
 
+def setup_killswitches():
+    """Download and setup the main killswitch list."""
+    logger.debug('fetching killswitches...')
+    killswitch.setup_main_list()
+
+
+def show_killswitch_poppup(root=None):
+    """Show a warning popup if there are any killswitches that match the current version."""
+    if len(kills := killswitch.kills_for_version()) == 0:
+        return
+
+    text = (
+        "Some EDMC Features have been disabled for known issues.\n"
+        "Please update EDMC as soon as possible to resolve any issues.\n"
+    )
+
+    tl = tk.Toplevel(root)
+    tl.wm_attributes('-topmost', True)
+    tl.geometry(f'+{root.winfo_rootx()}+{root.winfo_rooty()}')
+
+    tl.columnconfigure(1, weight=1)
+    tl.title("EDMC Features have been disabled")
+
+    frame = tk.Frame(tl)
+    frame.grid()
+    t = tk.Label(frame, text=text)
+    t.grid(columnspan=2)
+    idx = 1
+
+    for version in kills:
+        tk.Label(frame, text=f'Version: {version.version}').grid(row=idx, sticky=tk.W)
+        idx += 1
+        for id, reason in version.kills.items():
+            tk.Label(frame, text=id).grid(column=0, row=idx, sticky=tk.W, padx=(10, 0))
+            tk.Label(frame, text=reason).grid(column=1, row=idx, sticky=tk.E, padx=(0, 10))
+            idx += 1
+        idx += 1
+
+    ok_button = tk.Button(frame, text="ok", command=tl.destroy)
+    ok_button.grid(columnspan=2, sticky=tk.EW)
+
+    theme.apply(tl)
+
+
 # Run the app
 if __name__ == "__main__":
     # Command-line arguments
@@ -1327,7 +1371,8 @@ sys.path: {sys.path}'''
 
             except Exception:
                 logger.exception(
-                    f"Exception other than locale.Error on setting LC_ALL=('{locale_startup[0]}', 'UTF_8')")
+                    f"Exception other than locale.Error on setting LC_ALL=('{locale_startup[0]}', 'UTF_8')"
+                )
 
             else:
                 log_locale('After switching to UTF-8 encoding (same language)')
@@ -1362,9 +1407,7 @@ sys.path: {sys.path}'''
 
     Translations.install(config.get_str('language'))  # Can generate errors so wait til log set up
 
-    logger.debug('fetching killswitches...')
-    killswitch.setup_main_list()
-
+    setup_killswitches()
     root = tk.Tk(className=appname.lower())
 
     # UI Scaling
@@ -1411,6 +1454,7 @@ sys.path: {sys.path}'''
             config.set('plugins_not_py3_last', int(time()))
 
     root.after(0, messagebox_not_py3)
+    root.after(1, show_killswitch_poppup, root)
     root.mainloop()
 
     logger.info('Exiting')

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -12,6 +12,7 @@ import webbrowser
 from builtins import object, str
 from os import chdir, environ
 from os.path import dirname, isdir, join
+import killswitch
 from sys import platform
 from time import localtime, strftime, time
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Tuple, cast
@@ -1360,6 +1361,9 @@ sys.path: {sys.path}'''
     print(f'{applongname} {appversion}')
 
     Translations.install(config.get_str('language'))  # Can generate errors so wait til log set up
+
+    logger.debug('fetching killswitches...')
+    killswitch.setup_main_list()
 
     root = tk.Tk(className=appname.lower())
 

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -165,7 +165,7 @@ import tkinter as tk
 import tkinter.filedialog
 import tkinter.font
 import tkinter.messagebox
-from tkinter import ttk
+from tkinter import Toplevel, ttk
 
 import commodity
 import companion
@@ -1255,7 +1255,7 @@ def show_killswitch_poppup(root=None):
         return
 
     text = (
-        "Some EDMC Features have been disabled for known issues.\n"
+        "Some EDMC Features have been disabled due to known issues.\n"
         "Please update EDMC as soon as possible to resolve any issues.\n"
     )
 

--- a/docs/Killswitches.md
+++ b/docs/Killswitches.md
@@ -54,3 +54,9 @@ The current recognised (to EDMC and its internal plugins) killswitch strings are
 | `plugins.(eddn|inara|edsm|eddb).journal`             | Disables all journal processing for EDDN/EDSM/INARA                                          |
 | `plugins.(edsm|inara).worker`                        | Disables the EDSM/INARA worker thread (effectively disables updates) (does not close thread) |
 | `plugins.(eddn|inara|edsm).journal.event.$eventname` | Specific events to disable processing for                                                    |
+
+## File location
+
+The main killswitch file is kept in the `releases` branch on the EDMC github repo. The file should NEVER be committed to
+any other repos. In the case that the killswitch file is found in other repos, the one in releases should always
+be taken as correct regardless of others.

--- a/docs/Killswitches.md
+++ b/docs/Killswitches.md
@@ -6,18 +6,18 @@ EDMarketConnector implements a Kill Switch system that allows us to disable feat
 
 Killswitches are stored in a JSON file that is queried by EDMC on startup. The format is as follows:
 
-|             Key |  Type   | Description                                                   |
-| --------------: | :-----: | :------------------------------------------------------------ |
-|       `version` | integer | the version of the Kill Switch JSON file, always 1            |
-|  `last_updated` | string  | When last the kill switches were updated (for human use only) |
-| `kill_switches` |  array  | The kill switches this file contains (expanded below)         |
+|             Key |   Type   | Description                                                   |
+| --------------: | :------: | :------------------------------------------------------------ |
+|       `version` |  `int`   | the version of the Kill Switch JSON file, always 1            |
+|  `last_updated` | `string` | When last the kill switches were updated (for human use only) |
+| `kill_switches` | `array`  | The kill switches this file contains (expanded below)         |
 
 The `kill_switches` array contains kill switch objects. Each contains two fields:
 
 |       Key |        Type        | Description                                                             |
 | --------: | :----------------: | :---------------------------------------------------------------------- |
 | `version` | `semantic version` | The version of EDMC these kill switches apply to (Must be valid semver) |
-|   `kills` |  array of strings  | The different keys to disable                                           |
+|   `kills` |  `Dict[str, str]`  | The different keys to disable, and the reason for the disable           |
 An example follows:
 
 ```json
@@ -27,7 +27,9 @@ An example follows:
     "kill_switches": [
         {
             "version": "1.0.0",
-            "kills": ["plugins.eddn.send"]
+            "kills": {
+                "plugins.eddn.send": "some reason"
+            }
         }
     ]
 }

--- a/docs/Killswitches.md
+++ b/docs/Killswitches.md
@@ -48,12 +48,9 @@ be used to query the kill switch set, see the docstrings for more information on
 ## Currently supported killswitch strings
 
 The current recognised (to EDMC and its internal plugins) killswitch strings are as follows:
-| Kill Switch             | Description                                                                               |
-| :---------------------- | :---------------------------------------------------------------------------------------- |
-| `plugins.eddn.send`     | Disables all use of the send method on EDDN (effectively disables EDDN updates)           |
-| `plugins.eddn.journal`  | Disables all journal processing for EDDN                                                  |
-| `plugins.edsm.worker`   | Disables the send portion of the EDSM worker thread (effectively disables EDSM updates)   |
-| `plugins.edsm.journal`  | Disables all journal processing for EDSM                                                  |
-| `plugins.inara.worker`  | Disables the send portion of the INARA worker thread (effectively disables INARA updates) |
-| `plugins.inara.journal` | Disables all journal processing for INARA                                                 |
-| `plugins.eddn.journal`  | Disables all journal processing for EDDN                                                   |
+| Kill Switch                                          | Description                                                                                  |
+| :--------------------------------------------------- | :------------------------------------------------------------------------------------------- |
+| `plugins.eddn.send`                                  | Disables all use of the send method on EDDN (effectively disables EDDN updates)              |
+| `plugins.(eddn|inara|edsm|eddb).journal`             | Disables all journal processing for EDDN/EDSM/INARA                                          |
+| `plugins.(edsm|inara).worker`                        | Disables the EDSM/INARA worker thread (effectively disables updates) (does not close thread) |
+| `plugins.(eddn|inara|edsm).journal.event.$eventname` | Specific events to disable processing for                                                    |

--- a/docs/Killswitches.md
+++ b/docs/Killswitches.md
@@ -14,10 +14,10 @@ Killswitches are stored in a JSON file that is queried by EDMC on startup. The f
 
 The `kill_switches` array contains kill switch objects. Each contains two fields:
 
-|       Key |        Type        | Description                                                             |
-| --------: | :----------------: | :---------------------------------------------------------------------- |
-| `version` | `semantic version` | The version of EDMC these kill switches apply to (Must be valid semver) |
-|   `kills` |  `Dict[str, str]`  | The different keys to disable, and the reason for the disable           |
+|       Key |       Type       | Description                                                                  |
+| --------: | :--------------: | :--------------------------------------------------------------------------- |
+| `version` |  `version spec`  | The version of EDMC these kill switches apply to (Must be valid semver spec) |
+|   `kills` | `Dict[str, str]` | The different keys to disable, and the reason for the disable                |
 An example follows:
 
 ```json
@@ -37,7 +37,7 @@ An example follows:
 
 ### Versions
 
-Versions are checked using equality checks on `semantic_version.Version` instances. Meaning that **all** fields are checked (ie, Major, Minor, Patch, Prerelease, and Build).
+Versions are checked using contains checks on `semantic_version.SimpleSpec` instances.
 
 ## Plugin support
 

--- a/docs/Killswitches.md
+++ b/docs/Killswitches.md
@@ -1,0 +1,53 @@
+# Kill Switches
+
+EDMarketConnector implements a Kill Switch system that allows us to disable features based on a version mask. Meaning that we can stop major bugs from affecting the services we support, at the expense of disabling that support.
+
+## Format
+
+Killswitches are stored in a JSON file that is queried by EDMC on startup. The format is as follows:
+
+|             Key |  Type   | Description                                                   |
+| --------------: | :-----: | :------------------------------------------------------------ |
+|       `version` | integer | the version of the Kill Switch JSON file, always 1            |
+|  `last_updated` | string  | When last the kill switches were updated (for human use only) |
+| `kill_switches` |  array  | The kill switches this file contains (expanded below)         |
+
+The `kill_switches` array contains kill switch objects. Each contains two fields:
+
+|       Key |        Type        | Description                                                             |
+| --------: | :----------------: | :---------------------------------------------------------------------- |
+| `version` | `semantic version` | The version of EDMC these kill switches apply to (Must be valid semver) |
+|   `kills` |  array of strings  | The different keys to disable                                           |
+An example follows:
+
+```json
+{
+    "version": 1,
+    "last_updated": "19 October 2020",
+    "kill_switches": [
+        {
+            "version": "1.0.0",
+            "kills": ["plugins.eddn.send"]
+        }
+    ]
+}
+```
+
+### Versions
+
+Versions are checked using equality checks on `semantic_version.Version` instances. Meaning that **all** fields are checked (ie, Major, Minor, Patch, Prerelease, and Build).
+
+## Plugin support
+
+Plugins may use the killswitch system simply by hosting their own version of the killswitch file, and fetching it
+using `killswitch.get_kill_switches(target='https://example.com/myplugin_killswitches.json')`. The returned object can
+be used to query the kill switch set, see the docstrings for more information on specifying versions.
+
+## Currently supported killswitch strings
+
+The current recognised (to EDMC and its internal plugins) killswitch strings are as follows:
+| Kill Switch            | Description                                                                               |
+| :--------------------- | :---------------------------------------------------------------------------------------- |
+| `plugins.eddn.send`    | Disables all use of the send method on EDDN (effectively disables EDDN updates)           |
+| `plugins.edsm.worker`  | Disables the send portion of the EDSM worker thread (effectively disables EDSM updates)   |
+| `plugins.inara.worker` | Disables the send portion of the INARA worker thread (effectively disables INARA updates) |

--- a/docs/Killswitches.md
+++ b/docs/Killswitches.md
@@ -48,8 +48,12 @@ be used to query the kill switch set, see the docstrings for more information on
 ## Currently supported killswitch strings
 
 The current recognised (to EDMC and its internal plugins) killswitch strings are as follows:
-| Kill Switch            | Description                                                                               |
-| :--------------------- | :---------------------------------------------------------------------------------------- |
-| `plugins.eddn.send`    | Disables all use of the send method on EDDN (effectively disables EDDN updates)           |
-| `plugins.edsm.worker`  | Disables the send portion of the EDSM worker thread (effectively disables EDSM updates)   |
-| `plugins.inara.worker` | Disables the send portion of the INARA worker thread (effectively disables INARA updates) |
+| Kill Switch             | Description                                                                               |
+| :---------------------- | :---------------------------------------------------------------------------------------- |
+| `plugins.eddn.send`     | Disables all use of the send method on EDDN (effectively disables EDDN updates)           |
+| `plugins.eddn.journal`  | Disables all journal processing for EDDN                                                  |
+| `plugins.edsm.worker`   | Disables the send portion of the EDSM worker thread (effectively disables EDSM updates)   |
+| `plugins.edsm.journal`  | Disables all journal processing for EDSM                                                  |
+| `plugins.inara.worker`  | Disables the send portion of the INARA worker thread (effectively disables INARA updates) |
+| `plugins.inara.journal` | Disables all journal processing for INARA                                                 |
+| `plugins.eddn.journal`  | Disables all journal processing for EDDN                                                   |

--- a/killswitch.py
+++ b/killswitch.py
@@ -51,13 +51,22 @@ class KillSwitchSet:
 
         return DisabledResult(False, "")
 
-    def is_disabled(self, id: str, *, version=_current_version) -> bool:
+    def is_disabled(self, id: str, *, version: semantic_version.Version = _current_version) -> bool:
         """Return whether or not a given feature ID is disabled for the given version."""
         return self.get_disabled(id, version=version).disabled
 
-    def get_reason(self, id: str, version=_current_version) -> str:
+    def get_reason(self, id: str, version: semantic_version.Version = _current_version) -> str:
         """Return a reason for why the given id is disabled for the given version, if any."""
         return self.get_disabled(id, version=version).reason
+
+    def kills_for_version(self, version: semantic_version.Version = _current_version) -> List[KillSwitch]:
+        """
+        Get all killswitch entries that apply to the given version.
+
+        :param version: the version to check against, defaults to the current EDMC version
+        :return: the matching kill switches
+        """
+        return [k for k in self.kill_switches if version in k.version]
 
     def __str__(self) -> str:
         """Return a string representation of KillSwitchSet."""
@@ -172,14 +181,19 @@ def get_disabled(id: str, *, version: semantic_version.Version = _current_versio
     return active.get_disabled(id, version=version)
 
 
-def is_disabled(id: str, *, version=_current_version) -> bool:
+def is_disabled(id: str, *, version: semantic_version.Version = _current_version) -> bool:
     """Query the global KillSwitchSet#is_disabled method."""
     return active.is_disabled(id, version=version)
 
 
-def get_reason(id: str, *, version=_current_version) -> str:
+def get_reason(id: str, *, version: semantic_version.Version = _current_version) -> str:
     """Query the global KillSwitchSet#get_reason method."""
     return active.get_reason(id, version=version)
+
+
+def kills_for_version(version: semantic_version.Version = _current_version) -> List[KillSwitch]:
+    """Query the global KillSwitchSet for kills matching a particular version."""
+    return active.kills_for_version(version)
 
 
 if __name__ == "__main__":

--- a/killswitch.py
+++ b/killswitch.py
@@ -1,0 +1,150 @@
+"""Fetch kill switches from EDMC Repo."""
+from typing import Dict, List, NamedTuple, Optional, Union, cast
+
+import requests
+import semantic_version
+
+import config
+import EDMCLogging
+
+logger = EDMCLogging.get_main_logger()
+
+# DEFAULT_KILLSWITCH_URL = 'https://github.com/EDCD/EDMarketConnector'
+DEFAULT_KILLSWITCH_URL = 'http://127.0.0.1:8080/killswitches.json'
+
+_current_version: semantic_version.Version = semantic_version.Version(config.appversion)
+
+
+class KillSwitch(NamedTuple):
+    """One version's set of kill switches."""
+
+    version: semantic_version.Version
+    kills: List[str]
+
+
+class KillSwitchSet:
+    """Queryable set of kill switches."""
+
+    def __init__(self, kill_switches: List[KillSwitch]) -> None:
+        self.kill_switches = kill_switches
+
+    def is_disabled(self, id: str, *, version=_current_version) -> bool:
+        """
+        Return whether or not the given feature ID is disabled by a killswitch for the given version.
+
+        :param id: The feature ID to check
+        :param version: The version to check killswitches for, defaults to the current EDMC version
+        :return: a bool indicating status
+        """
+        for ks in self.kill_switches:
+            if version != ks.version:
+                continue
+
+            return id in ks.kills
+
+        return False
+
+    def __str__(self) -> str:
+        """Return a string representation of KillSwitchSet."""
+        return f'KillSwitchSet: {str(self.kill_switches)}'
+
+    def __repr__(self) -> str:
+        """return __repr__ for KillSwitchSet."""
+        return f'KillSwitchSet(kill_switches={self.kill_switches!r})'
+
+
+KILL_SWITCH_JSON = List[Dict[str, Union[str, List[str]]]]
+KILL_SWITCH_JSON_DICT = Dict[
+    str, Union[
+        str,  # Last updated
+        int,  # Version
+        KILL_SWITCH_JSON  # kills
+    ]
+]
+
+
+def fetch_kill_switches(target=DEFAULT_KILLSWITCH_URL) -> Optional[KILL_SWITCH_JSON_DICT]:
+    """
+    Fetch the JSON representation of our kill switches.
+
+    :param target: the URL to fetch the kill switch list from, defaults to DEFAULT_KILLSWITCH_URL
+    :return: a list of dicts containing kill switch data, or None
+    """
+    logger.info("Attempting to fetch kill switches")
+    try:
+        data = requests.get(target).json()
+
+    except ValueError as e:
+        logger.warning(f"Failed to get kill switches, data was invalid: {e}")
+        return None
+
+    except requests.exceptions.BaseHTTPError as e:
+        logger.warning(f"unable to connect to {target:r}: {e}")
+        return None
+
+    return data
+
+
+def parse_kill_switches(data: KILL_SWITCH_JSON_DICT) -> List[KillSwitch]:
+    """
+    Parse kill switch dict to List of KillSwitches.
+
+    :param data: dict containing raw killswitch data
+    :return: a list of all provided killswitches
+    """
+    last_updated = data['last_updated']
+    ks_version = data['version']
+    logger.info(f'Kill switches last updated {last_updated}')
+
+    if ks_version != 1:
+        logger.warning(f'Unknown killswitch version {ks_version}. Bailing out')
+        return []
+
+    kill_switches = cast(KILL_SWITCH_JSON, data['kill_switches'])
+    out: List[KillSwitch] = []
+
+    for idx, ks_data in enumerate(kill_switches):
+        try:
+            ver = semantic_version.Version(ks_data['version'])
+
+        except ValueError as e:
+            logger.warning(f'could not parse killswitch idx {idx}: {e}')
+            continue
+
+        ks = KillSwitch(version=ver, kills=cast(List[str], ks_data['kills']))
+        out.append(ks)
+
+    return out
+
+
+active: KillSwitchSet = KillSwitchSet([])
+
+
+def setup_main_list():
+    """
+    Set up the global set of kill switches for querying.
+
+    Plugins should NOT call this EVER.
+    """
+    if (data := fetch_kill_switches()) is None:
+        logger.warning("Unable to fetch kill switches. Setting global set to an empty set")
+        return
+
+    global active
+    active = KillSwitchSet(parse_kill_switches(data))
+
+
+def is_disabled(id: str, *, version: semantic_version.Version = _current_version) -> bool:
+    """
+    Query the global KillSwitchSet for whether or not a given ID is disabled.
+
+    See KillSwitchSet#is_disabled for more information
+    """
+    return active.is_disabled(id, version=version)
+
+
+if __name__ == "__main__":
+    setup_main_list()
+    print(f'{_current_version=}')
+    print(f"{is_disabled('test')=}")
+    print(f"{active=}")

--- a/killswitch.py
+++ b/killswitch.py
@@ -1,4 +1,5 @@
 """Fetch kill switches from EDMC Repo."""
+from ast import parse
 from typing import Dict, List, NamedTuple, Optional, Union, cast
 
 import requests
@@ -49,7 +50,7 @@ class KillSwitchSet:
         return f'KillSwitchSet: {str(self.kill_switches)}'
 
     def __repr__(self) -> str:
-        """return __repr__ for KillSwitchSet."""
+        """Return __repr__ for KillSwitchSet."""
         return f'KillSwitchSet(kill_switches={self.kill_switches!r})'
 
 
@@ -115,6 +116,20 @@ def parse_kill_switches(data: KILL_SWITCH_JSON_DICT) -> List[KillSwitch]:
         out.append(ks)
 
     return out
+
+
+def get_kill_switches(target=DEFAULT_KILLSWITCH_URL) -> Optional[KillSwitchSet]:
+    """
+    Get a kill switch set object.
+
+    :param target: the URL to fetch the killswitch JSON from, defaults to DEFAULT_KILLSWITCH_URL
+    :return: the KillSwitchSet for the URL, or None if there was an error
+    """
+    if (data := fetch_kill_switches(target)) is None:
+        logger.warning('could not get killswitches')
+        return None
+
+    return KillSwitchSet(parse_kill_switches(data))
 
 
 active: KillSwitchSet = KillSwitchSet([])

--- a/killswitch.py
+++ b/killswitch.py
@@ -78,8 +78,8 @@ def fetch_kill_switches(target=DEFAULT_KILLSWITCH_URL) -> Optional[KILL_SWITCH_J
         logger.warning(f"Failed to get kill switches, data was invalid: {e}")
         return None
 
-    except requests.exceptions.BaseHTTPError as e:
-        logger.warning(f"unable to connect to {target:r}: {e}")
+    except (requests.exceptions.BaseHTTPError, requests.exceptions.ConnectionError) as e:
+        logger.warning(f"unable to connect to {target!r}: {e}")
         return None
 
     return data

--- a/killswitch.py
+++ b/killswitch.py
@@ -9,8 +9,7 @@ import EDMCLogging
 
 logger = EDMCLogging.get_main_logger()
 
-# DEFAULT_KILLSWITCH_URL = 'https://github.com/EDCD/EDMarketConnector'
-DEFAULT_KILLSWITCH_URL = 'http://127.0.0.1:8080/killswitches.json'
+DEFAULT_KILLSWITCH_URL = 'https://raw.githubusercontent.com/EDCD/EDMarketConnector/releases/killswitches.json'
 
 _current_version: semantic_version.Version = semantic_version.Version(config.appversion)
 

--- a/killswitch.py
+++ b/killswitch.py
@@ -1,5 +1,4 @@
 """Fetch kill switches from EDMC Repo."""
-from ast import parse
 from typing import Dict, List, NamedTuple, Optional, Union, cast
 
 import requests
@@ -73,7 +72,7 @@ def fetch_kill_switches(target=DEFAULT_KILLSWITCH_URL) -> Optional[KILL_SWITCH_J
     """
     logger.info("Attempting to fetch kill switches")
     try:
-        data = requests.get(target).json()
+        data = requests.get(target, timeout=10).json()
 
     except ValueError as e:
         logger.warning(f"Failed to get kill switches, data was invalid: {e}")

--- a/killswitch.py
+++ b/killswitch.py
@@ -193,10 +193,3 @@ def get_reason(id: str, *, version: semantic_version.Version = _current_version)
 def kills_for_version(version: semantic_version.Version = _current_version) -> List[KillSwitch]:
     """Query the global KillSwitchSet for kills matching a particular version."""
     return active.kills_for_version(version)
-
-
-if __name__ == "__main__":
-    setup_main_list()
-    print(f'{_current_version=}')
-    print(f"{get_disabled('test')=}")
-    print(f"{active=}")

--- a/killswitch.py
+++ b/killswitch.py
@@ -18,7 +18,7 @@ _current_version: semantic_version.Version = semantic_version.Version(config.app
 class KillSwitch(NamedTuple):
     """One version's set of kill switches."""
 
-    version: semantic_version.Version
+    version: semantic_version.SimpleSpec
     kills: Dict[str, str]
 
 
@@ -44,7 +44,7 @@ class KillSwitchSet:
         :return: a namedtuple indicating status and reason, if any
         """
         for ks in self.kill_switches:
-            if version != ks.version:
+            if version not in ks.version:
                 continue
 
             return DisabledResult(id in ks.kills, ks.kills.get(id, ""))
@@ -120,7 +120,7 @@ def parse_kill_switches(data: KILL_SWITCH_JSON_DICT) -> List[KillSwitch]:
 
     for idx, ks_data in enumerate(kill_switches):
         try:
-            ver = semantic_version.Version(ks_data['version'])
+            ver = semantic_version.SimpleSpec(ks_data['version'])
 
         except ValueError as e:
             logger.warning(f'could not parse killswitch idx {idx}: {e}')

--- a/plugins/eddb.py
+++ b/plugins/eddb.py
@@ -97,6 +97,9 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
         logger.warning(f'Journal processing for EDDB has been disabled: {ks.reason}')
         plug.show_error('EDDB Journal processing disabled. See Log')
         return
+    elif (ks := killswitch.get_disabled(f'plugins.eddb.journal.event.{entry["event"]}')).disabled:
+        logger.warning(f'Processing of event {entry["event"]} has been disabled: {ks.reason}')
+        return
 
     # Always update our system address even if we're not currently the provider for system or station, but dont update
     # on events that contain "future" data, such as FSDTarget

--- a/plugins/eddb.py
+++ b/plugins/eddb.py
@@ -97,6 +97,7 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
         logger.warning(f'Journal processing for EDDB has been disabled: {ks.reason}')
         plug.show_error('EDDB Journal processing disabled. See Log')
         return
+
     elif (ks := killswitch.get_disabled(f'plugins.eddb.journal.event.{entry["event"]}')).disabled:
         logger.warning(f'Processing of event {entry["event"]} has been disabled: {ks.reason}')
         return

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -127,7 +127,7 @@ class EDDN:
         :param cmdr: the CMDR to use as the uploader ID
         :param msg: the payload to send
         """
-        if killswitch.is_disabled('plugins.eddn_send'):
+        if killswitch.is_disabled('plugins.eddn.send'):
             logger.warning("eddn.send has been disabled via killswitch. Returning")
             return
 

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -127,8 +127,8 @@ class EDDN:
         :param cmdr: the CMDR to use as the uploader ID
         :param msg: the payload to send
         """
-        if killswitch.is_disabled('plugins.eddn.send'):
-            logger.warning("eddn.send has been disabled via killswitch. Returning")
+        if (res := killswitch.is_disabled('plugins.eddn.send')).disbled:
+            logger.warning(f"eddn.send has been disabled via killswitch. Returning. ({res.reason})")
             return
 
         uploader_id = cmdr

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -127,7 +127,7 @@ class EDDN:
         :param cmdr: the CMDR to use as the uploader ID
         :param msg: the payload to send
         """
-        if (res := killswitch.is_disabled('plugins.eddn.send')).disbled:
+        if (res := killswitch.get_disabled('plugins.eddn.send')).disabled:
             logger.warning(f"eddn.send has been disabled via killswitch. Returning. ({res.reason})")
             return
 

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -10,12 +10,13 @@ from collections import OrderedDict
 from os import SEEK_SET
 from os.path import join
 from platform import system
-from typing import TYPE_CHECKING, Any, AnyStr, Dict, Iterator, List, Mapping, MutableMapping, Optional, Tuple
+from typing import TYPE_CHECKING, Any, AnyStr, Dict, Iterator, List, Mapping, MutableMapping, Optional
 from typing import OrderedDict as OrderedDictT
-from typing import Sequence, TextIO
+from typing import Sequence, TextIO, Tuple
 
 import requests
 
+import killswitch
 import myNotebook as nb  # noqa: N813
 from companion import CAPIData, category_map
 from config import applongname, appversion, config
@@ -25,7 +26,7 @@ from prefs import prefsVersion
 from ttkHyperlinkLabel import HyperlinkLabel
 
 if sys.platform != 'win32':
-    from fcntl import lockf, LOCK_EX, LOCK_NB
+    from fcntl import LOCK_EX, LOCK_NB, lockf
 
 
 if TYPE_CHECKING:
@@ -126,6 +127,10 @@ class EDDN:
         :param cmdr: the CMDR to use as the uploader ID
         :param msg: the payload to send
         """
+        if killswitch.is_disabled('plugins.eddn_send'):
+            logger.warning("eddn.send has been disabled via killswitch. Returning")
+            return
+
         uploader_id = cmdr
 
         to_send: OrderedDictT[str, str] = OrderedDict([

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -606,7 +606,7 @@ def journal_entry(  # noqa: C901
         logger.warning(f"EDDN journal handler has been disabled via killswitch: {ks.reason}")
         plug.show_error("EDDN journal handler disabled. See Log.")
         return None
-    elif (ks := killswitch.get_disabled(f'plugins.eddn.journal.event{entry["event"]}')).disabled:
+    elif (ks := killswitch.get_disabled(f'plugins.eddn.journal.event.{entry["event"]}')).disabled:
         logger.warning(f'Handling of event {entry["event"]} disabled via killswitch: {ks.reason}')
         return None
 

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -605,10 +605,10 @@ def journal_entry(  # noqa: C901
     if (ks := killswitch.get_disabled("plugins.eddn.journal")).disabled:
         logger.warning(f"EDDN journal handler has been disabled via killswitch: {ks.reason}")
         plug.show_error("EDDN journal handler disabled. See Log.")
-        return
-    elif (ks := killswitch.get_disabled(f'plugins.eddn.journal.event{entry["name"]}')).disabled:
-        logger.warning(f'Handling of event {entry["name"]} disabled via killswitch: {ks.reason}')
-        return
+        return None
+    elif (ks := killswitch.get_disabled(f'plugins.eddn.journal.event{entry["event"]}')).disabled:
+        logger.warning(f'Handling of event {entry["event"]} disabled via killswitch: {ks.reason}')
+        return None
 
     # Recursively filter '*_Localised' keys from dict
     def filter_localised(d: Mapping[str, Any]) -> OrderedDictT[str, Any]:

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -606,6 +606,9 @@ def journal_entry(  # noqa: C901
         logger.warning(f"EDDN journal handler has been disabled via killswitch: {ks.reason}")
         plug.show_error("EDDN journal handler disabled. See Log.")
         return
+    elif (ks := killswitch.get_disabled(f'plugins.eddn.journal.event{entry["name"]}')).disabled:
+        logger.warning(f'Handling of event {entry["name"]} disabled via killswitch: {ks.reason}')
+        return
 
     # Recursively filter '*_Localised' keys from dict
     def filter_localised(d: Mapping[str, Any]) -> OrderedDictT[str, Any]:

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -606,6 +606,7 @@ def journal_entry(  # noqa: C901
         logger.warning(f"EDDN journal handler has been disabled via killswitch: {ks.reason}")
         plug.show_error("EDDN journal handler disabled. See Log.")
         return None
+
     elif (ks := killswitch.get_disabled(f'plugins.eddn.journal.event.{entry["event"]}')).disabled:
         logger.warning(f'Handling of event {entry["event"]} disabled via killswitch: {ks.reason}')
         return None

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -18,6 +18,7 @@ import requests
 
 import killswitch
 import myNotebook as nb  # noqa: N813
+import plug
 from companion import CAPIData, category_map
 from config import applongname, appversion, config
 from EDMCLogging import get_main_logger
@@ -601,6 +602,11 @@ def plugin_stop() -> None:
 def journal_entry(  # noqa: C901
     cmdr: str, is_beta: bool, system: str, station: str, entry: MutableMapping[str, Any], state: Mapping[str, Any]
 ) -> Optional[str]:
+    if (ks := killswitch.get_disabled("plugins.eddn.journal")).disabled:
+        logger.warning(f"EDDN journal handler has been disabled via killswitch: {ks.reason}")
+        plug.show_error("EDDN journal handler disabled. See Log.")
+        return
+
     # Recursively filter '*_Localised' keys from dict
     def filter_localised(d: Mapping[str, Any]) -> OrderedDictT[str, Any]:
         filtered: OrderedDictT[str, Any] = OrderedDict()

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -343,6 +343,7 @@ def journal_entry(
         logger.warning(f'EDSM Journal handler disabled via killswitch: {ks.reason}')
         plug.show_error('EDSM Handler disabled. See Log.')
         return
+
     elif (ks := killswitch.get_disabled(f'plugins.edsm.journal.event.{entry["event"]}')).disabled:
         logger.warning(f'Handling of event {entry["event"]} has been disabled via killswitch: {ks.reason}')
         return

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -339,6 +339,11 @@ def journal_entry(
     cmdr: str, is_beta: bool, system: str, station: str, entry: MutableMapping[str, Any], state: Mapping[str, Any]
 ) -> None:
     """Journal Entry hook."""
+    if (ks := killswitch.get_disabled("plugins.edsm.journal")).disabled:
+        logger.warning(f"EDSM Journal handler disabled via killswitch: {ks.reason}")
+        plug.show_error("EDSM Handler disabled. See Log.")
+        return
+
     if entry['event'] in ('CarrierJump', 'FSDJump', 'Location', 'Docked'):
         logger.trace(f'''{entry["event"]}
 Commander: {cmdr}

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -509,7 +509,7 @@ def worker() -> None:
             logger.debug('Empty queue message, setting closing = True')
             closing = True  # Try to send any unsent events before we close
 
-        if killswitch.is_disabled("plugins.eddn.worker"):
+        if killswitch.is_disabled("plugins.edsm.worker"):
             logger.warning('EDSM worker has been disabled via kill switch. Not uploading data.')
             continue
 

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -509,12 +509,11 @@ def worker() -> None:
             logger.debug('Empty queue message, setting closing = True')
             closing = True  # Try to send any unsent events before we close
 
-        if killswitch.is_disabled("plugins.edsm.worker"):
-            logger.warning('EDSM worker has been disabled via kill switch. Not uploading data.')
-            continue
-
         retrying = 0
         while retrying < 3:
+            if killswitch.is_disabled("plugins.edsm.worker"):
+                logger.warning('EDSM worker has been disabled via kill switch. Not uploading data.')
+                break
             try:
                 if TYPE_CHECKING:
                     # Tell the type checker that these two are bound.

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -511,8 +511,10 @@ def worker() -> None:
 
         retrying = 0
         while retrying < 3:
-            if killswitch.is_disabled("plugins.edsm.worker"):
-                logger.warning('EDSM worker has been disabled via kill switch. Not uploading data.')
+            if (res := killswitch.is_disabled("plugins.edsm.worker")).disbled:
+                logger.warning(
+                    f'EDSM worker has been disabled via kill switch. Not uploading data. ({res.reason})'
+                )
                 break
             try:
                 if TYPE_CHECKING:

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -511,7 +511,7 @@ def worker() -> None:
 
         retrying = 0
         while retrying < 3:
-            if (res := killswitch.is_disabled("plugins.edsm.worker")).disbled:
+            if (res := killswitch.get_disabled("plugins.edsm.worker")).disabled:
                 logger.warning(
                     f'EDSM worker has been disabled via kill switch. Not uploading data. ({res.reason})'
                 )

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -339,9 +339,12 @@ def journal_entry(
     cmdr: str, is_beta: bool, system: str, station: str, entry: MutableMapping[str, Any], state: Mapping[str, Any]
 ) -> None:
     """Journal Entry hook."""
-    if (ks := killswitch.get_disabled("plugins.edsm.journal")).disabled:
-        logger.warning(f"EDSM Journal handler disabled via killswitch: {ks.reason}")
-        plug.show_error("EDSM Handler disabled. See Log.")
+    if (ks := killswitch.get_disabled('plugins.edsm.journal')).disabled:
+        logger.warning(f'EDSM Journal handler disabled via killswitch: {ks.reason}')
+        plug.show_error('EDSM Handler disabled. See Log.')
+        return
+    elif (ks := killswitch.get_disabled(f'plugins.edsm.journal.event.{entry["name"]}')).disabled:
+        logger.warning(f'Handling of event {entry["name"]} has been disabled via killswitch: {ks.reason}')
         return
 
     if entry['event'] in ('CarrierJump', 'FSDJump', 'Location', 'Docked'):

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any, List, Mapping, MutableMapping, Optional, 
 
 import requests
 
+import killswitch
 import myNotebook as nb  # noqa: N813
 import plug
 from config import applongname, appversion, config
@@ -507,6 +508,10 @@ def worker() -> None:
         else:
             logger.debug('Empty queue message, setting closing = True')
             closing = True  # Try to send any unsent events before we close
+
+        if killswitch.is_disabled("plugins.eddn.worker"):
+            logger.warning('EDSM worker has been disabled via kill switch. Not uploading data.')
+            continue
 
         retrying = 0
         while retrying < 3:

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -343,8 +343,8 @@ def journal_entry(
         logger.warning(f'EDSM Journal handler disabled via killswitch: {ks.reason}')
         plug.show_error('EDSM Handler disabled. See Log.')
         return
-    elif (ks := killswitch.get_disabled(f'plugins.edsm.journal.event.{entry["name"]}')).disabled:
-        logger.warning(f'Handling of event {entry["name"]} has been disabled via killswitch: {ks.reason}')
+    elif (ks := killswitch.get_disabled(f'plugins.edsm.journal.event.{entry["event"]}')).disabled:
+        logger.warning(f'Handling of event {entry["event"]} has been disabled via killswitch: {ks.reason}')
         return
 
     if entry['event'] in ('CarrierJump', 'FSDJump', 'Location', 'Docked'):

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -1,6 +1,5 @@
 """Inara Sync."""
 
-from companion import CAPIData
 import dataclasses
 import json
 import sys
@@ -17,9 +16,11 @@ from typing import Sequence, Union, cast
 
 import requests
 
+import killswitch
 import myNotebook as nb  # noqa: N813
 import plug
 import timeout_session
+from companion import CAPIData
 from config import applongname, appversion, config
 from EDMCLogging import get_main_logger
 from ttkHyperlinkLabel import HyperlinkLabel
@@ -1202,6 +1203,9 @@ def new_worker():
     logger.debug('Starting...')
     while True:
         events = get_events()
+        if killswitch.is_disabled("plugins.inara.worker"):
+            logger.warning("Inara worker disabled via killswitch")
+            return
 
         for creds, event_list in events.items():
             if not event_list:

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -1205,7 +1205,7 @@ def new_worker():
         events = get_events()
         if killswitch.is_disabled("plugins.inara.worker"):
             logger.warning("Inara worker disabled via killswitch")
-            return
+            continue
 
         for creds, event_list in events.items():
             if not event_list:

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -322,6 +322,11 @@ def journal_entry(
     cmdr: str, is_beta: bool, system: str, station: str, entry: Dict[str, Any], state: Dict[str, Any]
 ) -> None:
     """Journal entry hook."""
+    if (ks := killswitch.get_disabled("plugins.inara.journal")).disabled:
+        logger.warning(f"INARA support has been disabled via killswitch: {ks.reason}")
+        plug.show_error("INARA disabled. See Log.")
+        return
+
     event_name: str = entry['event']
     this.cmdr = cmdr
     this.FID = state['FID']

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -1203,8 +1203,8 @@ def new_worker():
     logger.debug('Starting...')
     while True:
         events = get_events()
-        if killswitch.is_disabled("plugins.inara.worker"):
-            logger.warning("Inara worker disabled via killswitch")
+        if (res := killswitch.is_disabled("plugins.inara.worker")).disbled:
+            logger.warning(f"Inara worker disabled via killswitch. ({res.reason})")
             continue
 
         for creds, event_list in events.items():

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -322,10 +322,11 @@ def journal_entry(
     cmdr: str, is_beta: bool, system: str, station: str, entry: Dict[str, Any], state: Dict[str, Any]
 ) -> None:
     """Journal entry hook."""
-    if (ks := killswitch.get_disabled("plugins.inara.journal")).disabled:
-        logger.warning(f"INARA support has been disabled via killswitch: {ks.reason}")
-        plug.show_error("INARA disabled. See Log.")
+    if (ks := killswitch.get_disabled('plugins.inara.journal')).disabled:
+        logger.warning(f'INARA support has been disabled via killswitch: {ks.reason}')
+        plug.show_error('INARA disabled. See Log.')
         return
+    elif (ks := killswitch.get_disabled(f''))
 
     event_name: str = entry['event']
     this.cmdr = cmdr

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -326,6 +326,7 @@ def journal_entry(
         logger.warning(f'INARA support has been disabled via killswitch: {ks.reason}')
         plug.show_error('INARA disabled. See Log.')
         return
+
     elif (ks := killswitch.get_disabled(f'plugins.inara.journal.event.{entry["event"]}')).disabled:
         logger.warning(f'event {entry["event"]} processing has been disabled via killswitch: {ks.reason}')
 

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -1203,7 +1203,7 @@ def new_worker():
     logger.debug('Starting...')
     while True:
         events = get_events()
-        if (res := killswitch.is_disabled("plugins.inara.worker")).disbled:
+        if (res := killswitch.get_disabled("plugins.inara.worker")).disabled:
             logger.warning(f"Inara worker disabled via killswitch. ({res.reason})")
             continue
 

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -326,7 +326,8 @@ def journal_entry(
         logger.warning(f'INARA support has been disabled via killswitch: {ks.reason}')
         plug.show_error('INARA disabled. See Log.')
         return
-    elif (ks := killswitch.get_disabled(f''))
+    elif (ks := killswitch.get_disabled(f'plugins.inara.journal.event.{entry["event"]}')).disabled:
+        logger.warning(f'event {entry["event"]} processing has been disabled via killswitch: {ks.reason}')
 
     event_name: str = entry['event']
     this.cmdr = cmdr


### PR DESCRIPTION

Killswitch exists to allow us to disable features causing issues in
specific versions remotely.

The system is designed to support plugins, where they can request their
own killswitch list by querying any web file that follows our format
(docs to be added), and using the returned KillSwitchSet to check for
disabled features.