### PR TITLE
Extra paranoia about game version for forthcoming Odyssey Alpha

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -58,7 +58,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
     _POLL = 1		# Polling is cheap, so do it often
     _RE_CANONICALISE = re.compile(r'\$(.+)_name;')
     _RE_CATEGORY = re.compile(r'\$MICRORESOURCE_CATEGORY_(.+);')
-    _RE_LOGFILE = re.compile(r'^Journal(Alpha|Beta)?\.[0-9]{12}\.[0-9]{2}\.log$')
+    _RE_LOGFILE = re.compile(r'^Journal(Beta)?\.[0-9]{12}\.[0-9]{2}\.log$')
 
     def __init__(self):
         # TODO(A_D): A bunch of these should be switched to default values (eg '' for strings) and no longer be Optional

--- a/monitor.py
+++ b/monitor.py
@@ -58,7 +58,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
     _POLL = 1		# Polling is cheap, so do it often
     _RE_CANONICALISE = re.compile(r'\$(.+)_name;')
     _RE_CATEGORY = re.compile(r'\$MICRORESOURCE_CATEGORY_(.+);')
-    _RE_LOGFILE = re.compile(r'^Journal(Beta)?\.[0-9]{12}\.[0-9]{2}\.log$')
+    _RE_LOGFILE = re.compile(r'^Journal(Alpha|Beta)?\.[0-9]{12}\.[0-9]{2}\.log$')
 
     def __init__(self):
         # TODO(A_D): A bunch of these should be switched to default values (eg '' for strings) and no longer be Optional
@@ -382,7 +382,12 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             if event_type == 'Fileheader':
                 self.live = False
                 self.version = entry['gameversion']
-                self.is_beta = 'beta' in entry['gameversion'].lower()
+                self.is_beta = any(v in entry['gameversion'].lower() for v in ('alpha', 'beta'))
+
+                # TODO: This is an extra paranoia check, because we don't yet know what will (not) be in the Odyssey alpha string.
+                if ('Fleet Carriers Update' not in entry['gameversion']):
+                    self.is_beta = True
+
                 self.cmdr = None
                 self.mode = None
                 self.group = None

--- a/monitor.py
+++ b/monitor.py
@@ -385,7 +385,8 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.is_beta = any(v in entry['gameversion'].lower() for v in ('alpha', 'beta'))
 
                 # TODO: This is an extra paranoia check, because we don't yet know what will (not) be in the Odyssey alpha string.
-                if ('Fleet Carriers Update' not in entry['gameversion']):
+                if 'Fleet Carriers Update' not in entry['gameversion']:
+                    logger.warning(f'Forcing is_beta to True due to gameversion: {entry["gameversion"]}')
                     self.is_beta = True
 
                 self.cmdr = None


### PR DESCRIPTION
1. Pick up 'JournalAlpha' files if they ever are a thing.
2. Pick up 'alpha' in gameversion to set is_beta = True.
3. For now any gameversion without 'Fleet Carriers Update' is considered a beta.

The last bit can be removed/updated as and when we know for certain what's in the Odyssey alpha game version.