### PR TITLE
Move us to Python 3.9

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8.6"
+          python-version: "3.9.2"
           architecture: "x86"
 
       - name: Install python tools

--- a/EDMarketConnector.wxs
+++ b/EDMarketConnector.wxs
@@ -198,7 +198,7 @@
 						<File KeyPath="yes" Source="SourceDir\pyexpat.pyd" />
 					</Component>
 					<Component Guid="*">
-						<File KeyPath="yes" Source="SourceDir\python38.dll" />
+						<File KeyPath="yes" Source="SourceDir\python39.dll" />
 					</Component>
 					<Component Guid="*">
 						<File KeyPath="yes" Source="SourceDir\rare_commodity.csv" />
@@ -596,7 +596,7 @@
 			<ComponentRef Id="pt_BR.strings" />
 			<ComponentRef Id="pt_PT.strings" />
 			<ComponentRef Id="pyexpat.pyd" />
-			<ComponentRef Id="python38.dll" />
+			<ComponentRef Id="python39.dll" />
 			<ComponentRef Id="rare_commodity.csv" />
 			<ComponentRef Id="ru.strings" />
 			<ComponentRef Id="select.pyd" />

--- a/monitor.py
+++ b/monitor.py
@@ -1068,7 +1068,7 @@ class JournalLock:
 
     def __init__(self):
         """Initialise where the journal directory and lock file are."""
-        self.journal_dir: str = config.get('journaldir') or config.default_journal_dir
+        self.journal_dir: str = config.get_str('journaldir') or config.default_journal_dir
         self.journal_dir_path = pathlib.Path(self.journal_dir)
         self.journal_dir_lockfile_name = None
         self.journal_dir_lockfile = None
@@ -1228,7 +1228,7 @@ class JournalLock:
 
     def update_lock(self, parent: tk.Tk):
         """Update journal directory lock to new location if possible."""
-        current_journaldir = config.get('journaldir') or config.default_journal_dir
+        current_journaldir = config.get_str('journaldir') or config.default_journal_dir
 
         if current_journaldir == self.journal_dir:
             return  # Still the same
@@ -1247,7 +1247,7 @@ class JournalLock:
         if not retry:
             return
 
-        current_journaldir = config.get('journaldir') or config.default_journal_dir
+        current_journaldir = config.get_str('journaldir') or config.default_journal_dir
         self.journal_dir = current_journaldir
         self.journal_dir_path = pathlib.Path(self.journal_dir)
         if not self.obtain_lock():

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ import semantic_version
 
 from config import appcmdname, applongname, appname, appversion, copyright, update_feed, update_interval
 
-if sys.version_info[0:2] != (3, 8):
+if sys.version_info[0:2] != (3, 9):
     raise AssertionError(f'Unexpected python version {sys.version}')
 
 if sys.platform == 'win32':


### PR DESCRIPTION
Also contains a config.get() -> config.get_str() change for the new references of journaldir in monitor.py that I'd just forward ported.