### PR TITLE
CAPIData: Only call self.check_modules_ships() if lastStarport present

### DIFF
--- a/companion.py
+++ b/companion.py
@@ -137,7 +137,9 @@ class CAPIData(UserDict):
 
         self.original_data = self.data.copy()  # Just in case
 
-        self.check_modules_ships()
+        # Only the /profile end point has star port, and thus ships/modules.
+        if self.data.get('lastStarport'):
+            self.check_modules_ships()
 
     def check_modules_ships(self) -> None:
         modules: Dict[str, Any] = self.data['lastStarport'].get('modules')


### PR DESCRIPTION
* The companion Session.query is called for *all* CAPI endpoints and
  only the /profile one will return lastStartport data, which is where
  ships/modules are if present, so only do these checks if we see
  lastStarport.