### PR TITLE
Switch to using a journals folder lockfile to enforce single process

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -120,16 +120,16 @@ if __name__ == '__main__':
                 def enumwindowsproc(window_handle, l_param):
                     # class name limited to 256 - https://msdn.microsoft.com/en-us/library/windows/desktop/ms633576
                     cls = ctypes.create_unicode_buffer(257)
-                    if GetClassName(window_handle, cls, 257) \
-                            and cls.value == 'TkTopLevel' \
-                            and window_title(window_handle) == applongname \
-                            and GetProcessHandleFromHwnd(window_handle):
-                        # If GetProcessHandleFromHwnd succeeds then the app is already running as this user
-                        if len(sys.argv) > 1 and sys.argv[1].startswith(protocolhandler_redirect):
-                            CoInitializeEx(0, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE)
-                            # Wait for it to be responsive to avoid ShellExecute recursing
-                            ShowWindow(window_handle, SW_RESTORE)
-                            ShellExecute(0, None, sys.argv[1], None, None, SW_RESTORE)
+                    if GetClassName(window_handle, cls, 257):
+                        if cls.value == 'TkTopLevel':
+                            if window_title(window_handle) == applongname:
+                                if GetProcessHandleFromHwnd(window_handle):
+                                    # If GetProcessHandleFromHwnd succeeds then the app is already running as this user
+                                    if len(sys.argv) > 1 and sys.argv[1].startswith(protocolhandler_redirect):
+                                        CoInitializeEx(0, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE)
+                                        # Wait for it to be responsive to avoid ShellExecute recursing
+                                        ShowWindow(window_handle, SW_RESTORE)
+                                        ShellExecute(0, None, sys.argv[1], None, None, SW_RESTORE)
 
                 # This performs the edmc://auth check and forward
                 EnumWindows(enumwindowsproc, 0)

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -43,71 +43,11 @@ if __name__ == '__main__':
 
     def no_other_instance_running() -> bool:  # noqa: CCR001
         """
-        Ensure only one copy of the app is running under this user account.
-
-        OSX does this automatically.
+        Ensure only one copy of the app is running for the configured journal directory.
 
         :returns: True if we are the single instance, else False.
         """
-        # TODO: Linux implementation
-        if platform == 'win32':
-            import ctypes
-            from ctypes.wintypes import BOOL, HWND, INT, LPARAM, LPCWSTR, LPWSTR
-
-            EnumWindows = ctypes.windll.user32.EnumWindows  # noqa: N806
-            GetClassName = ctypes.windll.user32.GetClassNameW  # noqa: N806
-            GetClassName.argtypes = [HWND, LPWSTR, ctypes.c_int]
-            GetWindowText = ctypes.windll.user32.GetWindowTextW  # noqa: N806
-            GetWindowText.argtypes = [HWND, LPWSTR, ctypes.c_int]
-            GetWindowTextLength = ctypes.windll.user32.GetWindowTextLengthW  # noqa: N806
-            GetProcessHandleFromHwnd = ctypes.windll.oleacc.GetProcessHandleFromHwnd  # noqa: N806
-
-            SW_RESTORE = 9  # noqa: N806
-            SetForegroundWindow = ctypes.windll.user32.SetForegroundWindow  # noqa: N806
-            ShowWindow = ctypes.windll.user32.ShowWindow  # noqa: N806
-            ShowWindowAsync = ctypes.windll.user32.ShowWindowAsync  # noqa: N806
-
-            COINIT_MULTITHREADED = 0  # noqa: N806,F841
-            COINIT_APARTMENTTHREADED = 0x2  # noqa: N806
-            COINIT_DISABLE_OLE1DDE = 0x4  # noqa: N806
-            CoInitializeEx = ctypes.windll.ole32.CoInitializeEx  # noqa: N806
-
-            ShellExecute = ctypes.windll.shell32.ShellExecuteW  # noqa: N806
-            ShellExecute.argtypes = [HWND, LPCWSTR, LPCWSTR, LPCWSTR, LPCWSTR, INT]
-
-            def window_title(h):
-                if h:
-                    text_length = GetWindowTextLength(h) + 1
-                    buf = ctypes.create_unicode_buffer(text_length)
-                    if GetWindowText(h, buf, text_length):
-                        return buf.value
-
-                return None
-
-            @ctypes.WINFUNCTYPE(BOOL, HWND, LPARAM)
-            def enumwindowsproc(window_handle, l_param):
-                # class name limited to 256 - https://msdn.microsoft.com/en-us/library/windows/desktop/ms633576
-                cls = ctypes.create_unicode_buffer(257)
-                if GetClassName(window_handle, cls, 257) \
-                        and cls.value == 'TkTopLevel' \
-                        and window_title(window_handle) == applongname \
-                        and GetProcessHandleFromHwnd(window_handle):
-                    # If GetProcessHandleFromHwnd succeeds then the app is already running as this user
-                    if len(sys.argv) > 1 and sys.argv[1].startswith(protocolhandler_redirect):
-                        CoInitializeEx(0, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE)
-                        # Wait for it to be responsive to avoid ShellExecute recursing
-                        ShowWindow(window_handle, SW_RESTORE)
-                        ShellExecute(0, None, sys.argv[1], None, None, SW_RESTORE)
-
-                    else:
-                        ShowWindowAsync(window_handle, SW_RESTORE)
-                        SetForegroundWindow(window_handle)
-
-                    return False
-
-                return True
-
-            return EnumWindows(enumwindowsproc, 0)
+        journal_dir = config.get('journaldir') or config.default_journal_dir
 
         return True
 

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -41,6 +41,9 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
+if __name__ == "__main__":
+    journal_dir_lockfile = None
+
     def no_other_instance_running() -> bool:  # noqa: CCR001
         """
         Ensure only one copy of the app is running for the configured journal directory.
@@ -48,6 +51,9 @@ if __name__ == '__main__':
         :returns: True if we are the single instance, else False.
         """
         journal_dir = config.get('journaldir') or config.default_journal_dir
+
+        if sys.platform == 'win32':
+            journal_dir_lockfile = open(join(journal_dir, 'edmc-journal-lock.txt'), mode='a+', encoding='utf-8')
 
         return True
 

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -15,6 +15,7 @@ from sys import platform
 from time import localtime, strftime, time
 from typing import TYPE_CHECKING
 
+from config import appversion, appversion_nobuild, config, copyright
 from constants import applongname, appname, protocolhandler_redirect
 
 # config will now cause an appname logger to be set up, so we need the
@@ -41,7 +42,6 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-if __name__ == "__main__":
     journal_dir: str = config.get('journaldir') or config.default_journal_dir
     # This must be at top level to guarantee the file handle doesn't go out
     # of scope and get cleaned up, removing the lock with it.
@@ -69,8 +69,6 @@ if __name__ == "__main__":
                 print(f"Exception: Couldn't lock journal directory \"{journal_dir}\", assuming another process running\n{e!r}")
                 return False
 
-            journal_dir_lockfile.write(f"Path: {journal_dir}\nPID: {os_getpid()}\n")
-
         else:
             print('no_other_instance_running(): NOT win32, using fcntl')
             try:
@@ -86,7 +84,7 @@ if __name__ == "__main__":
                 print(f"Exception: Couldn't lock journal directory \"{journal_dir}\", assuming another process running\n{e!r}")
                 return False
 
-            journal_dir_lockfile.write(f"Path: {journal_dir}\nPID: {os_getpid()}\n")
+        journal_dir_lockfile.write(f"Path: {journal_dir}\nPID: {os_getpid()}\n")
 
         print('no_other_instance_running(): Done')
         return True
@@ -145,9 +143,6 @@ if __name__ == "__main__":
         sys.stdout = sys.stderr = open(join(tempfile.gettempdir(), f'{appname}.log'), mode='wt', buffering=1)
     # TODO: Test: Make *sure* this redirect is working, else py2exe is going to cause an exit popup
 
-# isort: off
-from config import appversion, appversion_nobuild, config, copyright
-# isort: on
 
 from EDMCLogging import edmclogger, logger, logging
 

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -43,6 +43,8 @@ if __name__ == '__main__':
 
 if __name__ == "__main__":
     journal_dir = config.get('journaldir') or config.default_journal_dir
+    # This must be at top level to guarantee the file handle doesn't go out
+    # of scope and get cleaned up, removing the lock with it.
     journal_dir_lockfile = open(join(journal_dir, 'edmc-journal-lock.txt'), mode='w+', encoding='utf-8')
 
     def no_other_instance_running() -> bool:  # noqa: CCR001

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -136,6 +136,10 @@ if __name__ == '__main__':  # noqa C901
                                         ShowWindow(window_handle, SW_RESTORE)
                                         ShellExecute(0, None, sys.argv[1], None, None, SW_RESTORE)
 
+                                    else:
+                                        ShowWindowAsync(window_handle, SW_RESTORE)
+                                        SetForegroundWindow(window_handle)
+
                     return True  # Do not remove, else this function as a callback breaks
 
                 # This performs the edmc://auth check and forward

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -84,7 +84,7 @@ if __name__ == '__main__':  # noqa: C901
 
             except Exception as e:
                 logger.info(f"Exception: Couldn't lock journal directory \"{journal_dir}\""
-                            f", assuming another process running\n{e!r}")
+                            f", assuming another process running: {e!r}")
                 locked = True
 
             if locked:
@@ -183,7 +183,7 @@ if __name__ == '__main__':  # noqa: C901
 
             except Exception as e:
                 logger.info(f"Exception: Couldn't lock journal directory \"{journal_dir}\","
-                            f"assuming another process running\n{e!r}")
+                            f"assuming another process running: {e!r}")
                 return False
 
         journal_dir_lockfile.write(f"Path: {journal_dir}\nPID: {os_getpid()}\n")
@@ -221,9 +221,11 @@ if __name__ == '__main__':  # noqa: C901
     try:
         journal_dir_lockfile = open(journal_dir_lockfile_name, mode='w+', encoding='utf-8')
 
+    # Linux CIFS read-only mount throws: OSError(30, 'Read-only file system')
+    # Linux no-write-perm directory throws: PermissionError(13, 'Permission denied')
     except Exception as e:  # For remote FS this could be any of a wide range of exceptions
         logger.warning(f"Couldn't open \"{journal_dir_lockfile_name}\" for \"w+\""
-                       f"Aborting checks: {e!r}")
+                       f" Aborting duplicate process checks: {e!r}")
 
     else:
         if not no_other_instance_running():
@@ -237,9 +239,9 @@ if __name__ == '__main__':  # noqa: C901
             # reach here.
             sys.exit(0)
 
-        if getattr(sys, 'frozen', False):
-            # Now that we're sure we're the only instance running we can truncate the logfile
-            sys.stdout.truncate()
+    if getattr(sys, 'frozen', False):
+        # Now that we're sure we're the only instance running we can truncate the logfile
+        sys.stdout.truncate()
 
 
 # See EDMCLogging.py docs.

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -42,7 +42,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
 if __name__ == "__main__":
-    journal_dir = config.get('journaldir') or config.default_journal_dir
+    journal_dir: str = config.get('journaldir') or config.default_journal_dir
     # This must be at top level to guarantee the file handle doesn't go out
     # of scope and get cleaned up, removing the lock with it.
     journal_dir_lockfile = open(join(journal_dir, 'edmc-journal-lock.txt'), mode='w+', encoding='utf-8')
@@ -56,8 +56,8 @@ if __name__ == "__main__":
         print('no_other_instance_running(): Begin...')
 
         if platform == 'win32':
+            print('no_other_instance_running(): win32, using msvcrt')
             # win32 doesn't have fcntl, so we have to use msvcrt
-            print('no_other_instance_running(): win32')
             import msvcrt
 
             print(f'no_other_instance_running(): journal_dir_lockfile = {journal_dir_lockfile!r}')
@@ -80,6 +80,7 @@ if __name__ == "__main__":
             journal_dir_lockfile.write(f"Path: {journal_dir}\nPID: {os_getpid()}\n")
 
         else:
+            print('no_other_instance_running(): NOT win32, using fcntl')
             try:
                 import fcntl
 
@@ -87,7 +88,7 @@ if __name__ == "__main__":
                 print("Not on win32 and we have no fcntl, can't use a file lock!  Allowing multiple instances!")
 
             try:
-                fcntl.flock(lockfile, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                fcntl.flock(journal_dir_lockfile, fcntl.LOCK_EX | fcntl.LOCK_NB)
 
             except BlockingIOError as e:
                 print(f"BlockingIOError: Couldn't lock journal directory \"{journal_dir}\", assuming another process running\n{e}")

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -34,7 +34,7 @@ if __name__ == '__main__':
 from config import appversion, appversion_nobuild, config, copyright
 from EDMCLogging import edmclogger, logger, logging
 
-if __name__ == '__main__':  # noqa C901
+if __name__ == '__main__':  # noqa: C901
     # Command-line arguments
     parser = argparse.ArgumentParser(
         prog=appname,
@@ -158,7 +158,8 @@ if __name__ == '__main__':  # noqa C901
                 fcntl.flock(journal_dir_lockfile, fcntl.LOCK_EX | fcntl.LOCK_NB)
 
             except Exception as e:
-                print(f"Exception: Couldn't lock journal directory \"{journal_dir}\", assuming another process running\n{e!r}")
+                print(f"Exception: Couldn't lock journal directory \"{journal_dir}\","
+                      f"assuming another process running\n{e!r}")
                 return False
 
         journal_dir_lockfile.write(f"Path: {journal_dir}\nPID: {os_getpid()}\n")
@@ -234,13 +235,6 @@ from tkinter import ttk
 
 from ttkHyperlinkLabel import HyperlinkLabel
 
-if __debug__:
-    if platform != 'win32':
-        import pdb
-        import signal
-
-        signal.signal(signal.SIGTERM, lambda sig, frame: pdb.Pdb().set_trace(frame))
-
 import commodity
 import companion
 import plug
@@ -279,7 +273,7 @@ class AppWindow(object):
     EVENT_BUTTON = 4
     EVENT_VIRTUAL = 35
 
-    def __init__(self, master):
+    def __init__(self, master):  # noqa: C901
 
         self.holdofftime = config.getint('querytime') + companion.holdoff
 
@@ -635,7 +629,7 @@ class AppWindow(object):
             self.status['text'] = str(e)
         self.cooldown()
 
-    def getandsend(self, event=None, retrying=False):
+    def getandsend(self, event=None, retrying=False):  # noqa: C901
 
         auto_update = not event
         play_sound = (auto_update or int(event.type) == self.EVENT_VIRTUAL) and not config.getint('hotkey_mute')
@@ -794,7 +788,7 @@ class AppWindow(object):
             pass
 
     # Handle event(s) from the journal
-    def journal_event(self, event: str):
+    def journal_event(self, event: str):  # noqa: C901
         """
         Handle a Journal event passed through event queue from monitor.py.
 
@@ -1230,7 +1224,7 @@ Locale LC_TIME: {locale.getlocale(locale.LC_TIME)}'''
 
 
 # Run the app
-if __name__ == "__main__":
+if __name__ == "__main__":  # noqa C901
     if args.trace:
         logger.setLevel(logging.TRACE)
         edmclogger.set_channels_loglevel(logging.TRACE)

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -9,7 +9,8 @@ import re
 import sys
 import webbrowser
 from builtins import object, str
-from os import chdir, environ, getpid as os_getpid
+from os import chdir, environ
+from os import getpid as os_getpid
 from os.path import dirname, isdir, join
 from sys import platform
 from time import localtime, strftime, time
@@ -233,8 +234,6 @@ import tkinter.font
 import tkinter.messagebox
 from tkinter import ttk
 
-from ttkHyperlinkLabel import HyperlinkLabel
-
 import commodity
 import companion
 import plug
@@ -248,6 +247,7 @@ from l10n import Translations
 from monitor import monitor
 from protocol import protocolhandler
 from theme import theme
+from ttkHyperlinkLabel import HyperlinkLabel
 
 SERVER_RETRY = 5  # retry pause for Companion servers [s]
 

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -65,16 +65,8 @@ if __name__ == "__main__":
             try:
                 msvcrt.locking(journal_dir_lockfile.fileno(), msvcrt.LK_NBLCK, 4096)
 
-            except PermissionError as e:
-                print(f"PermissionError: Couldn't lock journal directory \"{journal_dir}\", assuming another process running\n{e}")
-                return False
-
-            except OSError as e:
-                print(f"OSError: Couldn't lock journal directory \"{journal_dir}\", assuming another process running\n{e}")
-                return False
-
             except Exception as e:
-                print(f"other Exception: Couldn't lock journal directory \"{journal_dir}\", assuming another process running\n{e}")
+                print(f"Exception: Couldn't lock journal directory \"{journal_dir}\", assuming another process running\n{e!r}")
                 return False
 
             journal_dir_lockfile.write(f"Path: {journal_dir}\nPID: {os_getpid()}\n")

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -134,7 +134,7 @@ if __name__ == '__main__':  # noqa: C901
                     process/window.  If not we'll raise that existing window to the
                     foreground.
                     :param window_handle: Window to check.
-                    :param l_param: ???
+                    :param l_param: The second parameter to the EnumWindows() call.
                     :return: False if we found a match, else True to continue iteration
                     """
                     # class name limited to 256 - https://msdn.microsoft.com/en-us/library/windows/desktop/ms633576

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -76,22 +76,14 @@ if __name__ == "__main__":
             try:
                 import fcntl
 
-            except Exception:
+            except ImportError:
                 print("Not on win32 and we have no fcntl, can't use a file lock!  Allowing multiple instances!")
 
             try:
                 fcntl.flock(journal_dir_lockfile, fcntl.LOCK_EX | fcntl.LOCK_NB)
 
-            except BlockingIOError as e:
-                print(f"BlockingIOError: Couldn't lock journal directory \"{journal_dir}\", assuming another process running\n{e}")
-                return False
-
-            except OSError as e:
-                print(f"OSError: Couldn't lock journal directory \"{journal_dir}\", assuming another process running\n{e}")
-                return False
-
             except Exception as e:
-                print(f"other Exception: Couldn't lock journal directory \"{journal_dir}\", assuming another process running\n{e}")
+                print(f"Exception: Couldn't lock journal directory \"{journal_dir}\", assuming another process running\n{e!r}")
                 return False
 
             journal_dir_lockfile.write(f"Path: {journal_dir}\nPID: {os_getpid()}\n")

--- a/protocol.py
+++ b/protocol.py
@@ -5,7 +5,7 @@ import threading
 import urllib.request, urllib.error, urllib.parse
 import sys
 
-from config import config
+from config import appname, config
 from constants import protocolhandler_redirect
 
 


### PR DESCRIPTION
So as to actually allow `runas` this changes the win32 "Is there any window with the expected handle already?" check into a lock on a file in the `journals_dir` instead.

This also means that we can actually enforce this on all platforms.  win32 doesn't have fcntl so we use msvcrt there, but we assume (with a try/except) that all other platforms will have fcntl.  Worst case scenario they're in the same situation as before, no check at all for more than one process.

NB: This is going to be tricky when forward-ported into `develop` due to absolutely needing to use config.get() to obtain the `journals_dir`.  In `develop` that will cause logging to be set up before it should.  Might have to add something to explicitly close all logging so that setting it up again later correctly follows the stdout/err redirect.