### PR TITLE
Avoid Tk event_generate() calls during shutdown.

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -1059,6 +1059,8 @@ class AppWindow(object):
             self.status['text'] = str(e)
 
     def onexit(self, event=None):
+        config.set_shutdown()  # Signal we're in shutdown now.
+
         # http://core.tcl.tk/tk/tktview/c84f660833546b1b84e7
         if platform != 'darwin' or self.w.winfo_rooty() > 0:
             x, y = self.w.geometry().split('+')[1:3]  # e.g. '212x170+2881+1267'

--- a/config.py
+++ b/config.py
@@ -117,7 +117,7 @@ class Config(object):
     if platform=='darwin':
 
         def __init__(self):
-            self.in_shutdown = False  # Is the application currently shutting down ?
+            self.__in_shutdown = False  # Is the application currently shutting down ?
 
             self.app_dir = join(NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, True)[0], appname)
             if not isdir(self.app_dir):
@@ -180,15 +180,15 @@ class Config(object):
             self.defaults = None
 
         def set_shutdown(self):
-            self.in_shutdown = True
+            self.__in_shutdown = True
 
         def shutting_down(self) -> bool:
-            return self.in_shutdown
+            return self.__in_shutdown
 
     elif platform=='win32':
 
         def __init__(self):
-            self.in_shutdown = False  # Is the application currently shutting down ?
+            self.__in_shutdown = False  # Is the application currently shutting down ?
 
             self.app_dir = join(KnownFolderPath(FOLDERID_LocalAppData), appname)
             if not isdir(self.app_dir):
@@ -278,17 +278,17 @@ class Config(object):
             self.hkey = None
 
         def set_shutdown(self):
-            self.in_shutdown = True
+            self.__in_shutdown = True
 
         def shutting_down(self) -> bool:
-            return self.in_shutdown
+            return self.__in_shutdown
 
     elif platform=='linux':
 
         SECTION = 'config'
 
         def __init__(self):
-            self.in_shutdown = False  # Is the application currently shutting down ?
+            self.__in_shutdown = False  # Is the application currently shutting down ?
 
             # http://standards.freedesktop.org/basedir-spec/latest/ar01s03.html
             self.app_dir = join(getenv('XDG_DATA_HOME', expanduser('~/.local/share')), appname)
@@ -363,10 +363,10 @@ class Config(object):
             self.config = None
 
         def set_shutdown(self):
-            self.in_shutdown = True
+            self.__in_shutdown = True
 
         def shutting_down(self) -> bool:
-            return self.in_shutdown
+            return self.__in_shutdown
 
         def _escape(self, val):
             return str(val).replace(u'\\', u'\\\\').replace(u'\n', u'\\n').replace(u';', u'\\;')

--- a/config.py
+++ b/config.py
@@ -117,6 +117,8 @@ class Config(object):
     if platform=='darwin':
 
         def __init__(self):
+            self.in_shutdown = False  # Is the application currently shutting down ?
+
             self.app_dir = join(NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, True)[0], appname)
             if not isdir(self.app_dir):
                 mkdir(self.app_dir)
@@ -177,9 +179,16 @@ class Config(object):
             self.save()
             self.defaults = None
 
+        def set_shutdown(self):
+            self.in_shutdown = True
+
+        def shutting_down(self) -> bool:
+            return self.in_shutdown
+
     elif platform=='win32':
 
         def __init__(self):
+            self.in_shutdown = False  # Is the application currently shutting down ?
 
             self.app_dir = join(KnownFolderPath(FOLDERID_LocalAppData), appname)
             if not isdir(self.app_dir):
@@ -268,11 +277,18 @@ class Config(object):
             RegCloseKey(self.hkey)
             self.hkey = None
 
+        def set_shutdown(self):
+            self.in_shutdown = True
+
+        def shutting_down(self) -> bool:
+            return self.in_shutdown
+
     elif platform=='linux':
 
         SECTION = 'config'
 
         def __init__(self):
+            self.in_shutdown = False  # Is the application currently shutting down ?
 
             # http://standards.freedesktop.org/basedir-spec/latest/ar01s03.html
             self.app_dir = join(getenv('XDG_DATA_HOME', expanduser('~/.local/share')), appname)
@@ -345,6 +361,12 @@ class Config(object):
         def close(self):
             self.save()
             self.config = None
+
+        def set_shutdown(self):
+            self.in_shutdown = True
+
+        def shutting_down(self) -> bool:
+            return self.in_shutdown
 
         def _escape(self, val):
             return str(val).replace(u'\\', u'\\\\').replace(u'\n', u'\\n').replace(u';', u'\\;')

--- a/config.py
+++ b/config.py
@@ -182,6 +182,7 @@ class Config(object):
         def set_shutdown(self):
             self.__in_shutdown = True
 
+        @property
         def shutting_down(self) -> bool:
             return self.__in_shutdown
 

--- a/config.py
+++ b/config.py
@@ -281,6 +281,7 @@ class Config(object):
         def set_shutdown(self):
             self.__in_shutdown = True
 
+        @property
         def shutting_down(self) -> bool:
             return self.__in_shutdown
 
@@ -366,6 +367,7 @@ class Config(object):
         def set_shutdown(self):
             self.__in_shutdown = True
 
+        @property
         def shutting_down(self) -> bool:
             return self.__in_shutdown
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -115,9 +115,9 @@ class Dashboard(FileSystemEventHandler):
 
     # Can be called either in watchdog thread or, if polling, in main thread.
     def process(self, logfile=None):
-        if config.shutting_down():
+        if config.shutting_down:
             return
-        
+
         try:
             with open(join(self.currentdir, 'Status.json'), 'rb') as h:
                 data = h.read().strip()

--- a/dashboard.py
+++ b/dashboard.py
@@ -115,6 +115,9 @@ class Dashboard(FileSystemEventHandler):
 
     # Can be called either in watchdog thread or, if polling, in main thread.
     def process(self, logfile=None):
+        if config.shutting_down():
+            return
+        
         try:
             with open(join(self.currentdir, 'Status.json'), 'rb') as h:
                 data = h.read().strip()
@@ -126,6 +129,7 @@ class Dashboard(FileSystemEventHandler):
                         self.status != entry):
                         self.status = entry
                         self.root.event_generate('<<DashboardEvent>>', when="tail")
+
         except Exception:
             logger.exception('Reading Status.json')
 

--- a/hotkey.py
+++ b/hotkey.py
@@ -92,7 +92,7 @@ if platform == 'darwin':
             self.observer = NSEvent.addGlobalMonitorForEventsMatchingMask_handler_(NSKeyDownMask, self._handler)
 
         def _poll(self):
-            if config.shutting_down():
+            if config.shutting_down:
                 return
 
             # No way of signalling to Tkinter from within the callback handler block that doesn't
@@ -127,7 +127,7 @@ if platform == 'darwin':
             self.acquire_state = HotkeyMgr.ACQUIRE_INACTIVE
 
         def _acquire_poll(self):
-            if config.shutting_down():
+            if config.shutting_down:
                 return
 
             # No way of signalling to Tkinter from within the monkey-patched event handler that doesn't
@@ -323,7 +323,7 @@ elif platform == 'win32':
             while GetMessage(ctypes.byref(msg), None, 0, 0) != 0:
                 if msg.message == WM_HOTKEY:
                     if config.getint('hotkey_always') or WindowTitle(GetForegroundWindow()).startswith('Elite - Dangerous'):
-                        if not config.shutting_down():
+                        if not config.shutting_down:
                             self.root.event_generate('<<Invoke>>', when="tail")
                     else:
                         # Pass the key on

--- a/hotkey.py
+++ b/hotkey.py
@@ -92,11 +92,15 @@ if platform == 'darwin':
             self.observer = NSEvent.addGlobalMonitorForEventsMatchingMask_handler_(NSKeyDownMask, self._handler)
 
         def _poll(self):
+            if config.shutting_down():
+                return
+
             # No way of signalling to Tkinter from within the callback handler block that doesn't
             # cause Python to crash, so poll.
             if self.activated:
                 self.activated = False
                 self.root.event_generate('<<Invoke>>', when="tail")
+
             if self.keycode or self.modifiers:
                 self.root.after(HotkeyMgr.POLL, self._poll)
 
@@ -123,6 +127,9 @@ if platform == 'darwin':
             self.acquire_state = HotkeyMgr.ACQUIRE_INACTIVE
 
         def _acquire_poll(self):
+            if config.shutting_down():
+                return
+
             # No way of signalling to Tkinter from within the monkey-patched event handler that doesn't
             # cause Python to crash, so poll.
             if self.acquire_state:
@@ -316,7 +323,8 @@ elif platform == 'win32':
             while GetMessage(ctypes.byref(msg), None, 0, 0) != 0:
                 if msg.message == WM_HOTKEY:
                     if config.getint('hotkey_always') or WindowTitle(GetForegroundWindow()).startswith('Elite - Dangerous'):
-                        self.root.event_generate('<<Invoke>>', when="tail")
+                        if not config.shutting_down():
+                            self.root.event_generate('<<Invoke>>', when="tail")
                     else:
                         # Pass the key on
                         UnregisterHotKey(None, 1)

--- a/monitor.py
+++ b/monitor.py
@@ -337,7 +337,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     self.event_queue.append(line)
 
                 if self.event_queue:
-                    if not config.shutting_down():
+                    if not config.shutting_down:
                         self.root.event_generate('<<JournalEvent>>', when="tail")
 
                 log_pos = loghandle.tell()
@@ -356,7 +356,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                         '{{ "timestamp":"{}", "event":"ShutDown" }}'.format(strftime('%Y-%m-%dT%H:%M:%SZ', gmtime()))
                     )
 
-                    if not config.shutting_down():
+                    if not config.shutting_down:
                         self.root.event_generate('<<JournalEvent>>', when="tail")
 
                     self.game_was_running = False

--- a/monitor.py
+++ b/monitor.py
@@ -337,7 +337,8 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     self.event_queue.append(line)
 
                 if self.event_queue:
-                    self.root.event_generate('<<JournalEvent>>', when="tail")
+                    if not config.shutting_down():
+                        self.root.event_generate('<<JournalEvent>>', when="tail")
 
                 log_pos = loghandle.tell()
 
@@ -355,7 +356,9 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                         '{{ "timestamp":"{}", "event":"ShutDown" }}'.format(strftime('%Y-%m-%dT%H:%M:%SZ', gmtime()))
                     )
 
-                    self.root.event_generate('<<JournalEvent>>', when="tail")
+                    if not config.shutting_down():
+                        self.root.event_generate('<<JournalEvent>>', when="tail")
+
                     self.game_was_running = False
 
             else:

--- a/plug.py
+++ b/plug.py
@@ -366,9 +366,16 @@ def notify_newdata(data, is_beta):
 def show_error(err):
     """
     Display an error message in the status line of the main window.
+
+    Will be NOP during shutdown to avoid Tk hang.
     :param err:
     .. versionadded:: 2.3.7
     """
+
+    if config.shutting_down():
+        logger.info(f'Called during shutdown: "{str(err)}"')
+        return
+
     if err and last_error['root']:
         last_error['msg'] = str(err)
         last_error['root'].event_generate('<<PluginError>>', when="tail")

--- a/plug.py
+++ b/plug.py
@@ -372,7 +372,7 @@ def show_error(err):
     .. versionadded:: 2.3.7
     """
 
-    if config.shutting_down():
+    if config.shutting_down:
         logger.info(f'Called during shutdown: "{str(err)}"')
         return
 

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -599,7 +599,7 @@ def worker() -> None:
                                 # Update main window's system status
                                 this.lastlookup = r
 
-                                if not config.shutting_down():
+                                if not config.shutting_down:
                                     # calls update_status in main thread
                                     this.system_link.event_generate('<<EDSMStatus>>', when="tail")
 

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -598,8 +598,10 @@ def worker() -> None:
                             if not closing and e['event'] in ('StartUp', 'Location', 'FSDJump', 'CarrierJump'):
                                 # Update main window's system status
                                 this.lastlookup = r
-                                # calls update_status in main thread
-                                this.system_link.event_generate('<<EDSMStatus>>', when="tail")
+
+                                if not config.shutting_down():
+                                    # calls update_status in main thread
+                                    this.system_link.event_generate('<<EDSMStatus>>', when="tail")
 
                             if r['msgnum'] // 100 != 1:
                                 logger.warning(f'EDSM event with not-1xx status:\n{r["msgnum"]}\n{r["msg"]}\n'

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -1291,14 +1291,14 @@ def send_data(url: str, data: Mapping[str, Any]) -> bool:
             ):
                 this.lastlocation = reply_event.get('eventData', {})
 
-                if not config.shutting_down():
+                if not config.shutting_down:
                     # calls update_location in main thread
                     this.system_link.event_generate('<<InaraLocation>>', when="tail")
 
             elif data_event['eventName'] in ['addCommanderShip', 'setCommanderShip']:
                 this.lastship = reply_event.get('eventData', {})
 
-                if not config.shutting_down():
+                if not config.shutting_down:
                     # calls update_ship in main thread
                     this.system_link.event_generate('<<InaraShip>>', when="tail")
 

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -1290,13 +1290,17 @@ def send_data(url: str, data: Mapping[str, Any]) -> bool:
                 'setCommanderTravelLocation'
             ):
                 this.lastlocation = reply_event.get('eventData', {})
-                # calls update_location in main thread
-                this.system_link.event_generate('<<InaraLocation>>', when="tail")
+
+                if not config.shutting_down():
+                    # calls update_location in main thread
+                    this.system_link.event_generate('<<InaraLocation>>', when="tail")
 
             elif data_event['eventName'] in ['addCommanderShip', 'setCommanderShip']:
                 this.lastship = reply_event.get('eventData', {})
-                # calls update_ship in main thread
-                this.system_link.event_generate('<<InaraShip>>', when="tail")
+
+                if not config.shutting_down():
+                    # calls update_ship in main thread
+                    this.system_link.event_generate('<<InaraShip>>', when="tail")
 
     return True  # regardless of errors above, we DID manage to send it, therefore inform our caller as such
 

--- a/prefs.py
+++ b/prefs.py
@@ -1157,5 +1157,5 @@ class PreferencesDialog(tk.Toplevel):
             except Exception:
                 AXIsProcessTrustedWithOptions({kAXTrustedCheckOptionPrompt: True})
 
-            if not config.shutting_down():
+            if not config.shutting_down:
                 self.parent.event_generate('<<Quit>>', when="tail")

--- a/prefs.py
+++ b/prefs.py
@@ -1157,4 +1157,5 @@ class PreferencesDialog(tk.Toplevel):
             except Exception:
                 AXIsProcessTrustedWithOptions({kAXTrustedCheckOptionPrompt: True})
 
-            self.parent.event_generate('<<Quit>>', when="tail")
+            if not config.shutting_down():
+                self.parent.event_generate('<<Quit>>', when="tail")

--- a/protocol.py
+++ b/protocol.py
@@ -32,7 +32,9 @@ class GenericProtocolHandler(object):
 
     def event(self, url):
         self.lastpayload = url
-        self.master.event_generate('<<CompanionAuthEvent>>', when="tail")
+
+        if not config.shutting_down():
+            self.master.event_generate('<<CompanionAuthEvent>>', when="tail")
 
 
 if sys.platform == 'darwin' and getattr(sys, 'frozen', False):

--- a/protocol.py
+++ b/protocol.py
@@ -33,7 +33,7 @@ class GenericProtocolHandler(object):
     def event(self, url):
         self.lastpayload = url
 
-        if not config.shutting_down():
+        if not config.shutting_down:
             self.master.event_generate('<<CompanionAuthEvent>>', when="tail")
 
 

--- a/update.py
+++ b/update.py
@@ -40,7 +40,7 @@ class Updater(object):
         Receive (Win)Sparkle shutdown request and send it to parent.
         :rtype: None
         """
-        if not config.shutting_down():
+        if not config.shutting_down:
             self.root.event_generate('<<Quit>>', when="tail")
 
     def use_internal(self) -> bool:

--- a/update.py
+++ b/update.py
@@ -40,7 +40,8 @@ class Updater(object):
         Receive (Win)Sparkle shutdown request and send it to parent.
         :rtype: None
         """
-        self.root.event_generate('<<Quit>>', when="tail")
+        if not config.shutting_down():
+            self.root.event_generate('<<Quit>>', when="tail")
 
     def use_internal(self) -> bool:
         """


### PR DESCRIPTION
1. Adds a Config class member and helper functions to set and check for shutdown.
2. Sets this flag at the top of AppWindow.onexit().
3. Checks the flag so far only in plug.py show_error().

Still needs a further look into where else calls event_generate() and should have the check.