### PR TITLE
Build automatically with github actions

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,47 @@
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Build EDMC
+    runs-on: windows-2019
+
+    defaults:
+      run:
+        shell: powershell
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.7.9"
+          architecture: "x86"
+
+      - name: Install python tools
+        run: |
+          pip install wheel
+          pip install -r requirements-dev.txt
+          pip install py2exe
+          ls
+
+      - name: Download winsparkle
+        run: |
+          Invoke-Webrequest -UseBasicParsing https://github.com/vslavik/winsparkle/releases/download/v0.7.0/WinSparkle-0.7.0.zip -OutFile out.zip
+          Expand-Archive out.zip
+          Move-Item 'out\WinSparkle-0.7.0\Release\*' '.\'
+
+      - name: Build EDMC
+        run: |
+          python setup.py py2exe
+
+      - name: Upload build files
+        uses: actions/upload-artifact@v2
+        with:
+          name: Built files
+          path: |
+            EDMarketConnector_win*.msi
+            dist.win32\EDMarketConnector.exe
+            appcast_win_*.xml

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -24,8 +24,6 @@ jobs:
         run: |
           pip install wheel
           pip install -r requirements-dev.txt
-          pip install py2exe
-          ls
 
       - name: Download winsparkle
         run: |


### PR DESCRIPTION
This can be invoked manually or on pushes to tags matching v*, which may or may not actually behave as expected. If GA takes the workflow version etc from that tag, it should work fine. Otherwise py versions may cause it to fail.