### PR TITLE
EDMCLogging: Catch inspect.getframeinfo(frame) not working

### DIFF
--- a/EDMCLogging.py
+++ b/EDMCLogging.py
@@ -286,7 +286,7 @@ class EDMCContextFilter(logging.Filter):
             # <https://stackoverflow.com/questions/2203424/python-how-to-retrieve-class-information-from-a-frame-object#2220759>
             try:
                 frame_info = inspect.getframeinfo(frame)
-                raise(IndexError)  # TODO: Remove, only for testing
+                # raise(IndexError)  # TODO: Remove, only for testing
 
             except Exception:
                 # Separate from the print below to guarantee we see at least this much.

--- a/EDMCLogging.py
+++ b/EDMCLogging.py
@@ -284,7 +284,25 @@ class EDMCContextFilter(logging.Filter):
         caller_qualname = caller_class_names = ''
         if frame:
             # <https://stackoverflow.com/questions/2203424/python-how-to-retrieve-class-information-from-a-frame-object#2220759>
-            frame_info = inspect.getframeinfo(frame)
+            try:
+                frame_info = inspect.getframeinfo(frame)
+                raise(IndexError)  # TODO: Remove, only for testing
+
+            except Exception:
+                # Separate from the print below to guarantee we see at least this much.
+                print('EDMCLogging:EDMCContextFilter:caller_attributes(): Failed in `inspect.getframinfo(frame)`')
+
+                # We want to *attempt* to show something about the nature of 'frame',
+                # but at this point we can't trust it will work.
+                try:
+                    print(f'frame: {frame}')
+
+                except Exception:
+                    pass
+
+                # We've given up, so just return all '??' to signal we couldn't get the info
+                return '??', '??', '??'
+
             args, _, _, value_dict = inspect.getargvalues(frame)
             if len(args) and args[0] in ('self', 'cls'):
                 frame_class: 'object' = value_dict[args[0]]


### PR DESCRIPTION
Maybe with this we'll see something 'here' or later to give a clue as to why this doesn't work on at least two systems.