### PR TITLE
docs: General update for `main` now using Python 3.9 & misc

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -700,8 +700,8 @@ Disabled and enabled plugins are listed on the "Plugins" Settings tab
 ## Migration from Python 2.7
 
 Starting with pre-release 3.5 EDMC used Python 3.7.   The first full
-release under Python 3.7 was 4.0.0.0.   The 4.1.x series was the last to use
-Python 3.7, with releases moving on to latest Python 3.8.x after that.
+release under Python 3.7 was 4.0.0.0.   The 4.2.x series was the last to use
+Python 3.7, with releases moving on to the latest Python 3.9.x after that.
 
 This is a brief outline of the steps required to migrate a plugin from earlier
 versions of EDMC:
@@ -717,14 +717,11 @@ versions of EDMC:
     the correct number of arguments.  Older versions of this app were tolerant
     of missing arguments in these function declarations.
 
-- Port the code to Python 3.7 or 3.8 as appropriate. The
+- Port the code to Python 3.9+. The
  [2to3](https://docs.python.org/3/library/2to3.html)
  tool can automate much of this work.
 
-Depending on the complexity of the plugin it may be feasible to make it
-compatible with both EDMC 3.4 + Python 2.7 and EDMC 3.5 + Python 3.7/3.8.
-
-You might find [compatible idioms](https://python-future.org/compatible_idioms.html),
-a guide on writing Python 2/3 compatible code, useful.  There's also [an
- example of changes required for a simple plugin](https://github.com/Marginal/HabZone/commit/3c41cd41d5ad81ef36aab40e967e3baf77b4bd06)
-.
+We advise *against* making any attempt to have a plugin's code work under 
+both Python 2.7 and 3.x.  We no longer maintain the Python 2.7-based 
+versions of this application and you shouldn't support use of them with 
+your plugin.

--- a/README.md
+++ b/README.md
@@ -42,16 +42,9 @@ Please see the [Troubleshooting](https://github.com/EDCD/EDMarketConnector/wiki/
 Reporting a problem
 ---
 Please report a problem as a new GitHub [issue](https://github.com/EDCD/EDMarketConnector/issues/new?assignees=&labels=bug%2C+unconfirmed&template=bug_report.md&title=).
-Please wait for the error to occur and zip up and attach this app's log file to the new issue:
-
-Mac:
-
-* `$TMPDIR/EDMarketConnector.log`
-
-Windows:
-
-* `%TMP%\EDMarketConnector.log`
-
+See [Reporting a problem](https://github.com/EDCD/EDMarketConnector/wiki/Troubleshooting#reporting-a-problem)
+for further guidance, including how to find the necessary log files to 
+attach to the report.
 
 Packaging for distribution
 --------
@@ -74,6 +67,6 @@ Please see the [Acknowledgements](https://github.com/EDCD/EDMarketConnector/wiki
 
 License
 -------
-Copyright © 2015-2019 Jonathan Harris, 2020 EDCD
+Copyright © 2015-2019 Jonathan Harris, 2020-2021 EDCD
 
 Licensed under the [GNU Public License (GPL)](http://www.gnu.org/licenses/gpl-2.0.html) version 2 or later.

--- a/docs/Releasing.md
+++ b/docs/Releasing.md
@@ -31,10 +31,11 @@ You will need several pieces of software installed, or the files from their
  auto-select some others).  NB: If you have need to uninstall this it's
  "Windows Software Development Kit - Windows 10.0.19041.1" in
  "Apps & Features", *not* "Windows SDK AddOn".
-1. [Python](https://python.org): 32-bit version of Python 3.8 for Windows.
- [v3.8.6](https://www.python.org/downloads/release/python-386/) is the most
+1. [Python](https://python.org): 32-bit version of Python 3.9 for Windows.
+ [v3.9.2](https://www.python.org/downloads/release/python-392/) is the most
  recently tested version.  You need the `Windows x86 executable installer`
- file, for the 32-bit version.
+ file, for the 32-bit version.  Double-check the version against the
+   `.python.version` file, as it should always contain the intended version.
 1. [py2exe](https://github.com/albertosottile/py2exe) - Now available via PyPi,
  so will be picked up with the `pip install` below.  Latest tested as per
  `requirements-dev.txt`.
@@ -92,9 +93,6 @@ that.
  appears in the EXE properties, and is also used as the location of WinSparkle
  registry entries on Windows.
 
-1. Location of release files. To change this edit `setup.py`.  Look for the
-`appcast.write()` statement and change the `url="...` line.
-
 1. Application names, version and URL of the file with latest release
  information. These are all in the `config.py` file.  See the
  `from config import ...` lines in setup.py.
@@ -112,6 +110,21 @@ that.
 	 URL doesn't change over application versions) version of the
 	 appcast_win_<version>.xml file.  The original upstream value is
 	 `https://raw.githubusercontent.com/EDCD/EDMarketConnector/releases/edmarketconnector.xml`.
+       
+1. Location of release files.  This needs to be cited correctly in the
+   `edmarketconnector.xml` file, which is what the application queries to
+   see if there is a newer version.
+   Look for the `url="...` line in the `<enclosure ...` that is like:
+
+       <enclosure
+            url="https://github.com/EDCD/EDMarketConnector/releases/download/Release/4.2.3/EDMarketConnector_win_4.2.3.msi"
+            sparkle:os="windows"
+            sparkle:installerArguments="/passive LAUNCH=yes"
+            sparkle:version="4.2.3"
+            length="11382784"
+            type="application/octet-stream"
+       />
+
 
 ## Adding a new file
 


### PR DESCRIPTION
* Extend EDCD copyright into 2021 here as well.
* Recommend *against* any attempt at making plugins also work with Python 2.7.
* setup.py no longer writes appcast files.  Mention edmarketconnector.xml enclosure instead for the url= bit.
* DRY about location of log files, just point to appropriate wiki link.