### PR TITLE
Make export_ship() paranoid about possible encoding issues

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -1137,7 +1137,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             except UnicodeError:
                 logger.exception("UnicodeError reading old ship loadout with utf-8 encoding, trying without...")
                 try:
-                    with open(join(config.get('outdir'), oldfiles[-1]), 'rU') as h:  # type: ignore
+                    with open(join(config.get('outdir'), oldfiles[-1]), 'r') as h:  # type: ignore
                         if h.read() == string:
                             return  # same as last time - don't write
 


### PR DESCRIPTION
We had a report of a UnicodeDecodeError trying to read an old file.  So try utf-8 first, if it fails try the default, and if nothing else try to write a new file so the next call should actually work as expected.