### PR TITLE
Reduce some log spam:

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -845,7 +845,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             return None
 
         if not self.event_queue:
-            logger.debug('Called with no event_queue')
+            logger.trace('Called with no event_queue')
             return None
 
         else:

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -6,7 +6,6 @@ import pathlib
 import re
 import sys
 import tkinter as tk
-import traceback
 from collections import OrderedDict
 from os import SEEK_SET
 from os.path import join
@@ -187,9 +186,10 @@ Msg:\n{msg}'''
 
         # Paranoia check in case this function gets chain-called.
         if not self.replaylog:
-            logger.error(
-                f'self.replaylog (type: {type(self.replaylog)}) is falsey after update_idletasks().  Traceback:\n'
-                f'{"".join(traceback.format_list(traceback.extract_stack()))}')
+            # import traceback
+            # logger.error(
+            #     f'self.replaylog (type: {type(self.replaylog)}) is falsey after update_idletasks().  Traceback:\n'
+            #     f'{"".join(traceback.format_list(traceback.extract_stack()))}')
             return
 
         try:

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -1275,8 +1275,11 @@ def send_data(url: str, data: Mapping[str, Any]) -> bool:
         # Log individual errors and warnings
         for data_event, reply_event in zip(data['events'], reply['events']):
             if reply_event['eventStatus'] != 200:
-                logger.warning(f'Inara\t{status} {reply_event.get("eventStatusText", "")}')
-                logger.debug(f'JSON data:\n{json.dumps(data_event)}')
+                if ("Everything was alright, the near-neutral status just wasn't stored."
+                        not in reply_event.get("eventStatusText")):
+                    logger.warning(f'Inara\t{status} {reply_event.get("eventStatusText", "")}')
+                    logger.debug(f'JSON data:\n{json.dumps(data_event)}')
+
                 if reply_event['eventStatus'] // 100 != 2:
                     plug.show_error(_('Error: Inara {MSG}').format(
                         MSG=f'{data_event["eventName"]},'


### PR DESCRIPTION
* Comment out the traceback in plugins/eddn.py, the return is enough.
* 'Called with no event_queue' can be TRACE.
* Don't care about "Everything was alright, the near-neutral status just wasn't stored." from Inara.