### PR TITLE
Get MacOS working as well as we can.

### DIFF
--- a/config.py
+++ b/config.py
@@ -581,6 +581,12 @@ class MacConfig(AbstractConfig):
 
     def __raw_get(self, key: str) -> Union[None, list, str, int]:
         res = self._settings.get(key)
+        # On MacOS Catalina, with python.org python 3.9.2 any 'list'
+        # has type __NSCFArray so a simple `isinstance(res, list)` is
+        # False.  So, check it's not-None, and not the other types.
+        #
+        # If we can find where to import the definition of NSCFArray
+        # then we could possibly test against that.
         if res and not isinstance(res, str) and not isinstance(res, int):
             return list(res)
 

--- a/config.py
+++ b/config.py
@@ -587,7 +587,7 @@ class MacConfig(AbstractConfig):
         #
         # If we can find where to import the definition of NSCFArray
         # then we could possibly test against that.
-        if res and not isinstance(res, str) and not isinstance(res, int):
+        if res is not None and not isinstance(res, str) and not isinstance(res, int):
             return list(res)
 
         return res

--- a/config.py
+++ b/config.py
@@ -581,7 +581,7 @@ class MacConfig(AbstractConfig):
 
     def __raw_get(self, key: str) -> Union[None, list, str, int]:
         res = self._settings.get(key)
-        if isinstance(res, list):
+        if res and not isinstance(res, str) and not isinstance(res, int):
             return list(res)
 
         return res

--- a/config.py
+++ b/config.py
@@ -670,7 +670,12 @@ class MacConfig(AbstractConfig):
 
         :param key: the key to delete
         """
-        del self._settings[key]
+        try:
+            del self._settings[key]
+
+        except Exception:
+            if suppress:
+                pass
 
     def save(self) -> None:
         """Save the configuration."""

--- a/journal_lock.py
+++ b/journal_lock.py
@@ -37,6 +37,7 @@ class JournalLock:
         self.journal_dir_lockfile_name: Optional[pathlib.Path] = None
         # We never test truthiness of this, so let it be defined when first assigned.  Avoids type hint issues.
         # self.journal_dir_lockfile: Optional[IO] = None
+        self.locked = False
 
     def obtain_lock(self) -> JournalLockResult:
         """
@@ -91,6 +92,8 @@ class JournalLock:
         self.journal_dir_lockfile.flush()
 
         logger.trace('Done')
+        self.locked = True
+
         return JournalLockResult.LOCKED
 
     def release_lock(self) -> bool:
@@ -99,6 +102,9 @@ class JournalLock:
 
         :return: bool - Success of unlocking operation.
         """
+        if not self.locked:
+            return True  # We weren't locked, and still aren't
+
         unlocked = False
         if platform == 'win32':
             logger.trace('win32, using msvcrt')

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ watchdog==2.0.2
 # argh==0.26.2 watchdog dep
 # pyyaml==5.3.1 watchdog dep
 semantic-version==2.8.5
+
+# Base requirement for MacOS
+pyobjc; sys_platform == 'darwin'


### PR DESCRIPTION
1. pyobjc in requirements.txt
2. Bug with `darwin` config.delete() not respecting `suppress` argument fixed.
3. Only actually JournalLock.release_lock() if we actually hold a lock.  Enables changing Journals location from non-existent to another without a fatal exception.

There's still an issue with the whole hotkey code not working because the application needs a MacOS permission to generally monitor keyboard input.  The old way to grant this has changed in Catalina.  There's "Input Monitoring" but I can't find any way to add an arbitrary app to it.  We might need to find how to get the EDMC code to explicitly make the request so that the user can grant it.

And even then I'm not sure the current way of doing hotkeys on `darwin` is the recommended way on Catalina.  It's going to take a lot of study of the code to discern what is just the tk input monitoring and what is specifici MacOS calls.