### PR TITLE
Add `--force-localserver-for-auth` CL arg to EDMarketConnector

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -55,6 +55,11 @@ if __name__ == '__main__':  # noqa: C901
                         action='store_true'
                         )
 
+    parser.add_argument('--force-localserver-for-auth',
+                        help='Force EDMC to use a localhost webserver for Frontier Auth callback',
+                        action='store_true'
+                        )
+
     args = parser.parse_args()
 
     if args.trace:
@@ -62,6 +67,9 @@ if __name__ == '__main__':  # noqa: C901
         edmclogger.set_channels_loglevel(logging.TRACE)
     else:
         edmclogger.set_channels_loglevel(logging.DEBUG)
+
+    if args.force_localserver_for_auth:
+        config.set_auth_force_localserver()
 
     def no_other_instance_running() -> bool:  # noqa: CCR001
         """

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -242,6 +242,8 @@ if __name__ == '__main__':  # noqa: C901
 
     if getattr(sys, 'frozen', False):
         # Now that we're sure we're the only instance running we can truncate the logfile
+        logger.trace('Truncating plain logfile')
+        sys.stdout.seek(0)
         sys.stdout.truncate()
 
 

--- a/config.py
+++ b/config.py
@@ -118,6 +118,7 @@ class Config(object):
 
         def __init__(self):
             self.__in_shutdown = False  # Is the application currently shutting down ?
+            self.__auth_force_localserver = False  # Should we use localhost for auth callback ?
 
             self.app_dir = join(NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, True)[0], appname)
             if not isdir(self.app_dir):
@@ -186,10 +187,18 @@ class Config(object):
         def shutting_down(self) -> bool:
             return self.__in_shutdown
 
+        def set_auth_force_localserver(self):
+            self.__auth_force_localserver = True
+
+        @property
+        def auth_force_localserver(self) -> bool:
+            return self.__auth_force_localserver
+
     elif platform=='win32':
 
         def __init__(self):
             self.__in_shutdown = False  # Is the application currently shutting down ?
+            self.__auth_force_localserver = False  # Should we use localhost for auth callback ?
 
             self.app_dir = join(KnownFolderPath(FOLDERID_LocalAppData), appname)
             if not isdir(self.app_dir):
@@ -285,12 +294,20 @@ class Config(object):
         def shutting_down(self) -> bool:
             return self.__in_shutdown
 
+        def set_auth_force_localserver(self):
+            self.__auth_force_localserver = True
+
+        @property
+        def auth_force_localserver(self) -> bool:
+            return self.__auth_force_localserver
+
     elif platform=='linux':
 
         SECTION = 'config'
 
         def __init__(self):
             self.__in_shutdown = False  # Is the application currently shutting down ?
+            self.__auth_force_localserver = False  # Should we use localhost for auth callback ?
 
             # http://standards.freedesktop.org/basedir-spec/latest/ar01s03.html
             self.app_dir = join(getenv('XDG_DATA_HOME', expanduser('~/.local/share')), appname)
@@ -370,6 +387,13 @@ class Config(object):
         @property
         def shutting_down(self) -> bool:
             return self.__in_shutdown
+
+        def set_auth_force_localserver(self):
+            self.__auth_force_localserver = True
+
+        @property
+        def auth_force_localserver(self) -> bool:
+            return self.__auth_force_localserver
 
         def _escape(self, val):
             return str(val).replace(u'\\', u'\\\\').replace(u'\n', u'\\n').replace(u';', u'\\;')

--- a/protocol.py
+++ b/protocol.py
@@ -7,7 +7,9 @@ import sys
 
 from config import appname, config
 from constants import protocolhandler_redirect
+from EDMCLogging import get_main_logger
 
+logger = get_main_logger()
 
 if sys.platform == 'win32':
     from ctypes import *
@@ -74,7 +76,7 @@ if sys.platform == 'darwin' and getattr(sys, 'frozen', False):
             protocolhandler.master.after(ProtocolHandler.POLL, protocolhandler.poll)
 
 
-elif sys.platform == 'win32' and getattr(sys, 'frozen', False) and not is_wine:
+elif sys.platform == 'win32' and getattr(sys, 'frozen', False) and not is_wine and not config.auth_force_localserver:
 
     class WNDCLASS(Structure):
         _fields_ = [('style', UINT),
@@ -217,6 +219,7 @@ else:	# Linux / Run from source
             GenericProtocolHandler.__init__(self)
             self.httpd = HTTPServer(('localhost', 0), HTTPRequestHandler)
             self.redirect = 'http://localhost:%d/auth' % self.httpd.server_port
+            logger.trace(f'Web server listening on {self.redirect}')
             self.thread = None
 
         def start(self, master):


### PR DESCRIPTION
This then gets checked in protocol.py to force using the localhost webserver instead of edmc://auth handler.

Will address #856 