### PR TITLE
Fix console redirect to work with config.py now using logging.

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -133,7 +133,7 @@ if __name__ == '__main__':
 
     # Keep this as the very first code run to be as sure as possible of no
     # output until after this redirect is done, if needed.
-    if True or getattr(sys, 'frozen', False):
+    if getattr(sys, 'frozen', False):
         # By default py2exe tries to write log to dirname(sys.executable) which fails when installed
         import tempfile
 

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -16,11 +16,10 @@ from sys import platform
 from time import localtime, strftime, time
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Tuple, cast
 
+from constants import applongname, appname, protocolhandler_redirect
+
 # config will now cause an appname logger to be set up, so we need the
 # console redirect before this
-appname = 'EDMarketConnector'  # TODO: Must match config.appname, add test
-applongname = 'E:D Market Connector'  # TODO: Must match config.applongname, add test
-protocolhandler_redirect = 'edmc://auth'  # TODO: Must match protocolhandler.redirect, add test
 if __name__ == '__main__':
     def no_other_instance_running() -> bool:  # noqa: CCR001
         """
@@ -143,8 +142,8 @@ if __name__ == '__main__':
     # TODO: Test: Make *sure* this redirect is working, else py2exe is going to cause an exit popup
 
 # isort: off
-import killswitch  # noqa: E402 # Will cause a logging import/startup so needs to be after the redirect
-from config import applongname, appname, appversion, appversion_nobuild, config, copyright  # noqa: E402
+import killswitch  # Will cause a logging import/startup so needs to be after the redirect
+from config import appversion, appversion_nobuild, config, copyright
 # isort: on
 
 

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -12,12 +12,28 @@ import webbrowser
 from builtins import object, str
 from os import chdir, environ
 from os.path import dirname, isdir, join
-import killswitch
 from sys import platform
 from time import localtime, strftime, time
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Tuple, cast
 
-from config import applongname, appname, appversion, appversion_nobuild, config, copyright
+# config will now cause an appname logger to be set up, so we need the
+# console redirect before this
+appname = 'EDMarketConnector'  # TODO: Must match config.appname, add test
+if __name__ == '__main__':
+    # Keep this as the very first code run to be as sure as possible of no
+    # output until after this redirect is done, if needed.
+    if True or getattr(sys, 'frozen', False):
+        # By default py2exe tries to write log to dirname(sys.executable) which fails when installed
+        import tempfile
+
+        # unbuffered not allowed for text in python3, so use `1 for line buffering
+        sys.stdout = sys.stderr = open(join(tempfile.gettempdir(), f'{appname}.log'), mode='wt', buffering=1)
+    # TODO: Test: Make *sure* this redirect is working, else py2exe is going to cause an exit popup
+
+# isort: off
+import killswitch  # noqa: E402 # Will cause a logging import/startup so needs to be after the redirect
+from config import applongname, appname, appversion, appversion_nobuild, config, copyright  # noqa: E402
+# isort: on
 
 if __name__ == "__main__":
     def no_other_instance_running() -> bool:  # noqa: CCR001
@@ -130,15 +146,6 @@ if __name__ == "__main__":
         # reach here.
         sys.exit(0)
 
-    # Keep this as the very first code run to be as sure as possible of no
-    # output until after this redirect is done, if needed.
-    if getattr(sys, 'frozen', False):
-        # By default py2exe tries to write log to dirname(sys.executable) which fails when installed
-        import tempfile
-
-        # unbuffered not allowed for text in python3, so use `1 for line buffering
-        sys.stdout = sys.stderr = open(join(tempfile.gettempdir(), f'{appname}.log'), mode='wt', buffering=1)
-    # TODO: Test: Make *sure* this redirect is working, else py2exe is going to cause an exit popup
 
 from EDMCLogging import edmclogger, logger, logging
 

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -19,23 +19,9 @@ from typing import TYPE_CHECKING, Any, Mapping, Optional, Tuple, cast
 # config will now cause an appname logger to be set up, so we need the
 # console redirect before this
 appname = 'EDMarketConnector'  # TODO: Must match config.appname, add test
+applongname = 'E:D Market Connector'  # TODO: Must match config.applongname, add test
+protocolhandler_redirect = 'edmc://auth'  # TODO: Must match protocolhandler.redirect, add test
 if __name__ == '__main__':
-    # Keep this as the very first code run to be as sure as possible of no
-    # output until after this redirect is done, if needed.
-    if True or getattr(sys, 'frozen', False):
-        # By default py2exe tries to write log to dirname(sys.executable) which fails when installed
-        import tempfile
-
-        # unbuffered not allowed for text in python3, so use `1 for line buffering
-        sys.stdout = sys.stderr = open(join(tempfile.gettempdir(), f'{appname}.log'), mode='wt', buffering=1)
-    # TODO: Test: Make *sure* this redirect is working, else py2exe is going to cause an exit popup
-
-# isort: off
-import killswitch  # noqa: E402 # Will cause a logging import/startup so needs to be after the redirect
-from config import applongname, appname, appversion, appversion_nobuild, config, copyright  # noqa: E402
-# isort: on
-
-if __name__ == "__main__":
     def no_other_instance_running() -> bool:  # noqa: CCR001
         """
         Ensure only one copy of the app is running under this user account.
@@ -88,7 +74,7 @@ if __name__ == "__main__":
                         and window_title(window_handle) == applongname \
                         and GetProcessHandleFromHwnd(window_handle):
                     # If GetProcessHandleFromHwnd succeeds then the app is already running as this user
-                    if len(sys.argv) > 1 and sys.argv[1].startswith(protocolhandler.redirect):
+                    if len(sys.argv) > 1 and sys.argv[1].startswith(protocolhandler_redirect):
                         CoInitializeEx(0, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE)
                         # Wait for it to be responsive to avoid ShellExecute recursing
                         ShowWindow(window_handle, SW_RESTORE)
@@ -145,6 +131,21 @@ if __name__ == "__main__":
         # If the user closes the popup with the 'X', not the 'OK' button we'll
         # reach here.
         sys.exit(0)
+
+    # Keep this as the very first code run to be as sure as possible of no
+    # output until after this redirect is done, if needed.
+    if True or getattr(sys, 'frozen', False):
+        # By default py2exe tries to write log to dirname(sys.executable) which fails when installed
+        import tempfile
+
+        # unbuffered not allowed for text in python3, so use `1 for line buffering
+        sys.stdout = sys.stderr = open(join(tempfile.gettempdir(), f'{appname}.log'), mode='wt', buffering=1)
+    # TODO: Test: Make *sure* this redirect is working, else py2exe is going to cause an exit popup
+
+# isort: off
+import killswitch  # noqa: E402 # Will cause a logging import/startup so needs to be after the redirect
+from config import applongname, appname, appversion, appversion_nobuild, config, copyright  # noqa: E402
+# isort: on
 
 
 from EDMCLogging import edmclogger, logger, logging

--- a/config.py
+++ b/config.py
@@ -21,9 +21,9 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, Typ
 
 import semantic_version
 
+from constants import applongname, appname
+
 # Any of these may be imported by plugins
-appname = 'EDMarketConnector'
-applongname = 'E:D Market Connector'
 appcmdname = 'EDMC'
 # appversion **MUST** follow Semantic Versioning rules:
 # <https://semver.org/#semantic-versioning-specification-semver>

--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,14 @@
+"""
+All constants for the application.
+
+This file should contain all constants that the application uses, but that
+means migrating the existing ones, so for now it's only the ones that we've
+found necessary to move out of other files.
+"""
+
+# config.py
+appname = 'EDMarketConnector'
+applongname = 'E:D Market Connector'
+
+# protocol.py
+protocolhandler_redirect = 'edmc://auth'

--- a/protocol.py
+++ b/protocol.py
@@ -7,6 +7,7 @@ import sys
 
 from EDMCLogging import get_main_logger
 from config import config
+from constants import protocolhandler_redirect
 
 logger = get_main_logger()
 
@@ -22,7 +23,7 @@ if sys.platform == 'win32':
 class GenericProtocolHandler(object):
 
     def __init__(self):
-        self.redirect = 'edmc://auth'	# Base redirection URL
+        self.redirect = protocolhandler_redirect  # Base redirection URL
         self.master = None
         self.lastpayload = None
 


### PR DESCRIPTION
1. We were now importing from config before the console redirect code
   runs.
2. That means that config.py's `logger = logging.getLogger(appname)` caused the logger to be set up whilst stdout/err were still pointing at the console.
3. So the redirect then had no effect on logging output.

This commit moves the import from config (and also killswitch, because it also imports logging) to after the *moved* console redirect code.

NB: This needs the "detected a process already running" instance checking.

NB: There's still a `True or ` for testing purposes EDMarketConnector.py:25