### PR TITLE
Add Paranoia check in sendreplay()

### DIFF
--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -6,6 +6,7 @@ import pathlib
 import re
 import sys
 import tkinter as tk
+import traceback
 from collections import OrderedDict
 from os import SEEK_SET
 from os.path import join
@@ -183,6 +184,12 @@ Msg:\n{msg}'''
             status['text'] = f'{localized.replace("...", "")} [{len(self.replaylog)}]'
 
         self.parent.update_idletasks()
+
+        # Paranoia check in case this function gets chain-called.
+        if not self.replaylog:
+            logger.error('self.replaylog is False after update_idletasks().  Traceback:\n'
+                         f'{"".join(traceback.format_list(traceback.extract_stack()))}')
+            return
 
         try:
             cmdr, msg = json.loads(self.replaylog[0], object_pairs_hook=OrderedDict)

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -187,8 +187,9 @@ Msg:\n{msg}'''
 
         # Paranoia check in case this function gets chain-called.
         if not self.replaylog:
-            logger.error('self.replaylog is False after update_idletasks().  Traceback:\n'
-                         f'{"".join(traceback.format_list(traceback.extract_stack()))}')
+            logger.error(
+                f'self.replaylog (type: {type(self.replaylog)}) is falsey after update_idletasks().  Traceback:\n'
+                f'{"".join(traceback.format_list(traceback.extract_stack()))}')
             return
 
         try:


### PR DESCRIPTION
self.replaylog[0] should always exist for the `json.load()`, unless the `update_idletasks()` is somehow allowing the timer to call into `sendreplay()` again.  So add a check after that, with traceback logging, to return.

See #926