### PR TITLE
    Fix spurious modules or ships was None

### DIFF
--- a/companion.py
+++ b/companion.py
@@ -634,8 +634,6 @@ class Session(object):
             else:
                 data['lastStarport'].update(shipdata)
 
-        data.check_modules_ships()
-
         return data
 
     def close(self) -> None:


### PR DESCRIPTION
Nothing other than /shipyard actually returns the modules and ships data, so checking for it anywhere other than that automatically is just asking for extra log noise and nothing else.