### PR TITLE
Add multi platform transparency

### DIFF
--- a/EDMarketConnector - reset-ui.bat
+++ b/EDMarketConnector - reset-ui.bat
@@ -1,0 +1,1 @@
+EDMarketConnector.exe --reset-ui

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -1406,6 +1406,13 @@ sys.path: {sys.path}'''
             )
             config.set('plugins_not_py3_last', int(time()))
 
+    # UI Transparency
+    ui_transparency = config.getint('ui_transparency')
+    if ui_transparency == 0:
+        ui_transparency = 100
+
+    root.wm_attributes('-alpha', ui_transparency / 100)
+
     root.after(0, messagebox_not_py3)
     root.mainloop()
 

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -1253,10 +1253,17 @@ if __name__ == "__main__":
                     "such as EDSM, Inara.cz and EDDB."
     )
 
-    parser.add_argument('--trace',
-                        help='Set the Debug logging loglevel to TRACE',
-                        action='store_true',
-                        )
+    parser.add_argument(
+        '--trace',
+        help='Set the Debug logging loglevel to TRACE',
+        action='store_true',
+    )
+
+    parser.add_argument(
+        '--reset-ui',
+        help='reset UI theme and transparency to defaults',
+        action='store_true'
+    )
 
     args = parser.parse_args()
 
@@ -1273,6 +1280,11 @@ exec_prefix: {sys.exec_prefix}
 executable: {sys.executable}
 sys.path: {sys.path}'''
                  )
+
+    if args.reset_ui:
+        config.set('theme', 0)  # 'Default' theme uses ID 0
+        config.set('ui_transparency', 100)  # 100 is completely opaque
+        logger.info('reset theme and transparency to default.')
 
     # We prefer a UTF-8 encoding gets set, but older Windows versions have
     # issues with this.  From Windows 10 1903 onwards we can rely on the

--- a/L10n/en.template
+++ b/L10n/en.template
@@ -1,3 +1,9 @@
+/* Label for 'UI Transparency' option in [prefs.py]*/
+"Main window transparency" = "Main window transparency";
+
+/* Warning next to 'UI Transparency' slider */
+"100 means fully opaque.{CR}Window is updated in real time{CR}do NOT use this with the transparent theme on windows" = "100 means fully opaque.{CR}Window is updated in real time{CR}do NOT use this with the transparent theme on windows";
+
 /* Label for 'UI Scaling' option [prefs.py] */
 "UI Scale Percentage" = "UI Scale Percentage";
 

--- a/L10n/en.template
+++ b/L10n/en.template
@@ -1,8 +1,8 @@
 /* Label for 'UI Transparency' option in [prefs.py]*/
 "Main window transparency" = "Main window transparency";
 
-/* Warning next to 'UI Transparency' slider */
-"100 means fully opaque.{CR}Window is updated in real time{CR}do NOT use this with the transparent theme on windows" = "100 means fully opaque.{CR}Window is updated in real time{CR}do NOT use this with the transparent theme on windows";
+/* Message next to 'UI Transparency' slider  [prefs.py] */
+"100 means fully opaque.{CR}Window is updated in real time" = "100 means fully opaque.{CR}Window is updated in real time";
 
 /* Label for 'UI Scaling' option [prefs.py] */
 "UI Scale Percentage" = "UI Scale Percentage";

--- a/prefs.py
+++ b/prefs.py
@@ -745,14 +745,14 @@ class PreferencesDialog(tk.Toplevel):
         )
 
         with row as cur_row:
-            nb.Label(appearance_frame, text="Main window transparency").grid(
+            nb.Label(appearance_frame, text=_("Main window transparency")).grid(
                 padx=self.PADX, pady=self.PADY*2, sticky=tk.W, row=cur_row
             )
             self.transparency = tk.IntVar()
             self.transparency.set(config.getint('ui_transparency') or 100)  # Default to 100 for users
             self.transparency_bar = tk.Scale(
                 appearance_frame,
-                variable=self.transparency,
+                variable=self.transparency,  # type: ignore # Its accepted as an intvar
                 orient=tk.HORIZONTAL,
                 length=300 * (float(theme.startup_ui_scale) / 100.0 * theme.default_ui_scale),  # type: ignore # runtime
                 from_=100,
@@ -764,11 +764,11 @@ class PreferencesDialog(tk.Toplevel):
 
             nb.Label(
                 appearance_frame,
-                text=(
-                    "100 means fully opaque.\n"
-                    "Window is updated in real time\n"
+                text=_(
+                    "100 means fully opaque.{CR}"
+                    "Window is updated in real time{CR}"
                     "do NOT use this with the transparent theme on windows"
-                )
+                ).format(CR='\n')
             ).grid(
                 column=3,
                 padx=self.PADX,

--- a/prefs.py
+++ b/prefs.py
@@ -739,9 +739,42 @@ class PreferencesDialog(tk.Toplevel):
                 text=_('100 means Default{CR}Restart Required for{CR}changes to take effect!')
             ).grid(column=3, padx=self.PADX, pady=2*self.PADY, sticky=tk.E, row=cur_row)
 
+        # Transparency slider
+        ttk.Separator(appearance_frame, orient=tk.HORIZONTAL).grid(
+            columnspan=4, padx=self.PADX, pady=self.PADY*4, sticky=tk.EW, row=row.get()
+        )
+
+        with row as cur_row:
+            nb.Label(appearance_frame, text="Main window transparency").grid(
+                padx=self.PADX, pady=self.PADY*2, sticky=tk.W, row=cur_row
+            )
+            self.transparency = tk.IntVar()
+            self.transparency.set(config.getint('ui_transparency') or 100)  # Default to 100 for users
+            self.transparency_bar = tk.Scale(
+                appearance_frame,
+                variable=self.transparency,
+                orient=tk.HORIZONTAL,
+                length=300 * (float(theme.startup_ui_scale) / 100.0 * theme.default_ui_scale),  # type: ignore # runtime
+                from_=100,
+                to=5,
+                tickinterval=10,
+                resolution=5,
+                command=lambda _: self.parent.wm_attributes("-alpha", self.transparency.get() / 100)
+            )
+
+            nb.Label(appearance_frame, text="100 means fully opaque.\nWindow is updated in real time").grid(
+                column=3,
+                padx=self.PADX,
+                pady=self.PADY*2,
+                sticky=tk.E,
+                row=cur_row
+            )
+
+            self.transparency_bar.grid(column=1, sticky=tk.W, row=cur_row)
+
         # Always on top
         ttk.Separator(appearance_frame, orient=tk.HORIZONTAL).grid(
-            columnspan=3, padx=self.PADX, pady=self.PADY*4, sticky=tk.EW, row=row.get()
+            columnspan=4, padx=self.PADX, pady=self.PADY*4, sticky=tk.EW, row=row.get()
         )
 
         self.ontop_button = nb.Checkbutton(
@@ -1122,6 +1155,7 @@ class PreferencesDialog(tk.Toplevel):
         Translations.install(config.get_str('language', default=None))  # type: ignore # This sets self in weird ways.
 
         config.set('ui_scale', self.ui_scale.get())
+        config.set('ui_transparency', self.transparency.get())
         config.set('always_ontop', self.always_ontop.get())
         config.set('theme', self.theme.get())
         config.set('dark_text', self.theme_colors[0])

--- a/prefs.py
+++ b/prefs.py
@@ -766,8 +766,7 @@ class PreferencesDialog(tk.Toplevel):
                 appearance_frame,
                 text=_(
                     "100 means fully opaque.{CR}"
-                    "Window is updated in real time{CR}"
-                    "do NOT use this with the transparent theme on windows"
+                    "Window is updated in real time"
                 ).format(CR='\n')
             ).grid(
                 column=3,

--- a/prefs.py
+++ b/prefs.py
@@ -762,7 +762,14 @@ class PreferencesDialog(tk.Toplevel):
                 command=lambda _: self.parent.wm_attributes("-alpha", self.transparency.get() / 100)
             )
 
-            nb.Label(appearance_frame, text="100 means fully opaque.\nWindow is updated in real time").grid(
+            nb.Label(
+                appearance_frame,
+                text=(
+                    "100 means fully opaque.\n"
+                    "Window is updated in real time\n"
+                    "do NOT use this with the transparent theme on windows"
+                )
+            ).grid(
                 column=3,
                 padx=self.PADX,
                 pady=self.PADY*2,


### PR DESCRIPTION
This is distinct from the windows only transparent theme, I wanted to enable that on other platforms too but could not find a way.

The way this works is it changes the transparency of the entire EDMC window. Tested on windows and linux, works as expected for both.
![Screenshot from 2020-11-04 17-57-19](https://user-images.githubusercontent.com/21071450/98134246-3a472b80-1ec7-11eb-8a53-e85be9d6ccb7.png)
