### PR TITLE
Add support for NavRoute event and file contents.

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -462,6 +462,22 @@ Examples of this are:
     *NB: There is no indication available when a player cancels a route.*  The
     game itself does not provide any such, not in a Journal event, not in a
    `Status.json` flag.
+   
+    The Journal documentation v28 is incorrect about the event
+    and file being `Route(.json)` the word is `NavRoute`.  Also the format of
+    the data is, e.g.
+   
+    ```json
+   { "timestamp":"2021-03-10T11:31:37Z",
+      "event":"NavRoute",
+      "Route": [
+         { "StarSystem": "Esuvit", "SystemAddress": 2869709317505, "StarPos": [-13.18750,-1.15625,-92.68750], "StarClass": "M" },
+         { "StarSystem": "Ndozins", "SystemAddress": 3446451210595, "StarPos": [-14.31250,-10.68750,-60.56250], "StarClass": "M" },
+         { "StarSystem": "Tascheter Sector MN-T b3-6", "SystemAddress": 13864825529753, "StarPos": [-11.87500,-21.96875,-29.03125], "StarClass": "M" },
+         { "StarSystem": "LP 823-4", "SystemAddress": 9466778953129, "StarPos": [-8.62500,-27.84375,3.93750], "StarClass": "M" }
+      ]
+   }
+    ```
 
 #### Player Dashboard
 

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -426,7 +426,9 @@ Content of `state` (updated to the current journal entry):
 | `ModulesValue` |            `int`            | Value of the current ship's modules                                                                             |
 | `Rebuy`        |            `int`            | Current ship's rebuy cost                                                                                       |
 | `Modules`      |           `dict`            | Currently fitted modules                                                                                        |
-| `Route`        |           `dict`            | Last plotted multi-hop route                                                                                    |
+| `NavRoute`     |           `dict`            | Last plotted multi-hop route                                                                                    |
+
+##### Synthetic Events
 
 A special "StartUp" entry is sent if EDMC is started while the game is already
 running. In this case you won't receive initial events such as "LoadGame",
@@ -444,6 +446,22 @@ between the two scenarios.
 
 This event is not sent when EDMC is running on a different
 machine so you should not *rely* on receiving this event.
+
+##### Augmented Events
+
+In some cases we augment the events, as seen in the Journal, with extra data.
+Examples of this are:
+
+1. Every `Cargo` event passed to plugins contains the data from
+   `Cargo.json` (but see above for caveats).
+
+1. Every `NavRoute` event contains the full `Route` array as loaded from
+    `NavRoute.json`.  You do not need to access this via
+   `monitor.state['NavRoute']`, although it is available there.
+   
+    *NB: There is no indication available when a player cancels a route.*  The
+    game itself does not provide any such, not in a Journal event, not in a
+   `Status.json` flag.
 
 #### Player Dashboard
 
@@ -473,8 +491,8 @@ It contains more information about the cargo contents, such as the mission ID fo
 
 New in version 5.0.0:
 
-`Route` contains the `json.load()` of `Route.json` as indicated by a journal
-`Route` event.
+`NavRoute` contains the `json.load()` of `NavRoute.json` as indicated by a journal
+`NavRoute` event.
 
 #### Getting Commander Data
 

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -426,6 +426,7 @@ Content of `state` (updated to the current journal entry):
 | `ModulesValue` |            `int`            | Value of the current ship's modules                                                                             |
 | `Rebuy`        |            `int`            | Current ship's rebuy cost                                                                                       |
 | `Modules`      |           `dict`            | Currently fitted modules                                                                                        |
+| `Route`        |           `dict`            | Last plotted multi-hop route                                                                                    |
 
 A special "StartUp" entry is sent if EDMC is started while the game is already
 running. In this case you won't receive initial events such as "LoadGame",
@@ -469,6 +470,11 @@ New in version 4.1.6:
 
 `CargoJSON` contains the raw data from the last read of `cargo.json` passed through json.load.
 It contains more information about the cargo contents, such as the mission ID for mission specific cargo
+
+New in version 5.0.0:
+
+`Route` contains the `json.load()` of `Route.json` as indicated by a journal
+`Route` event.
 
 #### Getting Commander Data
 

--- a/monitor.py
+++ b/monitor.py
@@ -126,7 +126,8 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             'ModulesValue': None,
             'Rebuy':        None,
             'Modules':      None,
-            'CargoJSON':   None,  # The raw data from the last time cargo.json was read
+            'CargoJSON':    None,  # The raw data from the last time cargo.json was read
+            'Route':        None,  # Last plotted route from Route.json file
         }
 
     def start(self, root: 'tkinter.Tk'):
@@ -458,6 +459,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     'ModulesValue': None,
                     'Rebuy':        None,
                     'Modules':      None,
+                    'Route':        None,
                 }
 
             elif event_type == 'Commander':
@@ -664,6 +666,12 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 clean = self.coalesce_cargo(entry['Inventory'])
 
                 self.state['Cargo'].update({self.canonicalise(x['Name']): x['Count'] for x in clean})
+
+            elif event_type == 'Route':
+                # Added in ED 3.7 - multi-hop route details in Route.json
+                with open(join(self.currentdir, 'Route.json'), 'rb') as rf:  # type: ignore
+                    entry = json.load(rf)
+                    self.state['Route'] = entry
 
             elif event_type in ('CollectCargo', 'MarketBuy', 'BuyDrones', 'MiningRefined'):
                 commodity = self.canonicalise(entry['Type'])

--- a/monitor.py
+++ b/monitor.py
@@ -667,9 +667,9 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
                 self.state['Cargo'].update({self.canonicalise(x['Name']): x['Count'] for x in clean})
 
-            elif event_type == 'Route':
+            elif event_type == 'NavRoute':
                 # Added in ED 3.7 - multi-hop route details in Route.json
-                with open(join(self.currentdir, 'Route.json'), 'rb') as rf:  # type: ignore
+                with open(join(self.currentdir, 'NavRoute.json'), 'rb') as rf:  # type: ignore
                     entry = json.load(rf)
                     self.state['Route'] = entry
 

--- a/monitor.py
+++ b/monitor.py
@@ -674,7 +674,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                         entry = json.load(rf)
 
                     except json.JSONDecodeError:
-                        logger.exception('Failed decoding NavRoute.json')
+                        logger.exception('Failed decoding NavRoute.json', exc_info=True)
 
                     else:
                         self.state['NavRoute'] = entry

--- a/monitor.py
+++ b/monitor.py
@@ -670,8 +670,14 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             elif event_type == 'NavRoute':
                 # Added in ED 3.7 - multi-hop route details in NavRoute.json
                 with open(join(self.currentdir, 'NavRoute.json'), 'rb') as rf:  # type: ignore
-                    entry = json.load(rf)
-                    self.state['NavRoute'] = entry
+                    try:
+                        entry = json.load(rf)
+
+                    except json.JSONDecodeError:
+                        logger.exception('Failed decoding NavRoute.json')
+
+                    else:
+                        self.state['NavRoute'] = entry
 
             elif event_type in ('CollectCargo', 'MarketBuy', 'BuyDrones', 'MiningRefined'):
                 commodity = self.canonicalise(entry['Type'])

--- a/monitor.py
+++ b/monitor.py
@@ -668,10 +668,10 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.state['Cargo'].update({self.canonicalise(x['Name']): x['Count'] for x in clean})
 
             elif event_type == 'NavRoute':
-                # Added in ED 3.7 - multi-hop route details in Route.json
+                # Added in ED 3.7 - multi-hop route details in NavRoute.json
                 with open(join(self.currentdir, 'NavRoute.json'), 'rb') as rf:  # type: ignore
                     entry = json.load(rf)
-                    self.state['Route'] = entry
+                    self.state['NavRoute'] = entry
 
             elif event_type in ('CollectCargo', 'MarketBuy', 'BuyDrones', 'MiningRefined'):
                 commodity = self.canonicalise(entry['Type'])


### PR DESCRIPTION
Journal doc v28 is incorrect about the word for the event and file being `Route`, it is `NavRoute` (tested in-game).

We augment the `NavRoute` event with the data from the file, so plugins can just look at the event rather than needing to check monitor.state[`NavRoute`], although the data is also there for later reference.

There is **no indication** if the player clears a route (not in journal or a Status.json flag).

The format of the `Route` array data is also different from the v28 doc.