### PR TITLE
Allow 'edmc' argument to .exe to work (and add Korean language)

### DIFF
--- a/EDMarketConnector - localserver-auth.bat
+++ b/EDMarketConnector - localserver-auth.bat
@@ -1,0 +1,1 @@
+EDMarketConnector.exe --force-localserver-for-auth

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -60,6 +60,11 @@ if __name__ == '__main__':  # noqa: C901
                         action='store_true'
                         )
 
+    parser.add_argument('edmc',
+                        help='Callback from Frontier Auth',
+                        nargs='*'
+                        )
+
     args = parser.parse_args()
 
     if args.trace:

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -199,7 +199,8 @@ if __name__ == '__main__':  # noqa: C901
         logger.info("An EDMarketConnector.exe process was already running, exiting.")
 
         # To be sure the user knows, we need a popup
-        already_running_popup()
+        if not args.edmc:
+            already_running_popup()
         # If the user closes the popup with the 'X', not the 'OK' button we'll
         # reach here.
         sys.exit(0)

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -142,6 +142,7 @@ if __name__ == '__main__':  # noqa: C901
                                 if GetProcessHandleFromHwnd(window_handle):
                                     # If GetProcessHandleFromHwnd succeeds then the app is already running as this user
                                     if len(sys.argv) > 1 and sys.argv[1].startswith(protocolhandler_redirect):
+                                        logger.debug('Invoked with edmc:// protocol handler arg')
                                         CoInitializeEx(0, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE)
                                         # Wait for it to be responsive to avoid ShellExecute recursing
                                         ShowWindow(window_handle, SW_RESTORE)

--- a/EDMarketConnector.wxs
+++ b/EDMarketConnector.wxs
@@ -18,8 +18,8 @@
 				 Description="$(var.PRODUCTLONGNAME) installer"
 				 InstallerVersion="300" Compressed="yes"
 				 Platform="x86"
-				 Languages="1033,1029,1031,1034,1035,1036,1038,1040,1041,1043,1045,1046,1049,1058,1062,2052,2070,2074,6170,1060,1053,0" />
-				 <!--        en   cs,  de   es   fi   fr   hu   it   ja   nl   pl  pt-BR ru   uk  lv zh-CN pt-PT sr-Latn sr-Latn-BA sl sv-SE neutral -->
+				 Languages="1033,1029,1031,1034,1035,1036,1038,1040,1041,1043,1045,1046,1049,1058,1062,2052,2070,2074,6170,1060,1053,18,0" />
+				 <!--        en   cs,  de   es   fi   fr   hu   it   ja   nl   pl  pt-BR ru   uk  lv zh-CN pt-PT sr-Latn sr-Latn-BA sl sv-SE ko neutral -->
 				 <!-- https://msdn.microsoft.com/en-gb/goglobal/bb964664.aspx -->
 
 		<!-- Always reinstall since patching is problematic -->
@@ -248,6 +248,9 @@
 						</Component>
 						<Component Guid="*">
 							<File KeyPath="yes" Source="SourceDir\L10n\ja.strings" />
+						</Component>
+						<Component Guid="*">
+							<File KeyPath="yes" Source="SourceDir\L10n\ko.strings" />
 						</Component>
 						<Component Guid="*">
 							<File KeyPath="yes" Source="SourceDir\L10n\lv.strings" />
@@ -565,6 +568,7 @@
 			<ComponentRef Id="libcrypto_1_1.dll" />
 			<ComponentRef Id="library.zip" />
 			<ComponentRef Id="libssl_1_1.dll" />
+			<ComponentRef Id="ko.strings" />
 			<ComponentRef Id="lv.strings" />
 			<ComponentRef Id="modules.p" />
 			<ComponentRef Id="nl.strings" />

--- a/EDMarketConnector.wxs
+++ b/EDMarketConnector.wxs
@@ -224,6 +224,9 @@
 					<Component Id="EDMarketConnector_TRACE.bat" Guid="*">
 					    <File KeyPath="yes" Source="SourceDir\EDMarketConnector - TRACE.bat" />
 					</Component>
+					<Component Id="EDMarketConnector_localserver_auth.bat" Guid="*">
+					    <File KeyPath="yes" Source="SourceDir\EDMarketConnector - localserver-auth.bat" />
+					</Component>
 					<Directory Id="L10n" Name="L10n">
 						<Component Guid="*">
 							<File KeyPath="yes" Source="SourceDir\L10n\cs.strings" />
@@ -597,6 +600,7 @@
 			<ComponentRef Id="winsound.pyd" />
 			<ComponentRef Id="WinSparkle.dll" />
 			<ComponentRef Id="EDMarketConnector_TRACE.bat" />
+			<ComponentRef Id="EDMarketConnector_localserver_auth.bat" />
 			<ComponentRef Id="zh_CN.strings" />
 			<ComponentRef Id="auto.tcl" />
 			<ComponentRef Id="clock.tcl" />

--- a/L10n/ko.strings
+++ b/L10n/ko.strings
@@ -1,0 +1,554 @@
+/* Label for 'UI Scaling' option [prefs.py] */
+"UI Scale Percentage" = "UI 스케일 백분율";
+
+/* Text describing that value '100' means 'default', and changes require a restart [prefs.py] */
+"100 means Default{CR}Restart Required for{CR}changes to take effect!" = "100은 '기본 설정'을 의미하며{CR}변경사항 적용을 위해{CR}재시작이 요구됩니다!";
+
+/* Language name */
+"!Language" = "영어";
+
+/* App menu entry on OSX. [EDMarketConnector.py] */
+"About {APP}" = "{APP} 정보";
+
+/* Federation rank. [stats.py] */
+"Admiral" = "Admiral";
+
+/* Explorer rank. [stats.py] */
+"Aimless" = "Aimless";
+
+/* Appearance setting. [EDMarketConnector.py] */
+"Always on top" = "항상 위에 보이기";
+
+/* CQC rank. [stats.py] */
+"Amateur" = "Amateur";
+
+/* EDSM setting. [edsm.py] */
+"API Key" = "API 키";
+
+/* Tab heading in settings. [prefs.py] */
+"Appearance" = "스타일";
+
+/* Successfully authenticated with the Frontier website. [EDMarketConnector.py] */
+"Authentication successful" = "인증 성공";
+
+/* Output setting. [prefs.py] */
+"Automatically update on docking" = "도킹시 자동으로 서버에 정보 업데이트하기";
+
+/* Cmdr stats. [stats.py] */
+"Balance" = "잔고";
+
+/* Empire rank. [stats.py] */
+"Baron" = "Baron";
+
+/* Trade rank. [stats.py] */
+"Broker" = "Broker";
+
+/* Folder selection button on Windows. [prefs.py] */
+"Browse..." = "찾아보기...";
+
+/* No 'commander' data in CAPI [EDMarketConnector.py] */
+"CAPI: No commander data returned" = "CAPI: 커맨더 정보가 반환되지 않음";
+
+/* Federation rank. [stats.py] */
+"Cadet" = "Cadet";
+
+/* CQC rank. [stats.py] */
+"Champion" = "Champion";
+
+/* Folder selection button on OSX. [prefs.py] */
+"Change..." = "바꾸기...";
+
+/* Menu item. [EDMarketConnector.py] */
+"Check for Updates..." = "업데이트 확인하기...";
+
+/* Federation rank. [stats.py] */
+"Chief Petty Officer" = "Chief Petty Officer";
+
+/* Main window. [EDMarketConnector.py] */
+"Cmdr" = "커맨더";
+
+/* Ranking. [stats.py] */
+"Combat" = "Combat";
+
+/* EDSM setting. [edsm.py] */
+"Commander Name" = "커맨더 이름";
+
+/* Combat rank. [stats.py] */
+"Competent" = "Competent";
+
+/* Tab heading in settings. [prefs.py] */
+"Configuration" = "환경 설정";
+
+/* Update button in main window. [EDMarketConnector.py] */
+"cooldown {SS}s" = "쿨다운 {SS}s";
+
+/* As in Copy and Paste. [EDMarketConnector.py] */
+"Copy" = "복사";
+
+/* Empire rank. [stats.py] */
+"Count" = "Count";
+
+/* Ranking. [stats.py] */
+"CQC" = "CQC";
+
+/* Combat rank. [stats.py] */
+"Dangerous" = "Dangerous";
+
+/* Appearance theme setting. [prefs.py] */
+"Dark" = "어둡게";
+
+/* Combat rank. [stats.py] */
+"Deadly" = "Deadly";
+
+/* Trade rank. [stats.py] */
+"Dealer" = "Dealer";
+
+/* Appearance theme and language setting. [l10n.py] */
+"Default" = "기본값";
+
+/* Output setting under 'Send system and scan data to the Elite Dangerous Data Network' new in E:D 2.2. [eddn.py] */
+"Delay sending until docked" = "도킹시까지 서버에 정보 전송을 미루기";
+
+/* Option to disabled Automatic Check For Updates whilst in-game [prefs.py] */
+"Disable Automatic Application Updates Check when in-game" = "게임이 실행중일 때 프로그램 업데이트 확인하지 않기";
+
+/* List of plugins in settings. [prefs.py] */
+"Disabled Plugins" = "비활성 플러그인";
+
+/* Help menu item. [EDMarketConnector.py] */
+"Documentation" = "문서 자료";
+
+/* Empire rank. [stats.py] */
+"Duke" = "Duke";
+
+/* Location of the new Journal file in E:D 2.2. [EDMarketConnector.py] */
+"E:D journal file location" = "E:D 저널(journal) 파일 위치";
+
+/* Empire rank. [stats.py] */
+"Earl" = "Earl";
+
+/* Menu title. [EDMarketConnector.py] */
+"Edit" = "편집";
+
+/* Top rank. [stats.py] */
+"Elite" = "Elite";
+
+/* Section heading in settings. [edsm.py] */
+"Elite Dangerous Star Map credentials" = "Elite Dangerous Star Map 계정";
+
+/* Ranking. [stats.py] */
+"Empire" = "Empire";
+
+/* List of plugins in settings. [prefs.py] */
+"Enabled Plugins" = "활성 플러그인";
+
+/* Federation rank. [stats.py] */
+"Ensign" = "Ensign";
+
+/* Trade rank. [stats.py] */
+"Entrepreneur" = "Entrepreneur";
+
+/* [eddn.py] */
+"Error: Can't connect to EDDN" = "오류: EDDN에 연결할 수 없음";
+
+/* [edsm.py] */
+"Error: Can't connect to EDSM" = "오류: EDSM에 연결할 수 없음";
+
+/* [inara.py] */
+"Error: Can't connect to Inara" = "오류: Inara에 연결할 수 없음";
+
+/* [edsm.py] */
+"Error: EDSM {MSG}" = "오류: EDSM {MSG}";
+
+/* Raised when cannot contact the Companion API server. [companion.py] */
+"Error: Frontier server is down" = "오류: Frontier 서버 CAPI 연결 불가";
+
+/* Raised when Companion API server is returning old data, e.g. when the servers are too busy. [companion.py] */
+"Error: Frontier server is lagging" = "오류: Frontier 서버 응답이 지연되고 있음";
+
+/* Raised when the Companion API server thinks that the user has not purchased E:D. i.e. doesn't have the correct 'SKU'. [companion.py] */
+"Error: Frontier server SKU problem" = "오류: Frontier 서버 SKU 문제 발생";
+
+/* [inara.py] */
+"Error: Inara {MSG}" = "오류: Inara {MSG}";
+
+/* [companion.py] */
+"Error: Invalid Credentials" = "오류: 잘못된 자격 증명";
+
+/* Raised when the user has multiple accounts and the username/password setting is not for the account they're currently playing OR the user has reset their Cmdr and the Companion API server is still returning data for the old Cmdr. [companion.py] */
+"Error: Wrong Cmdr" = "오류: 잘못된 Cmdr";
+
+/* Item in the File menu on Windows. [EDMarketConnector.py] */
+"Exit" = "종료";
+
+/* Combat rank. [stats.py] */
+"Expert" = "Expert";
+
+/* Ranking. [stats.py] */
+"Explorer" = "Explorer";
+
+/* Ranking. [stats.py] */
+"Federation" = "Federation";
+
+/* [EDMarketConnector.py] */
+"Fetching data..." = "데이터 가져오는 중...";
+
+/* Multicrew role. [EDMarketConnector.py] */
+"Fighter" = "Fighter";
+
+/* Menu title. [EDMarketConnector.py] */
+"File" = "파일";
+
+/* Section heading in settings. [prefs.py] */
+"File location" = "파일 위치";
+
+/* CQC rank. [stats.py] */
+"Gladiator" = "Gladiator";
+
+/* Multicrew role. [EDMarketConnector.py] */
+"Gunner" = "Gunner";
+
+/* Combat rank. [stats.py] */
+"Harmless" = "Harmless";
+
+/* Multicrew role. [EDMarketConnector.py] */
+"Helm" = "Helm";
+
+/* Menu title. [EDMarketConnector.py] */
+"Help" = "도움말";
+
+/* CQC rank. [stats.py] */
+"Helpless" = "Helpless";
+
+/* CQC rank. [stats.py] */
+"Hero" = "Hero";
+
+/* Dark theme color setting. [prefs.py] */
+"Highlighted text" = "강조된 텍스트";
+
+/* Hotkey/Shortcut settings prompt on Windows. [prefs.py] */
+"Hotkey" = "단축키";
+
+/* Changed journal update_lock failed [monitor.py] */
+"Ignore" = "무시하기";
+
+/* Section heading in settings. [inara.py] */
+"Inara credentials" = "Inara 계정 정보";
+
+/* Changed journal update_lock failed [monitor.py] */
+"Journal directory already locked" = "저널 디렉터리가 이미 잠김";
+
+/* Hotkey/Shortcut settings prompt on OSX. [prefs.py] */
+"Keyboard shortcut" = "단축키 설정";
+
+/* Empire rank. [stats.py] */
+"King" = "King";
+
+/* Empire rank. [stats.py] */
+"Knight" = "Knight";
+
+/* Appearance setting prompt. [prefs.py] */
+"Language" = "언어";
+
+/* [EDMarketConnector.py] - Leave '%H:%M:%S' as-is */
+"Last updated at %H:%M:%S" = "마지막 업데이트: %H:%M:%S";
+
+/* Federation rank. [stats.py] */
+"Lieutenant" = "Lieutenant";
+
+/* Federation rank. [stats.py] */
+"Lieutenant Commander" = "Lieutenant Commander";
+
+/* Cmdr stats. [stats.py] */
+"Loan" = "대출";
+
+/* [EDMarketConnector.py] */
+"Logging in..." = "로그인하는 중...";
+
+/* Empire rank. [stats.py] */
+"Lord" = "Lord";
+
+/* [prefs.py] */
+"Market data in CSV format file" = "CSV 형식 파일의 마켓 정보";
+
+/* [prefs.py] */
+"Market data in Trade Dangerous format file" = "Trade Dangerous 형식 파일의 마켓 정보";
+
+/* Empire rank. [stats.py] */
+"Marquis" = "Marquis";
+
+/* Combat rank. [stats.py] */
+"Master" = "Master";
+
+/* Trade rank. [stats.py] */
+"Merchant" = "Merchant";
+
+/* Federation rank. [stats.py] */
+"Midshipman" = "Midshipman";
+
+/* Explorer rank. [stats.py] */
+"Mostly Aimless" = "Mostly Aimless";
+
+/* Combat rank. [stats.py] */
+"Mostly Harmless" = "Mostly Harmless";
+
+/* CQC rank. [stats.py] */
+"Mostly Helpless" = "Mostly Helpless";
+
+/* Trade rank. [stats.py] */
+"Mostly Penniless" = "Mostly Penniless";
+
+/* No hotkey/shortcut currently defined. [prefs.py] */
+"None" = "없음";
+
+/* Dark theme color setting. [prefs.py] */
+"Normal text" = "일반 텍스트";
+
+/* Combat rank. [stats.py] */
+"Novice" = "Novice";
+
+/* [prefs.py] */
+"OK" = "OK";
+
+/* Hotkey/Shortcut setting. [prefs.py] */
+"Only when Elite: Dangerous is the active app" = "Elite: Dangerous가 활성 창 상태일때만";
+
+/* Button that opens a folder in Explorer/Finder. [prefs.py] */
+"Open" = "열기";
+
+/* Shortcut settings button on OSX. [prefs.py] */
+"Open System Preferences" = "시스템 설정 열기";
+
+/* Tab heading in settings. [prefs.py] */
+"Output" = "출력";
+
+/* Empire rank. [stats.py] */
+"Outsider" = "Outsider";
+
+/* Explorer rank. [stats.py] */
+"Pathfinder" = "Pathfinder";
+
+/* Trade rank. [stats.py] */
+"Peddler" = "Peddler";
+
+/* Trade rank. [stats.py] */
+"Penniless" = "Penniless";
+
+/* Federation rank. [stats.py] */
+"Petty Officer" = "Petty Officer";
+
+/* Explorer rank. [stats.py] */
+"Pioneer" = "Pioneer";
+
+/* Hotkey/Shortcut setting. [prefs.py] */
+"Play sound" = "소리 재생하기";
+
+/* [prefs.py] */
+"Please choose what data to save" = "어느 데이터를 저장할 지 선택해주세요";
+
+/* Tab heading in settings. [prefs.py] */
+"Plugins" = "플러그인";
+
+/* Section heading in settings. [prefs.py] */
+"Plugins folder" = "플러그인 폴더";
+
+/* Popup title: Warning about plugins without Python 3.x support [EDMarketConnector.py] */
+"EDMC: Plugins Without Python 3.x Support" = "EDMC: Python 3.x을 지원하지 않는 플러그인";
+
+/* Popup body: Warning about plugins without Python 3.x support [EDMarketConnector.py] */
+"One or more of your enabled plugins do not yet have support for Python 3.x. Please see the list on the '{PLUGINS}' tab of '{FILE}' > '{SETTINGS}'. You should check if there is an updated version available, else alert the developer that they need to update the code for Python 3.x.\r\n\r\nYou can disable a plugin by renaming its folder to have '{DISABLED}' on the end of the name." = "활성화된 플러그인 중 1개 이상이 Python 3.x를 지원하지 않습니다. '{FILE}' > '{SETTINGS}' 에서 '{PLUGINS}' 탭에 들어가 활성화되어있는 플러그인 목록을 확인하십시오. 플러그인들 중 새 버전이 나온 것이 있는지도 확인해보시고, 만약 3.x를 지원하지도, 새 버전도 없다면 해당 플러그인의 개발자에게 코드를 수정하기를 문의하십시오.\n\n플러그인을 비활성화하려면 '{DISABLED}'를 폴더명 뒤에 추가하면 됩니다.";
+
+/* Settings>Plugins>Plugins without Python 3.x support [prefs.py] */
+"Plugins Without Python 3.x Support" = "Python 3.x을 지원하지 않는 플러그인";
+
+/* Settings>Plugins>Information on migrating plugins [prefs.py] */
+"Information on migrating plugins" = "플러그인 위치 변경에 대한 정보";
+
+/* Federation rank. [stats.py] */
+"Post Captain" = "Post Captain";
+
+/* Federation rank. [stats.py] */
+"Post Commander" = "Post Commander";
+
+/* Ranking. [stats.py] */
+"Powerplay" = "Powerplay";
+
+/* [prefs.py] */
+"Preferences" = "설정";
+
+/* Settings prompt for preferred ship loadout, system and station info websites. [prefs.py] */
+"Preferred websites" = "선호하는 사이트";
+
+/* Empire rank. [stats.py] */
+"Prince" = "Prince";
+
+/* Help menu item. [EDMarketConnector.py] */
+"Privacy Policy" = "개인정보처리방침";
+
+/* CQC rank. [stats.py] */
+"Professional" = "Professional";
+
+/* Explorer rank. [stats.py] */
+"Ranger" = "Ranger";
+
+/* Power rank. [stats.py] */
+"Rating 1" = "Rating 1";
+
+/* Power rank. [stats.py] */
+"Rating 2" = "Rating 2";
+
+/* Power rank. [stats.py] */
+"Rating 3" = "Rating 3";
+
+/* Power rank. [stats.py] */
+"Rating 4" = "Rating 4";
+
+/* Power rank. [stats.py] */
+"Rating 5" = "Rating 5";
+
+/* Shortcut settings prompt on OSX. [prefs.py] */
+"Re-start {APP} to use shortcuts" = "단축키를 사용하려면 {APP}을(를) 다시 시작하십시오";
+
+/* Federation rank. [stats.py] */
+"Rear Admiral" = "Rear Admiral";
+
+/* Federation rank. [stats.py] */
+"Recruit" = "Recruit";
+
+/* Help menu item. [EDMarketConnector.py] */
+"Release Notes" = "릴리즈 노트";
+
+/* Changed journal update_lock failed [monitor.py] */
+"Retry" = "재시도";
+
+/* Multicrew role label in main window. [EDMarketConnector.py] */
+"Role" = "Role";
+
+/* Menu item. [EDMarketConnector.py] */
+"Save Raw Data..." = "Raw 데이터 저장하기...";
+
+/* Explorer rank. [stats.py] */
+"Scout" = "Scout";
+
+/* CQC rank. [stats.py] */
+"Semi Professional" = "Semi Professional";
+
+/* [edsm.py] */
+"Send flight log and Cmdr status to EDSM" = "EDSM에 flight 로그와  커맨더 상태 정보 전송하기";
+
+/* [inara.py] */
+"Send flight log and Cmdr status to Inara" = "Inara에 flight 로그와  커맨더 상태 정보 전송하기";
+
+/* Output setting. [eddn.py] */
+"Send station data to the Elite Dangerous Data Network" = "Elite Dangerous Data Network에 스테이션 정보 전송하기";
+
+/* Output setting new in E:D 2.2. [eddn.py] */
+"Send system and scan data to the Elite Dangerous Data Network" = "Elite Dangerous Data Network에 시스템 및 스캔 정보 전송하기";
+
+/* [eddn.py] */
+"Sending data to EDDN..." = "EDDN에 정보 전송하는 중...";
+
+/* Empire rank. [stats.py] */
+"Serf" = "Serf";
+
+/* Item in the File menu on Windows. [EDMarketConnector.py] */
+"Settings" = "설정";
+
+/* Main window. [EDMarketConnector.py] */
+"Ship" = "함선";
+
+/* Output setting. [prefs.py] */
+"Ship loadout" = "함선 피팅";
+
+/* Status dialog title. [stats.py] */
+"Ships" = "함선(들)";
+
+/* Setting to decide which ship outfitting website to link to - either E:D Shipyard or Coriolis. [prefs.py] */
+"Shipyard" = "쉽야드";
+
+/* Status line text that appears when process exit sequence starts [EDMarketConnector.py] */
+"Shutting down..." = "종료하는 중...";
+
+/* Empire rank. [stats.py] */
+"Squire" = "Squire";
+
+/* Main window. [EDMarketConnector.py] */
+"Station" = "스테이션";
+
+/* [EDMarketConnector.py] */
+"Station doesn't have a market!" = "스테이션에 마켓이 없습니다!";
+
+/* [EDMarketConnector.py] */
+"Station doesn't have anything!" = "스테이션에 아무것도 없습니다!";
+
+/* Menu item. [EDMarketConnector.py] */
+"Status" = "상태";
+
+/* Explorer rank. [stats.py] */
+"Surveyor" = "Surveyor";
+
+/* Main window. [EDMarketConnector.py] */
+"System" = "시스템";
+
+/* Changed journal update_lock failed [monitor.py] */
+"The new Journal Directory location is already locked.{CR}You can either attempt to resolve this and then Retry, or choose to Ignore this." = "새 저널 디렉토리(Journal Directory)가 이미 잠겨있습니다.{CR}문제 해결을 시도하고 재시도하거나, 무시하는 방법이 있습니다.";
+
+/* Appearance setting. [prefs.py] */
+"Theme" = "테마";
+
+/* Help text in settings. [prefs.py] */
+"Tip: You can disable a plugin by{CR}adding '{EXT}' to its folder name" = "팁: 플러그인을 비활성화하려면{CR} '{EXT}'를 폴더명 뒤에 추가하면 됨";
+
+/* Ranking. [stats.py] */
+"Trade" = "Trade";
+
+/* Explorer rank. [stats.py] */
+"Trailblazer" = "Trailblazer";
+
+/* Appearance theme setting. [prefs.py] */
+"Transparent" = "투명하게";
+
+/* Trade rank. [stats.py] */
+"Tycoon" = "Tycoon";
+
+/* Update button in main window. [EDMarketConnector.py] */
+"Update" = "새로 고침";
+
+/* Option to use alternate URL method on shipyard links [prefs.py] */
+"Use alternate URL method" = "다른 URL 형식 사용하기";
+
+/* Status dialog subtitle - CR value of ship. [stats.py] */
+"Value" = "가치";
+
+/* Federation rank. [stats.py] */
+"Vice Admiral" = "Vice Admiral";
+
+/* Menu title on OSX. [EDMarketConnector.py] */
+"View" = "보기";
+
+/* Empire rank. [stats.py] */
+"Viscount" = "Viscount";
+
+/* Federation rank. [stats.py] */
+"Warrant Officer" = "Warrant Officer";
+
+/* Shouldn't happen. [EDMarketConnector.py] */
+"What are you flying?!" = "지금 어떤 함선을 몰고 계신 건가요?!";
+
+/* Shouldn't happen. [EDMarketConnector.py] */
+"Where are you?!" = "어디 계신거죠?!";
+
+/* Shouldn't happen. [EDMarketConnector.py] */
+"Who are you?!" = "당신은 누구시죠?!";
+
+/* Menu title on OSX. [EDMarketConnector.py] */
+"Window" = "창";
+
+/* [EDMarketConnector.py] */
+"You're not docked at a station!" = "스테이션에 도킹되어 있지 않습니다!";
+
+/* Shortcut settings prompt on OSX. [prefs.py] */
+"{APP} needs permission to use shortcuts" = "단축기 사용을 위해선 {APP}이 권한 허용을 필요로 합니다";
+
+/* Label for user configured level of logging [prefs.py] */
+"Log Level" = "로깅 수준";

--- a/docs/Translations.md
+++ b/docs/Translations.md
@@ -82,7 +82,7 @@ To add a new language to the app:
 
     Remember that until there are translations all strings will default to the English version (actually the key, which is always specified in English).
 
-1. You need to get the new `.string` file added to the files the installer will install:
+1. You need to get the new `.strings` file added to the files the installer will install:
     1. Edit `EDMarketConnector.wxs` to add an appropriate section to the:
     
             `<Directory Id="L10n" Name="L10n">`

--- a/setup.py
+++ b/setup.py
@@ -150,6 +150,7 @@ elif sys.platform=='win32':
             '%s.ico' % APPNAME,
             '%s/DLLs/sqlite3.dll' % (sys.base_prefix),
             'EDMarketConnector - TRACE.bat',
+            'EDMarketConnector - localserver-auth.bat',
         ]),
         ('L10n', [join('L10n',x) for x in os.listdir('L10n') if x.endswith('.strings')]),
         ('plugins', PLUGINS),


### PR DESCRIPTION
Somehow `main` never got the code to allow `edmc...` argument.

And despite adding it on OneSky we never added Korean to the build/install process.