### PR TITLE
plugins/eddn: Add paranoia about data in is_horizons()

### DIFF
--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -796,11 +796,23 @@ def is_horizons(economies: MAP_STR_ANY, modules: MAP_STR_ANY, ships: MAP_STR_ANY
     if isinstance(dict, economies):
         economies_colony = any(economy['name'] == 'Colony' for economy in economies.values())
 
+    else:
+        logger.error(f'economies type is {type(economies)}')
+
     if isinstance(dict, modules):
         modules_horizons = any(module.get('sku') == HORIZ_SKU for module in modules.values())
+
+    else:
+        logger.error(f'modules type is {type(modules)}')
 
     if isinstance(dict, ships):
         if ships.get('shipyard_list') is not None:
             ship_horizons = any(ship.get('sku') == HORIZ_SKU for ship in ships['shipyard_list'].values())
+
+        else:
+            logger.debug('No ships["shipyard_list"] - Damaged station or FC ?')
+
+    else:
+        logger.error(f'ships type is {type(ships)}')
 
     return economies_colony or modules_horizons or ship_horizons

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -789,8 +789,18 @@ MAP_STR_ANY = Mapping[str, Any]
 
 
 def is_horizons(economies: MAP_STR_ANY, modules: MAP_STR_ANY, ships: MAP_STR_ANY) -> bool:
-    return (
-        any(economy['name'] == 'Colony' for economy in economies.values()) or
-        any(module.get('sku') == HORIZ_SKU for module in modules.values()) or
-        any(ship.get('sku') == HORIZ_SKU for ship in (ships['shipyard_list'] or {}).values())
-    )
+    economies_colony = False
+    modules_horizons = False
+    ship_horizons = False
+
+    if isinstance(dict, economies):
+        economies_colony = any(economy['name'] == 'Colony' for economy in economies.values())
+
+    if isinstance(dict, modules):
+        modules_horizons = any(module.get('sku') == HORIZ_SKU for module in modules.values())
+
+    if isinstance(dict, ships):
+        if ships.get('shipyard_list') is not None:
+            ship_horizons = any(ship.get('sku') == HORIZ_SKU for ship in ships['shipyard_list'].values())
+
+    return economies_colony or modules_horizons or ship_horizons


### PR DESCRIPTION
A damaged station has `"modules": []`, so trips over modules.values().

Being paranoid about the other data in there as well.