### PR TITLE
Add Steam and EGS to Frontier Auth audiences.

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -662,17 +662,25 @@ class AppWindow(object):
             config.set('querytime', querytime)
 
             # Validation
-            if not data.get('commander', {}).get('name'):
+            if 'commander' not in data:
+                # This can happen with EGS Auth if no commander created yet
+                self.status['text'] = _('CAPI: No commander data returned')
+
+            elif not data.get('commander', {}).get('name'):
                 self.status['text'] = _("Who are you?!")  # Shouldn't happen
+
             elif (not data.get('lastSystem', {}).get('name')
                   or (data['commander'].get('docked')
                       and not data.get('lastStarport', {}).get('name'))):  # Only care if docked
                 self.status['text'] = _("Where are you?!")  # Shouldn't happen
+
             elif not data.get('ship', {}).get('name') or not data.get('ship', {}).get('modules'):
                 self.status['text'] = _("What are you flying?!")  # Shouldn't happen
+
             elif monitor.cmdr and data['commander']['name'] != monitor.cmdr:
                 # Companion API return doesn't match Journal
                 raise companion.CmdrError()
+
             elif ((auto_update and not data['commander'].get('docked'))
                   or (data['lastSystem']['name'] != monitor.system)
                   or ((data['commander']['docked']

--- a/L10n/en.template
+++ b/L10n/en.template
@@ -46,6 +46,9 @@
 /* Folder selection button on Windows. [prefs.py] */
 "Browse..." = "Browse...";
 
+/* No 'commander' data in CAPI [EDMarketConnector.py] */
+"CAPI: No commander data returned" = "CAPI: No commander data returned";
+
 /* Federation rank. [stats.py] */
 "Cadet" = "Cadet";
 

--- a/companion.py
+++ b/companion.py
@@ -532,6 +532,10 @@ class Session(object):
     def station(self) -> CAPIData:
         """Perform CAPI /profile endpoint query for station data."""
         data = self.query(URL_QUERY)
+        if 'commander' not in data:
+            logger.error('No commander in returned data')
+            return data
+
         if not data['commander'].get('docked'):
             return data
 

--- a/companion.py
+++ b/companion.py
@@ -277,7 +277,7 @@ class Auth(object):
         logger.info(f'Trying auth from scratch for Commander "{self.cmdr}"')
         challenge = self.base64_url_encode(hashlib.sha256(self.verifier).digest())
         webbrowser.open(
-            f'{SERVER_AUTH}{URL_AUTH}?response_type=code&audience=frontier&scope=capi&client_id={CLIENT_ID}&code_challenge={challenge}&code_challenge_method=S256&state={self.state}&redirect_uri={protocolhandler.redirect}'  # noqa: E501 # I cant make this any shorter
+            f'{SERVER_AUTH}{URL_AUTH}?response_type=code&audience=frontier,steam,epic&scope=capi&client_id={CLIENT_ID}&code_challenge={challenge}&code_challenge_method=S256&state={self.state}&redirect_uri={protocolhandler.redirect}'  # noqa: E501 # I cant make this any shorter
         )
 
         return None

--- a/companion.py
+++ b/companion.py
@@ -527,7 +527,11 @@ class Session(object):
 
     def profile(self) -> CAPIData:
         """Perform general CAPI /profile endpoint query."""
-        return self.query(URL_QUERY)
+        data = self.query(URL_QUERY)
+        if 'commander' not in data:
+            logger.error('No commander in returned data')
+
+        return data
 
     def station(self) -> CAPIData:
         """Perform CAPI /profile endpoint query for station data."""


### PR DESCRIPTION
There's no reason to not allow Steam and EGS commanders to auth via the relevant store account, instead of needing to use the associated Frontier login credentials.