### PR TITLE
Added name mangling support to EDMCContextFilter

### DIFF
--- a/EDMCLogging.py
+++ b/EDMCLogging.py
@@ -300,11 +300,15 @@ class EDMCContextFilter(logging.Filter):
             frame_info = inspect.getframeinfo(frame)
             args, _, _, value_dict = inspect.getargvalues(frame)
             if len(args) and args[0] in ('self', 'cls'):
-                frame_class = value_dict[args[0]]
+                frame_class: 'object' = value_dict[args[0]]
 
                 if frame_class:
+                    # See https://en.wikipedia.org/wiki/Name_mangling#Python for how name mangling works.
+                    if (name := frame_info.function).startswith("__") and not name.endswith("__"):
+                        name = f'_{frame_class.__class__.__name__}{frame_info.function}'
+
                     # Find __qualname__ of the caller
-                    fn = getattr(frame_class, frame_info.function)
+                    fn = getattr(frame_class, name, None)
                     if fn and fn.__qualname__:
                         caller_qualname = fn.__qualname__
 

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -1334,6 +1334,10 @@ sys.path: {sys.path}'''
 
             def __init__(self):
                 logger.debug('A call from A.B.__init__')
+                self.__test()
+
+            def __test(self):
+                logger.debug("A call from A.B.__test")
 
     # abinit = A.B()
 


### PR DESCRIPTION
Python name mangling is more about name collisions than actually making
things private.

This commit adds a check to resolve mangled names to their runtime
names, and adds a just-in-case default to fetching the attribute.

Fixes #764