### PR TITLE
Bail out of Journal monitoring during shutdown

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -743,6 +743,10 @@ class AppWindow(object):
                 'FlightCon':  _('Helm'),  # Multicrew role
             }.get(role, role)
 
+        if monitor.thread is None:
+            logger.debug('monitor.thread is None, assuming shutdown and returning')
+            return
+
         while True:
             entry = monitor.get_entry()
             if not entry:

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,16 +1,13 @@
 import json
 from calendar import timegm
-from operator import itemgetter
-from os import listdir
 from os.path import isdir, isfile, join, getsize
 from sys import platform
 import time
 
-if __debug__:
-    from traceback import print_exc
-
 from config import config
+from EDMCLogging import get_main_logger
 
+logger = get_main_logger()
 
 if platform=='darwin':
     from watchdog.observers import Observer
@@ -67,8 +64,10 @@ class Dashboard(FileSystemEventHandler):
         if not self.observed and not polling:
             self.observed = self.observer.schedule(self, self.currentdir)
 
-        if __debug__:
-            print('%s Dashboard "%s"' % (polling and 'Polling' or 'Monitoring', self.currentdir))
+        if polling:
+            logger.debug(f'Polling Dashboard "{self.currentdir}"')
+        else:
+            logger.debug(f'Monitoring Dashboard "{self.currentdir}"')
 
         # Even if we're not intending to poll, poll at least once to process pre-existing
         # data and to check whether the watchdog thread has crashed due to events not
@@ -78,8 +77,8 @@ class Dashboard(FileSystemEventHandler):
         return True
 
     def stop(self):
-        if __debug__:
-            print('Stopping monitoring Dashboard')
+        logger.debug('Stopping monitoring Dashboard')
+
         self.currentdir = None
         if self.observed:
             self.observed = None
@@ -127,8 +126,8 @@ class Dashboard(FileSystemEventHandler):
                         self.status != entry):
                         self.status = entry
                         self.root.event_generate('<<DashboardEvent>>', when="tail")
-        except:
-            if __debug__: print_exc()
+        except Exception:
+            logger.exception('Reading Status.json')
 
 # singleton
 dashboard = Dashboard()

--- a/monitor.py
+++ b/monitor.py
@@ -828,6 +828,10 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
         :return: dict representing the event
         """
+        if self.thread is None:
+            logger.debug('Called whilst self.thread is None, returning')
+            return None
+
         if not self.event_queue:
             logger.debug('Called with no event_queue')
             return None

--- a/monitor.py
+++ b/monitor.py
@@ -187,8 +187,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         return True
 
     def stop(self):
-        if __debug__:
-            print('Stopping monitoring Journal')
+        logger.debug('Stopping monitoring Journal')
 
         self.currentdir = None
         self.version = None

--- a/monitor.py
+++ b/monitor.py
@@ -327,6 +327,11 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 loghandle.seek(0, SEEK_END)		  # required to make macOS notice log change over SMB
                 loghandle.seek(log_pos, SEEK_SET)  # reset EOF flag # TODO: log_pos reported as possibly unbound
                 for line in loghandle:
+                    # Paranoia check to see if we're shutting down
+                    if threading.current_thread() != self.thread:
+                        logger.info("We're not meant to be running, exiting...")
+                        return  # Terminate
+
                     if b'"event":"Location"' in line:
                         logger.trace('Found "Location" event, appending to event_queue')
 

--- a/plug.py
+++ b/plug.py
@@ -251,10 +251,14 @@ def notify_stop():
         plugin_stop = plugin._get_func('plugin_stop')
         if plugin_stop:
             try:
+                logger.info(f'Asking plugin "{plugin.name}" to stop...')
                 newerror = plugin_stop()
                 error = error or newerror
             except Exception as e:
                 logger.exception(f'Plugin "{plugin.name}" failed')
+
+    logger.info('Done')
+
     return error
 
 


### PR DESCRIPTION
See #834 - we need to be better about ceasing journal parsing during application shutdown.

This might go on to also re-ordering the shutdown sequence.