### PR TITLE
Fix multiple missions with the same cargo type

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -412,6 +412,7 @@ Content of `state` (updated to the current journal entry):
 | `ModulesValue` |            `int`            | Value of the current ship's modules                                                                             |
 | `Rebuy`        |            `int`            | Current ship's rebuy cost                                                                                       |
 | `Modules`      |           `dict`            | Currently fitted modules                                                                                        |
+| `CargoJSON`    |           `dict`            | content of cargo.json as of last read.                                                                          |
 
 A special "StartUp" entry is sent if EDMC is started while the game is already
 running. In this case you won't receive initial events such as "LoadGame",

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -392,7 +392,8 @@ Content of `state` (updated to the current journal entry):
 | Field          |            Type             | Description                                                                                                     |
 | :------------- | :-------------------------: | :-------------------------------------------------------------------------------------------------------------- |
 | `Captian`      |       `Optional[str]`       | Name of the commander who's crew you're on, if any                                                              |
-| `Cargo`        |           `dict`            | Current cargo                                                                                                   |
+| `Cargo`        |           `dict`            | Current cargo. Note that this will be totals, and any mission specific duplicates will be counted together      |
+| `CargoJSON`    |           `dict`            | content of cargo.json as of last read.                                                                          |
 | `Credits`      |            `int`            | Current credits balance                                                                                         |
 | `FID`          |            `str`            | Frontier commander ID                                                                                           |
 | `Loan`         |       `Optional[int]`       | Current loan amount, if any                                                                                     |
@@ -412,7 +413,6 @@ Content of `state` (updated to the current journal entry):
 | `ModulesValue` |            `int`            | Value of the current ship's modules                                                                             |
 | `Rebuy`        |            `int`            | Current ship's rebuy cost                                                                                       |
 | `Modules`      |           `dict`            | Currently fitted modules                                                                                        |
-| `CargoJSON`    |           `dict`            | content of cargo.json as of last read.                                                                          |
 
 A special "StartUp" entry is sent if EDMC is started while the game is already
 running. In this case you won't receive initial events such as "LoadGame",

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -443,6 +443,11 @@ typically about once a second when in orbital flight.
 
  For more info on `status.json`, See the "Status File" section in the Frontier [Journal documentation](https://forums.frontier.co.uk/showthread.php/401661) for the available `entry` properties and for the list of available `"Flags"`. Refer to the source code of [plug.py](./plug.py) for the list of available  constants.
 
+New in version 4.1.6:
+
+`CargoJSON` contains the raw data from the last read of `cargo.json` passed through json.load.
+It contains more information about the cargo contents, such as the mission ID for mission specific cargo
+
 #### Getting Commander Data
 
 ```python

--- a/monitor.py
+++ b/monitor.py
@@ -7,7 +7,7 @@ from os.path import basename, expanduser, isdir, join
 from sys import platform
 from time import gmtime, localtime, sleep, strftime, strptime, time
 from calendar import timegm
-from typing import Any, Optional, OrderedDict as OrderedDictT, Tuple, TYPE_CHECKING, Union
+from typing import Any, List, MutableMapping, Optional, OrderedDict as OrderedDictT, Tuple, TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     import tkinter
@@ -118,6 +118,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             'ModulesValue': None,
             'Rebuy':        None,
             'Modules':      None,
+            'CargoJSON':   None,  # The raw data from the last time cargo.json was read
         }
 
     def start(self, root: 'tkinter.Tk'):
@@ -363,7 +364,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
         try:
             # Preserve property order because why not?
-            entry: OrderedDictT[str, Any] = json.loads(line, object_pairs_hook=OrderedDict)
+            entry: MutableMapping[str, Any] = json.loads(line, object_pairs_hook=OrderedDict)
             entry['timestamp']  # we expect this to exist # TODO: replace with assert? or an if key in check
 
             event_type = entry['event']
@@ -608,8 +609,11 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 if 'Inventory' not in entry:
                     with open(join(self.currentdir, 'Cargo.json'), 'rb') as h:  # type: ignore
                         entry = json.load(h, object_pairs_hook=OrderedDict)  # Preserve property order because why not?
+                        self.state['CargoJSON'] = entry
 
-                self.state['Cargo'].update({self.canonicalise(x['Name']): x['Count'] for x in entry['Inventory']})
+                clean = self.coalesce_cargo(entry['Inventory'])
+
+                self.state['Cargo'].update({self.canonicalise(x['Name']): x['Count'] for x in clean})
 
             elif event_type in ('CollectCargo', 'MarketBuy', 'BuyDrones', 'MiningRefined'):
                 commodity = self.canonicalise(entry['Type'])
@@ -965,6 +969,35 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
         with open(filename, 'wt') as h:
             h.write(string)
+
+    def coalesce_cargo(self, raw_cargo: List[MutableMapping[str, Any]]) -> List[MutableMapping[str, Any]]:
+        """
+        Coalesce multiple entries of the same cargo into one.
+
+        This exists due to the fact that a user can accept multiple missions that all require the same cargo. On the ED
+        side, this is represented as multiple entries in the `Inventory` List with the same names etc. Just a differing
+        MissionID. We (as in EDMC Core) dont want to support the multiple mission IDs, but DO want to have correct cargo
+        counts. Thus, we reduce all existing cargo down to one total.
+
+        :param raw_cargo: Raw cargo data (usually from Cargo.json)
+        :return: Coalesced data
+        """
+        # self.state['Cargo'].update({self.canonicalise(x['Name']): x['Count'] for x in entry['Inventory']})
+        out: List[MutableMapping[str, Any]] = []
+        for inventory_item in raw_cargo:
+            if not any(self.canonicalise(x['Name']) == self.canonicalise(inventory_item['Name']) for x in out):
+                out.append(dict(inventory_item))
+                continue
+
+            # We've seen this before, update that count
+            x = list(filter(lambda x: self.canonicalise(x['Name']) == self.canonicalise(inventory_item['Name']), out))
+
+            if len(x) != 1:
+                logger.debug(f'Unexpected number of items: {len(x)} where 1 was expected. {x}')
+
+            x[0]['Count'] += inventory_item['Count']
+
+        return out
 
 
 # singleton

--- a/monitor.py
+++ b/monitor.py
@@ -978,6 +978,14 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         side, this is represented as multiple entries in the `Inventory` List with the same names etc. Just a differing
         MissionID. We (as in EDMC Core) dont want to support the multiple mission IDs, but DO want to have correct cargo
         counts. Thus, we reduce all existing cargo down to one total.
+        >>> test = [
+        ...     { "Name":"basicmedicines", "Name_Localised":"BM", "MissionID":684359162, "Count":147, "Stolen":0 },
+        ...     { "Name":"survivalequipment", "Name_Localised":"SE", "MissionID":684358939, "Count":147, "Stolen":0 },
+        ...     { "Name":"survivalequipment", "Name_Localised":"SE", "MissionID":684359344, "Count":36, "Stolen":0 }
+        ... ]
+        >>> EDLogs().coalesce_cargo(test) # doctest: +NORMALIZE_WHITESPACE
+        [{'Name': 'basicmedicines', 'Name_Localised': 'BM', 'MissionID': 684359162, 'Count': 147, 'Stolen': 0},
+        {'Name': 'survivalequipment', 'Name_Localised': 'SE', 'MissionID': 684358939, 'Count': 183, 'Stolen': 0}]
 
         :param raw_cargo: Raw cargo data (usually from Cargo.json)
         :return: Coalesced data


### PR DESCRIPTION
A user can collect multiple missions with the same mission cargo, which
is added to the cargo.json as distinct entries. Previously we would take
the last number as the total, leading to invalid counts (and possibly
negative counts).

This adds a method to sum cargo entries based on the cargo name. It also
adds a field on status to access the original cargo JSON data.

Fixes #817