### PR TITLE
Fix logging from mangled methods where class name starts with "_"

### DIFF
--- a/EDMCLogging.py
+++ b/EDMCLogging.py
@@ -322,9 +322,11 @@ class EDMCContextFilter(logging.Filter):
 
                 if frame_class:
                     # See https://en.wikipedia.org/wiki/Name_mangling#Python for how name mangling works.
+                    # For more detail, see _Py_Mangle in CPython's Python/compile.c.
                     name = frame_info.function
-                    if name.startswith("__") and not name.endswith("__"):
-                        name = f'_{frame_class.__class__.__name__}{frame_info.function}'
+                    class_name = frame_class.__class__.__name__.lstrip("_")
+                    if name.startswith("__") and not name.endswith("__") and class_name:
+                        name = f'_{class_name}{frame_info.function}'
 
                     # Find __qualname__ of the caller
                     fn = inspect.getattr_static(frame_class, name, None)


### PR DESCRIPTION
#766 didn't completely fix #764, unfortunately: logging from mangled methods inside classes whose names started with an underscore is still broken (it no longer crashes, just fails to determine the name). This PR fixes that.

Python's name-mangling rules are _weird_:

```python
# test.py

class Foo:
    def method(self): pass
    def __mangled_method(self): pass

class _Foo:
    def method(self): pass
    def __mangled_method(self): pass

class ___:
    def method(self): pass
    def __mangled_method(self): pass

for cls in [Foo, _Foo, ___]:
    print(cls.__name__, [attr for attr in dir(cls()) if "method" in attr])
```

```console
$ python3 test.py
Foo ['_Foo__mangled_method', 'method']
_Foo ['_Foo__mangled_method', 'method']
___ ['__mangled_method', 'method']
```

This PR is still arguably incomplete, because it incorrectly applies mangling to names with dots in, but that seems unlikely to be an issue for EDMC – as noted in [`_Py_Mangle`](https://github.com/python/cpython/blob/ee9f98d9f4b881ee15868a836a2b99271df1bc0e/Python/compile.c#L255), "The only time a name with a dot can occur is when we are compiling an import statement that has a package name", and this doesn't seem like something that the EDMC logging infrastructure will have to deal with.