### PR TITLE
Added support for logging from properties

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -1238,7 +1238,6 @@ executable: {sys.executable}
 sys.path: {sys.path}'''
                  )
 
-
     # We prefer a UTF-8 encoding gets set, but older Windows versions have
     # issues with this.  From Windows 10 1903 onwards we can rely on the
     # manifest ActiveCodePage to set this, but that is silently ignored on
@@ -1287,7 +1286,8 @@ sys.path: {sys.path}'''
                 logger.exception(f"Could not set LC_ALL to ('{locale_startup[0]}', 'UTF_8')")
 
             except Exception:
-                logger.exception(f"Exception other than locale.Error on setting LC_ALL=('{locale_startup[0]}', 'UTF_8')")
+                logger.exception(
+                    f"Exception other than locale.Error on setting LC_ALL=('{locale_startup[0]}', 'UTF_8')")
 
             else:
                 log_locale('After switching to UTF-8 encoding (same language)')
@@ -1303,9 +1303,15 @@ sys.path: {sys.path}'''
             def __init__(self):
                 logger.debug('A call from A.B.__init__')
                 self.__test()
+                _ = self.test_prop
 
             def __test(self):
                 logger.debug("A call from A.B.__test")
+
+            @property
+            def test_prop(self):
+                logger.debug("test log from property")
+                return "Test property is testy"
 
     # abinit = A.B()
 


### PR DESCRIPTION
This is some best effort support for using logging in properties.

This works by using the (as suggested by reporter) inspect
`getattr_static` method, and failing that (as it can possibly fail),
wrapping a `getattr` in a try/catch for a RecursionError--don't want to
catch other things, probably best if that explodes on its own.

From there as the `property` object will not have location information,
we rebuild as best we can to an approximation of what the path would be.
With a healthy dash of defensive programming "Just in case".

I don't think that this will have any adverse effects to other logging
methods, as all the new code should only be touched if we hit a property
object.

Closes #808