### PR TITLE
Fix where config.app_version() not being a string causes issues.

### DIFF
--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -164,7 +164,7 @@ class EDDN:
             ('$schemaRef', msg['$schemaRef']),
             ('header', OrderedDict([
                 ('softwareName',    f'{applongname} [{system() if sys.platform != "darwin" else "Mac OS"}]'),
-                ('softwareVersion', appversion_nobuild()),
+                ('softwareVersion', str(appversion_nobuild())),
                 ('uploaderID',      uploader_id),
             ])),
             ('message', msg['message']),

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -573,7 +573,7 @@ def worker() -> None:
                         'commanderName': username.encode('utf-8'),
                         'apiKey': apikey,
                         'fromSoftware': applongname,
-                        'fromSoftwareVersion': appversion(),
+                        'fromSoftwareVersion': str(appversion()),
                         'message': json.dumps(pending, ensure_ascii=False).encode('utf-8'),
                     }
 

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -1222,7 +1222,7 @@ def new_worker():
             data = {
                 'header': {
                     'appName': applongname,
-                    'appVersion': appversion(),
+                    'appVersion': str(appversion()),
                     'APIkey': creds.api_key,
                     'commanderName': creds.cmdr,
                     'commanderFrontierID': creds.fid

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ else:
     assert False, f'Unsupported platform {sys.platform}'
 
 # Split version, as py2exe wants the 'base' for version
-semver = semantic_version.Version.coerce(appversion())
+semver = appversion()
+appversion_str = str(semver)
 base_appversion = str(semver.truncate('patch'))
 
 if dist_dir and len(dist_dir) > 1 and isdir(dist_dir):
@@ -154,8 +155,8 @@ if sys.platform == 'darwin':
                 'CFBundleName': applongname,
                 'CFBundleIdentifier': f'uk.org.marginal.{appname.lower()}',
                 'CFBundleLocalizations': get_cfbundle_localizations(),
-                'CFBundleShortVersionString': appversion(),
-                'CFBundleVersion':  appversion(),
+                'CFBundleShortVersionString': appversion_str,
+                'CFBundleVersion':  appversion_str,
                 'CFBundleURLTypes': [
                     {
                         'CFBundleTypeRole': 'Viewer',
@@ -229,7 +230,7 @@ elif sys.platform == 'win32':
 
 setup(
     name=applongname,
-    version=appversion(),
+    version=appversion_str,
     windows=[
         {
             'dest_base': appname,
@@ -238,7 +239,7 @@ setup(
             'company_name': 'EDCD',  # Used by WinSparkle
             'product_name': appname,  # Used by WinSparkle
             'version': base_appversion,
-            'product_version': appversion(),
+            'product_version': appversion_str,
             'copyright': copyright,
             'other_resources': [(24, 1, open(f'{appname}.manifest').read())],
         }
@@ -250,7 +251,7 @@ setup(
             'company_name': 'EDCD',
             'product_name': appname,
             'version': base_appversion,
-            'product_version': appversion(),
+            'product_version': appversion_str,
             'copyright': copyright,
             'other_resources': [(24, 1, open(f'{appcmdname}.manifest').read())],
         }

--- a/update.py
+++ b/update.py
@@ -81,7 +81,7 @@ class Updater(object):
                 # NB: It 'accidentally' supports pre-release due to how it
                 # splits and compares strings:
                 # <https://github.com/vslavik/winsparkle/issues/214>
-                self.updater.win_sparkle_set_app_build_version(appversion_nobuild())
+                self.updater.win_sparkle_set_app_build_version(str(appversion_nobuild()))
 
                 # set up shutdown callback
                 global root


### PR DESCRIPTION
Various fixes for config.app_version() now returning `semantic_version.Version`, instead of `str`.

Checked the changes in debugger, plus built an installer and checked its .exe log file.