### PR TITLE
Attempt to get on-foot detection working, so EDDN data sends

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -337,6 +337,10 @@ class AppWindow(object):
 
         self.cmdr = tk.Label(frame, compound=tk.RIGHT, anchor=tk.W, name='cmdr')
         self.ship = HyperlinkLabel(frame, compound=tk.RIGHT, url=self.shipyard_url, name='ship')
+        # system and station text is set/updated by the 'provider' plugins
+        # eddb, edsm and inara.  Look for:
+        #
+        # parent.children['system'] / parent.children['station']
         self.system = HyperlinkLabel(frame, compound=tk.RIGHT, url=self.system_url, popup_copy=True, name='system')
         self.station = HyperlinkLabel(frame, compound=tk.RIGHT, url=self.station_url, name='station')
 

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -256,6 +256,7 @@ import plug
 import prefs
 import stats
 import td
+import util_ships
 from commodity import COMMODITY_CSV
 from dashboard import dashboard
 from hotkey import hotkeymgr
@@ -689,7 +690,7 @@ class AppWindow(object):
         :return: True if all OK, else False to trigger play_bad in caller.
         """
         if config.get_int('output') & (config.OUT_STATION_ANY):
-            if not data['commander'].get('docked'):
+            if not data['commander'].get('docked') and not monitor.on_foot:
                 if not self.status['text']:
                     # Signal as error because the user might actually be docked
                     # but the server hosting the Companion API hasn't caught up
@@ -810,7 +811,7 @@ class AppWindow(object):
                     self.dump_capi_data(data)
 
                 if not monitor.state['ShipType']:  # Started game in SRV or fighter
-                    self.ship['text'] = companion.ship_map.get(data['ship']['name'].lower(), data['ship']['name'])
+                    self.ship['text'] = util_ships.ship_map.get(data['ship']['name'].lower(), data['ship']['name'])
                     monitor.state['ShipID'] = data['ship']['id']
                     monitor.state['ShipType'] = data['ship']['name'].lower()
 
@@ -912,7 +913,7 @@ class AppWindow(object):
                     ship_text = monitor.state['ShipName']
 
                 else:
-                    ship_text = companion.ship_map.get(monitor.state['ShipType'], monitor.state['ShipType'])
+                    ship_text = util_ships.ship_map.get(monitor.state['ShipType'], monitor.state['ShipType'])
 
                 if not ship_text:
                     ship_text = ''

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -784,12 +784,18 @@ class AppWindow(object):
                 # CAPI system must match last journal one
                 raise companion.ServerLagging()
 
-            elif (monitor.on_foot and monitor.station
-                  and data['lastStarport']['name'] != monitor.station  # On foot station must match if set
-                  or ((data['commander']['docked'] and data['lastStarport']['name'] or None)
-                      != monitor.station)  # CAPI lastStarport must match
-                  ):
-                raise companion.ServerLagging()
+            elif data['lastStarport']['name'] != monitor.station:
+                if monitor.on_foot and monitor.station:
+                    raise companion.ServerLagging()
+
+                else:
+                    last_station = None
+                    if data['commander']['docked']:
+                        last_station = data['lastStarport']['name']
+
+                    if last_station != monitor.station:
+                        # CAPI lastStarport must match
+                        raise companion.ServerLagging()
 
             elif not monitor.on_foot and data['ship']['id'] != monitor.state['ShipID']:
                 # CAPI ship must match

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -690,7 +690,7 @@ class AppWindow(object):
         :return: True if all OK, else False to trigger play_bad in caller.
         """
         if config.get_int('output') & (config.OUT_STATION_ANY):
-            if not data['commander'].get('docked') and not monitor.on_foot:
+            if not data['commander'].get('docked') and not monitor.state['on_foot']:
                 if not self.status['text']:
                     # Signal as error because the user might actually be docked
                     # but the server hosting the Companion API hasn't caught up
@@ -777,7 +777,7 @@ class AppWindow(object):
                 # Companion API Commander doesn't match Journal
                 raise companion.CmdrError()
 
-            elif auto_update and not monitor.on_foot and not data['commander'].get('docked'):
+            elif auto_update and not monitor.state['on_foot'] and not data['commander'].get('docked'):
                 # auto update is only when just docked
                 raise companion.ServerLagging()
 
@@ -786,7 +786,7 @@ class AppWindow(object):
                 raise companion.ServerLagging()
 
             elif data['lastStarport']['name'] != monitor.station:
-                if monitor.on_foot and monitor.station:
+                if monitor.state['on_foot'] and monitor.station:
                     raise companion.ServerLagging()
 
                 else:
@@ -798,11 +798,11 @@ class AppWindow(object):
                         # CAPI lastStarport must match
                         raise companion.ServerLagging()
 
-            elif not monitor.on_foot and data['ship']['id'] != monitor.state['ShipID']:
+            elif not monitor.state['on_foot'] and data['ship']['id'] != monitor.state['ShipID']:
                 # CAPI ship must match
                 raise companion.ServerLagging()
 
-            elif not monitor.on_foot and data['ship']['name'].lower() != monitor.state['ShipType']:
+            elif not monitor.state['on_foot'] and data['ship']['name'].lower() != monitor.state['ShipType']:
                 # CAPI ship type must match
                 raise companion.ServerLagging()
 
@@ -909,6 +909,7 @@ class AppWindow(object):
 
                 self.ship_label['text'] = _('Ship') + ':'  # Main window
 
+                # TODO: Show something else when on_foot
                 if monitor.state['ShipName']:
                     ship_text = monitor.state['ShipName']
 

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -694,7 +694,7 @@ class AppWindow(object):
         :return: True if all OK, else False to trigger play_bad in caller.
         """
         if config.get_int('output') & (config.OUT_STATION_ANY):
-            if not data['commander'].get('docked') and not monitor.state['on_foot']:
+            if not data['commander'].get('docked') and not monitor.state['OnFoot']:
                 if not self.status['text']:
                     # Signal as error because the user might actually be docked
                     # but the server hosting the Companion API hasn't caught up
@@ -781,7 +781,7 @@ class AppWindow(object):
                 # Companion API Commander doesn't match Journal
                 raise companion.CmdrError()
 
-            elif auto_update and not monitor.state['on_foot'] and not data['commander'].get('docked'):
+            elif auto_update and not monitor.state['OnFoot'] and not data['commander'].get('docked'):
                 # auto update is only when just docked
                 raise companion.ServerLagging()
 
@@ -790,7 +790,7 @@ class AppWindow(object):
                 raise companion.ServerLagging()
 
             elif data['lastStarport']['name'] != monitor.station:
-                if monitor.state['on_foot'] and monitor.station:
+                if monitor.state['OnFoot'] and monitor.station:
                     raise companion.ServerLagging()
 
                 else:
@@ -802,11 +802,11 @@ class AppWindow(object):
                         # CAPI lastStarport must match
                         raise companion.ServerLagging()
 
-            elif not monitor.state['on_foot'] and data['ship']['id'] != monitor.state['ShipID']:
+            elif not monitor.state['OnFoot'] and data['ship']['id'] != monitor.state['ShipID']:
                 # CAPI ship must match
                 raise companion.ServerLagging()
 
-            elif not monitor.state['on_foot'] and data['ship']['name'].lower() != monitor.state['ShipType']:
+            elif not monitor.state['OnFoot'] and data['ship']['name'].lower() != monitor.state['ShipType']:
                 # CAPI ship type must match
                 raise companion.ServerLagging()
 

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -530,7 +530,7 @@ Content of `state` (updated to the current journal entry):
 | `Modules`      |           `dict`            | Currently fitted modules                                                                                        |
 | `NavRoute`     |           `dict`            | Last plotted multi-hop route                                                                                    |
 | `ModuleInfo`   |           `dict`            | Last loaded ModulesInfo.json data                                                                               |
-| `on_foot`      |           `bool`            | Whether you're on_foot                                                                                          |
+| `OnFoot`       |           `bool`            | Whether the Cmdr is on foot                                                                                     |
 
 New in version 4.1.6:
 
@@ -550,7 +550,7 @@ journal `NavRoute` event.
 `ModuleInfo` contains the `json.load()` of `ModulesInfo.json` as indicated by a
 Journal `ModuleInfo` event.
 
-`on_foot` is an indication as to if the player is on-foot, rather than in a
+`OnFoot` is an indication as to if the player is on-foot, rather than in a
 vehicle.
 
 ##### Synthetic Events

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -530,6 +530,28 @@ Content of `state` (updated to the current journal entry):
 | `Modules`      |           `dict`            | Currently fitted modules                                                                                        |
 | `NavRoute`     |           `dict`            | Last plotted multi-hop route                                                                                    |
 | `ModuleInfo`   |           `dict`            | Last loaded ModulesInfo.json data                                                                               |
+| `on_foot`      |           `bool`            | Whether you're on_foot                                                                                          |
+
+New in version 4.1.6:
+
+`CargoJSON` contains the raw data from the last read of `Cargo.json` passed
+through json.load. It contains more information about the cargo contents, such
+as the mission ID for mission specific cargo
+
+**NB: Because this is only the data loaded from the `Cargo.json` file, and that
+is not written at Commander login (instead the in-Journal `Cargo` event
+contains all the data), this will not be populated at login.**
+
+New in version 5.0.0:
+
+`NavRoute` contains the `json.load()` of `NavRoute.json` as indicated by a
+journal `NavRoute` event.
+
+`ModuleInfo` contains the `json.load()` of `ModulesInfo.json` as indicated by a
+Journal `ModuleInfo` event.
+
+`on_foot` is an indication as to if the player is on-foot, rather than in a
+vehicle.
 
 ##### Synthetic Events
 
@@ -587,24 +609,6 @@ Examples of this are:
    (noting that we used the singular form there to stay consistent with the
    Journal event name).
    
-New in version 4.1.6:
-
-`CargoJSON` contains the raw data from the last read of `Cargo.json` passed
-through json.load. It contains more information about the cargo contents, such
-as the mission ID for mission specific cargo
-
-**NB: Because this is only the data loaded from the `Cargo.json` file, and that
-is not written at Commander login (instead the in-Journal `Cargo` event
-contains all the data), this will not be populated at login.**
-
-New in version 5.0.0:
-
-`NavRoute` contains the `json.load()` of `NavRoute.json` as indicated by a
-journal `NavRoute` event.
-
-`ModuleInfo` contains the `json.load()` of `ModulesInfo.json` as indicated by a
-Journal `ModuleInfo` event.
-
 ---
 
 ### Shutdown

--- a/collate.py
+++ b/collate.py
@@ -6,12 +6,13 @@
 import csv
 import json
 import os
-from os.path import isfile
 import sys
+from os.path import isfile
 from traceback import print_exc
 
 import companion
 import outfitting
+import util_ships
 
 
 def __make_backup(file_name: str, suffix: str = '.bak') -> None:
@@ -106,7 +107,7 @@ def addmodules(data):
             raise ValueError('id: {} != {}'.format(key, module['id']))
 
         try:
-            new = outfitting.lookup(module, companion.ship_map, True)
+            new = outfitting.lookup(module, util_ships.ship_map, True)
 
         except Exception:
             print('{}, {}:'.format(module['id'], module['name']))
@@ -164,7 +165,7 @@ def addships(data):
     for ship in tuple(data_ships.get('shipyard_list', {}).values()) + data_ships.get('unavailable_list'):
         # sanity check
         key = int(ship['id'])
-        new = {'id': key, 'symbol': ship['name'], 'name': companion.ship_map.get(ship['name'].lower())}
+        new = {'id': key, 'symbol': ship['name'], 'name': util_ships.ship_map.get(ship['name'].lower())}
         if new:
             old = ships.get(key)
             if old:

--- a/companion.py
+++ b/companion.py
@@ -564,7 +564,7 @@ class Session(object):
             logger.error('No commander in returned data')
             return data
 
-        if not data['commander'].get('docked') and not monitor.state['on_foot']:
+        if not data['commander'].get('docked') and not monitor.state['OnFoot']:
             return data
 
         services = data['lastStarport'].get('services', {})

--- a/companion.py
+++ b/companion.py
@@ -28,6 +28,7 @@ import requests
 
 from config import appname, appversion, config
 from EDMCLogging import get_main_logger
+from monitor import monitor
 from protocol import protocolhandler
 
 logger = get_main_logger()
@@ -563,7 +564,7 @@ class Session(object):
             logger.error('No commander in returned data')
             return data
 
-        if not data['commander'].get('docked'):
+        if not data['commander'].get('docked') and not monitor.on_foot:
             return data
 
         services = data['lastStarport'].get('services', {})

--- a/companion.py
+++ b/companion.py
@@ -564,7 +564,7 @@ class Session(object):
             logger.error('No commander in returned data')
             return data
 
-        if not data['commander'].get('docked') and not monitor.on_foot:
+        if not data['commander'].get('docked') and not monitor.state['on_foot']:
             return data
 
         services = data['lastStarport'].get('services', {})

--- a/companion.py
+++ b/companion.py
@@ -75,53 +75,6 @@ category_map = {
 
 commodity_map: Dict = {}
 
-ship_map = {
-    'adder':                        'Adder',
-    'anaconda':                     'Anaconda',
-    'asp':                          'Asp Explorer',
-    'asp_scout':                    'Asp Scout',
-    'belugaliner':                  'Beluga Liner',
-    'cobramkiii':                   'Cobra MkIII',
-    'cobramkiv':                    'Cobra MkIV',
-    'clipper':                      'Panther Clipper',
-    'cutter':                       'Imperial Cutter',
-    'diamondback':                  'Diamondback Scout',
-    'diamondbackxl':                'Diamondback Explorer',
-    'dolphin':                      'Dolphin',
-    'eagle':                        'Eagle',
-    'empire_courier':               'Imperial Courier',
-    'empire_eagle':                 'Imperial Eagle',
-    'empire_fighter':               'Imperial Fighter',
-    'empire_trader':                'Imperial Clipper',
-    'federation_corvette':          'Federal Corvette',
-    'federation_dropship':          'Federal Dropship',
-    'federation_dropship_mkii':     'Federal Assault Ship',
-    'federation_gunship':           'Federal Gunship',
-    'federation_fighter':           'F63 Condor',
-    'ferdelance':                   'Fer-de-Lance',
-    'hauler':                       'Hauler',
-    'independant_trader':           'Keelback',
-    'independent_fighter':          'Taipan Fighter',
-    'krait_mkii':                   'Krait MkII',
-    'krait_light':                  'Krait Phantom',
-    'mamba':                        'Mamba',
-    'orca':                         'Orca',
-    'python':                       'Python',
-    'scout':                        'Taipan Fighter',
-    'sidewinder':                   'Sidewinder',
-    'testbuggy':                    'Scarab',
-    'type6':                        'Type-6 Transporter',
-    'type7':                        'Type-7 Transporter',
-    'type9':                        'Type-9 Heavy',
-    'type9_military':               'Type-10 Defender',
-    'typex':                        'Alliance Chieftain',
-    'typex_2':                      'Alliance Crusader',
-    'typex_3':                      'Alliance Challenger',
-    'viper':                        'Viper MkIII',
-    'viper_mkiv':                   'Viper MkIV',
-    'vulture':                      'Vulture',
-}
-
 
 class CAPIData(UserDict):
     """CAPI Response."""
@@ -767,20 +720,6 @@ def ship(data: CAPIData) -> CAPIData:
 
     # subset of "ship" that's not noisy
     return filter_ship(data['ship'])
-
-
-def ship_file_name(ship_name: str, ship_type: str) -> str:
-    """Return a ship name suitable for a filename."""
-    name = str(ship_name or ship_map.get(ship_type.lower(), ship_type)).strip()
-    if name.endswith('.'):
-        name = name[:-1]
-
-    if name.lower() in ('con', 'prn', 'aux', 'nul',
-                        'com1', 'com2', 'com3', 'com4', 'com5', 'com6', 'com7', 'com8', 'com9',
-                        'lpt1', 'lpt2', 'lpt3', 'lpt4', 'lpt5', 'lpt6', 'lpt7', 'lpt8', 'lpt9'):
-        name = name + '_'
-
-    return name.translate({ord(x): u'_' for x in ('\0', '<', '>', ':', '"', '/', '\\', '|', '?', '*')})
 
 
 # singleton

--- a/coriolis.py
+++ b/coriolis.py
@@ -15,6 +15,7 @@ from traceback import print_exc
 from config import config
 import outfitting
 import companion
+import util_ships
 
 
 if __name__ == "__main__":
@@ -39,7 +40,7 @@ if __name__ == "__main__":
     }
 
     # Symbolic name from in-game name
-    reverse_ship_map = {v: k for k, v in list(companion.ship_map.items())}
+    reverse_ship_map = {v: k for k, v in list(util_ships.ship_map.items())}
 
     bulkheads = list(outfitting.armour_map.keys())
 
@@ -98,7 +99,7 @@ if __name__ == "__main__":
         reader = csv.DictReader(csvfile, restval='')
         for row in reader:
             try:
-                module = outfitting.lookup({ 'id': row['id'], 'name': row['symbol'] }, companion.ship_map)
+                module = outfitting.lookup({ 'id': row['id'], 'name': row['symbol'] }, util_ships.ship_map)
             except:
                 print(row['symbol'])
                 print_exc()

--- a/edshipyard.py
+++ b/edshipyard.py
@@ -8,14 +8,14 @@ import re
 import time
 
 from config import config
-import companion
 import outfitting
+import util_ships
 
 from typing import Dict, Union, List
 __Module = Dict[str, Union[str, List[str]]]
 
 # Map API ship names to E:D Shipyard ship names
-ship_map = companion.ship_map.copy()
+ship_map = util_ships.ship_map.copy()
 
 ship_map.update(
     {
@@ -172,11 +172,11 @@ def export(data, filename=None):
     string += '---\nCargo : {} T\nFuel  : {} T\n'.format(cargo, fuel)
 
     # Add mass and range
-    assert data['ship']['name'].lower() in companion.ship_map, data['ship']['name']
-    assert companion.ship_map[data['ship']['name'].lower()] in ships, companion.ship_map[data['ship']['name'].lower()]
+    assert data['ship']['name'].lower() in util_ships.ship_map, data['ship']['name']
+    assert util_ships.ship_map[data['ship']['name'].lower()] in ships, util_ships.ship_map[data['ship']['name'].lower()]
 
     try:
-        mass += ships[companion.ship_map[data['ship']['name'].lower()]]['hullMass']
+        mass += ships[util_ships.ship_map[data['ship']['name'].lower()]]['hullMass']
         string += 'Mass  : {:.2f} T empty\n        {:.2f} T full\n'.format(mass, mass + fuel + cargo)
 
         multiplier = pow(min(fuel, fsd['maxfuel']) / fsd['fuelmul'], 1.0 / fsd['fuelpower']) * fsd['optmass']
@@ -197,7 +197,7 @@ def export(data, filename=None):
         return
 
     # Look for last ship of this type
-    ship = companion.ship_file_name(data['ship'].get('shipName'), data['ship']['name'])
+    ship = util_ships.ship_file_name(data['ship'].get('shipName'), data['ship']['name'])
     regexp = re.compile(re.escape(ship) + r'\.\d{4}-\d\d-\d\dT\d\d\.\d\d\.\d\d\.txt')
     oldfiles = sorted([x for x in os.listdir(config.get_str('outdir')) if regexp.match(x)])
     if oldfiles:

--- a/loadout.py
+++ b/loadout.py
@@ -8,6 +8,7 @@ import time
 
 from config import config
 import companion
+import util_ships
 
 
 def export(data, filename=None):
@@ -20,7 +21,7 @@ def export(data, filename=None):
         return
 
     # Look for last ship of this type
-    ship = companion.ship_file_name(data['ship'].get('shipName'), data['ship']['name'])
+    ship = util_ships.ship_file_name(data['ship'].get('shipName'), data['ship']['name'])
     regexp = re.compile(re.escape(ship) + '\.\d\d\d\d\-\d\d\-\d\dT\d\d\.\d\d\.\d\d\.txt')
     oldfiles = sorted([x for x in os.listdir(config.get_str('outdir')) if regexp.match(x)])
     if oldfiles:

--- a/monitor.py
+++ b/monitor.py
@@ -16,7 +16,7 @@ from typing import Tuple
 if TYPE_CHECKING:
     import tkinter
 
-from companion import ship_file_name
+import util_ships
 from config import config
 from EDMCLogging import get_main_logger
 
@@ -1141,7 +1141,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
             return
 
-        ship = ship_file_name(self.state['ShipName'], self.state['ShipType'])
+        ship = util_ships.ship_file_name(self.state['ShipName'], self.state['ShipType'])
         regexp = re.compile(re.escape(ship) + r'\.\d{4}\-\d\d\-\d\dT\d\d\.\d\d\.\d\d\.txt')
         oldfiles = sorted((x for x in listdir(config.get_str('outdir')) if regexp.match(x)))  # type: ignore
         if oldfiles:

--- a/monitor.py
+++ b/monitor.py
@@ -626,9 +626,13 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.stationservices = None
 
             elif event_type == 'Embark':
+                # If we've embarked then we're no longer on the station.
+                self.station = None
                 self.on_foot = False
 
             elif event_type == 'Disembark':
+                # We don't yet have a way, other than LoadGame+Location, to detect if we *are* on a station on-foot.
+                self.station = None
                 self.on_foot = True
 
             elif event_type in ('Location', 'FSDJump', 'Docked', 'CarrierJump'):

--- a/monitor.py
+++ b/monitor.py
@@ -133,7 +133,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             'Modules':      None,
             'CargoJSON':    None,  # The raw data from the last time cargo.json was read
             'Route':        None,  # Last plotted route from Route.json file
-            'on_foot':      False,  # Whether we think you're on-foot
+            'OnFoot':      False,  # Whether we think you're on-foot
         }
 
     def start(self, root: 'tkinter.Tk') -> bool:  # noqa: CCR001
@@ -234,7 +234,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         self.coordinates = None
         self.systemaddress = None
         self.is_beta = False
-        self.state['on_foot'] = False
+        self.state['OnFoot'] = False
 
         if self.observed:
             logger.debug('self.observed: Calling unschedule_all()')
@@ -497,7 +497,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     'Modules':      None,
                     'Route':        None,
                 }
-                self.state['on_foot'] = False
+                self.state['OnFoot'] = False
 
             elif event_type == 'Commander':
                 self.live = True  # First event in 3.0
@@ -530,7 +530,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     'Role':       None,
                 })
                 if self._RE_SHIP_ONFOOT.search(entry['Ship']):
-                    self.state['on_foot'] = True
+                    self.state['OnFoot'] = True
 
             elif event_type == 'NewCommander':
                 self.cmdr = entry['Name']
@@ -628,12 +628,12 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             elif event_type == 'Embark':
                 # If we've embarked then we're no longer on the station.
                 self.station = None
-                self.state['on_foot'] = False
+                self.state['OnFoot'] = False
 
             elif event_type == 'Disembark':
                 # We don't yet have a way, other than LoadGame+Location, to detect if we *are* on a station on-foot.
                 self.station = None
-                self.state['on_foot'] = True
+                self.state['OnFoot'] = True
 
             elif event_type in ('Location', 'FSDJump', 'Docked', 'CarrierJump'):
                 if event_type in ('Location', 'CarrierJump'):
@@ -896,7 +896,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.stationservices = None
                 self.coordinates = None
                 self.systemaddress = None
-                self.state['on_foot'] = False
+                self.state['OnFoot'] = False
 
             elif event_type == 'ChangeCrewRole':
                 self.state['Role'] = entry['Role']

--- a/monitor.py
+++ b/monitor.py
@@ -104,7 +104,6 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         self.coordinates: Optional[Tuple[float, float, float]] = None
         self.systemaddress: Optional[int] = None
         self.started: Optional[int] = None  # Timestamp of the LoadGame event
-        self.on_foot: bool = False
 
         # Cmdr state shared with EDSM and plugins
         # If you change anything here update PLUGINS.md documentation!
@@ -134,6 +133,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             'Modules':      None,
             'CargoJSON':    None,  # The raw data from the last time cargo.json was read
             'Route':        None,  # Last plotted route from Route.json file
+            'on_foot':      False,  # Whether we think you're on-foot
         }
 
     def start(self, root: 'tkinter.Tk') -> bool:  # noqa: CCR001
@@ -234,7 +234,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         self.coordinates = None
         self.systemaddress = None
         self.is_beta = False
-        self.on_foot = False
+        self.state['on_foot'] = False
 
         if self.observed:
             logger.debug('self.observed: Calling unschedule_all()')
@@ -497,7 +497,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     'Modules':      None,
                     'Route':        None,
                 }
-                self.on_foot = False
+                self.state['on_foot'] = False
 
             elif event_type == 'Commander':
                 self.live = True  # First event in 3.0
@@ -530,7 +530,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     'Role':       None,
                 })
                 if self._RE_SHIP_ONFOOT.search(entry['Ship']):
-                    self.on_foot = True
+                    self.state['on_foot'] = True
 
             elif event_type == 'NewCommander':
                 self.cmdr = entry['Name']
@@ -628,12 +628,12 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             elif event_type == 'Embark':
                 # If we've embarked then we're no longer on the station.
                 self.station = None
-                self.on_foot = False
+                self.state['on_foot'] = False
 
             elif event_type == 'Disembark':
                 # We don't yet have a way, other than LoadGame+Location, to detect if we *are* on a station on-foot.
                 self.station = None
-                self.on_foot = True
+                self.state['on_foot'] = True
 
             elif event_type in ('Location', 'FSDJump', 'Docked', 'CarrierJump'):
                 if event_type in ('Location', 'CarrierJump'):
@@ -896,7 +896,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.stationservices = None
                 self.coordinates = None
                 self.systemaddress = None
-                self.on_foot = False
+                self.state['on_foot'] = False
 
             elif event_type == 'ChangeCrewRole':
                 self.state['Role'] = entry['Role']

--- a/monitor.py
+++ b/monitor.py
@@ -234,6 +234,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         self.coordinates = None
         self.systemaddress = None
         self.is_beta = False
+        self.on_foot = False
 
         if self.observed:
             logger.debug('self.observed: Calling unschedule_all()')
@@ -496,6 +497,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     'Modules':      None,
                     'Route':        None,
                 }
+                self.on_foot = False
 
             elif event_type == 'Commander':
                 self.live = True  # First event in 3.0
@@ -622,6 +624,12 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.station_marketid = None
                 self.stationtype = None
                 self.stationservices = None
+
+            elif event_type == 'Embark':
+                self.on_foot = False
+
+            elif event_type == 'Disembark':
+                self.on_foot = True
 
             elif event_type in ('Location', 'FSDJump', 'Docked', 'CarrierJump'):
                 if event_type in ('Location', 'CarrierJump'):
@@ -884,6 +892,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.stationservices = None
                 self.coordinates = None
                 self.systemaddress = None
+                self.on_foot = False
 
             elif event_type == 'ChangeCrewRole':
                 self.state['Role'] = entry['Role']
@@ -899,6 +908,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.stationservices = None
                 self.coordinates = None
                 self.systemaddress = None
+                # TODO: on_foot: Will we get an event after this to know ?
 
             elif event_type == 'Friends':
                 if entry['Status'] in ('Online', 'Added'):

--- a/outfitting.py
+++ b/outfitting.py
@@ -3,7 +3,7 @@ import pickle
 from os.path import join
 import time
 
-import companion
+import util_ships
 from config import config
 
 
@@ -521,7 +521,7 @@ def export(data, filename):
     h.write(header)
     for v in list(data['lastStarport'].get('modules', {}).values()):
         try:
-            m = lookup(v, companion.ship_map)
+            m = lookup(v, util_ships.ship_map)
             if m:
                 h.write('%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' % (rowheader, m['category'], m['name'], m.get('mount',''), m.get('guidance',''), m.get('ship',''), m['class'], m['rating'], m['id'], data['timestamp']))
         except AssertionError as e:

--- a/plugins/eddb.py
+++ b/plugins/eddb.py
@@ -103,7 +103,7 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
         logger.warning(f'Processing of event {entry["event"]} has been disabled: {ks.reason}')
         return
 
-    this.on_foot = state['on_foot']
+    this.on_foot = state['OnFoot']
     # Always update our system address even if we're not currently the provider for system or station, but dont update
     # on events that contain "future" data, such as FSDTarget
     if entry['event'] in ('Location', 'Docked', 'CarrierJump', 'FSDJump'):

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -22,6 +22,7 @@ import plug
 from companion import CAPIData, category_map
 from config import applongname, appversion_nobuild, config
 from EDMCLogging import get_main_logger
+from monitor import monitor
 from myNotebook import Frame
 from prefs import prefsVersion
 from ttkHyperlinkLabel import HyperlinkLabel
@@ -907,7 +908,8 @@ def cmdr_data(data: CAPIData, is_beta: bool) -> Optional[str]:  # noqa: CCR001
     :param is_beta: bool - True if this is a beta version of the Game.
     :return: str - Error message, or `None` if no errors.
     """
-    if data['commander'].get('docked') and config.get_int('output') & config.OUT_MKT_EDDN:
+    if (data['commander'].get('docked') or (monitor.on_foot and monitor.station)
+            and config.get_int('output') & config.OUT_MKT_EDDN):
         try:
             if this.marketId != data['lastStarport']['id']:
                 this.commodities = this.outfitting = this.shipyard = None

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -42,6 +42,8 @@ class This:
     """Holds module globals."""
 
     def __init__(self):
+        # Track if we're on foot
+        self.on_foot = False
         # Track location to add to Journal events
         self.systemaddress: Optional[str] = None
         self.coordinates: Optional[Tuple] = None
@@ -766,6 +768,7 @@ def journal_entry(  # noqa: C901, CCR001
 
         return filtered
 
+    this.on_foot = state['OnFoot']
     # Track location
     if entry['event'] in ('Location', 'FSDJump', 'Docked', 'CarrierJump'):
         if entry['event'] in ('Location', 'CarrierJump'):
@@ -908,7 +911,7 @@ def cmdr_data(data: CAPIData, is_beta: bool) -> Optional[str]:  # noqa: CCR001
     :param is_beta: bool - True if this is a beta version of the Game.
     :return: str - Error message, or `None` if no errors.
     """
-    if (data['commander'].get('docked') or (monitor.on_foot and monitor.station)
+    if (data['commander'].get('docked') or (this.on_foot and monitor.station)
             and config.get_int('output') & config.OUT_MKT_EDDN):
         try:
             if this.marketId != data['lastStarport']['id']:

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -350,7 +350,7 @@ def journal_entry(
         logger.warning(f'Handling of event {entry["event"]} has been disabled via killswitch: {ks.reason}')
         return
 
-    this.on_foot = state['on_foot']
+    this.on_foot = state['OnFoot']
     if entry['event'] in ('CarrierJump', 'FSDJump', 'Location', 'Docked'):
         logger.trace(f'''{entry["event"]}
 Commander: {cmdr}

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -55,6 +55,7 @@ this.system_population: Optional[int] = None
 this.station_link: tk.Tk = None
 this.station: Optional[str] = None
 this.station_marketid: Optional[int] = None  # Frontier MarketID
+this.on_foot = False
 STATION_UNDOCKED: str = '×'  # "Station" name to display when not docked = U+00D7
 __cleanup = str.maketrans({' ': None, '\n': None})
 IMG_KNOWN_B64 = """
@@ -349,6 +350,7 @@ def journal_entry(
         logger.warning(f'Handling of event {entry["event"]} has been disabled via killswitch: {ks.reason}')
         return
 
+    this.on_foot = state['on_foot']
     if entry['event'] in ('CarrierJump', 'FSDJump', 'Location', 'Docked'):
         logger.trace(f'''{entry["event"]}
 Commander: {cmdr}
@@ -370,6 +372,10 @@ entry: {entry!r}'''
         this.system_population = pop
 
     this.station = entry.get('StationName', this.station)
+    # on_foot station detection
+    if not this.station and entry['event'] == 'Location' and entry['BodyType'] == 'Station':
+        this.station = entry['Body']
+
     this.station_marketid = entry.get('MarketID', this.station)
     # We might pick up StationName in DockingRequested, make sure we clear it if leaving
     if entry['event'] in ('Undocked', 'FSDJump', 'SupercruiseEntry'):
@@ -479,7 +485,7 @@ def cmdr_data(data: CAPIData, is_beta: bool) -> None:
         this.system_link.update_idletasks()
 
     if config.get_str('station_provider') == 'EDSM':
-        if data['commander']['docked']:
+        if data['commander']['docked'] or this.on_foot and this.station:
             this.station_link['text'] = this.station
 
         elif data['lastStarport']['name'] and data['lastStarport']['name'] != "":

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -331,7 +331,7 @@ def journal_entry(
     elif (ks := killswitch.get_disabled(f'plugins.inara.journal.event.{entry["event"]}')).disabled:
         logger.warning(f'event {entry["event"]} processing has been disabled via killswitch: {ks.reason}')
 
-    this.on_foot = state['on_foot']
+    this.on_foot = state['OnFoot']
     event_name: str = entry['event']
     this.cmdr = cmdr
     this.FID = state['FID']

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -59,6 +59,7 @@ this.storedmodules: Optional[OrderedDictT[str, Any]] = None
 this.loadout: Optional[OrderedDictT[str, Any]] = None
 this.fleet: Optional[List[OrderedDictT[str, Any]]] = None
 this.shipswap: bool = False  # just swapped ship
+this.on_foot = False
 
 # last time we updated, if unset in config this is 0, which means an instant update
 LAST_UPDATE_CONF_KEY = 'inara_last_update'
@@ -330,6 +331,7 @@ def journal_entry(
     elif (ks := killswitch.get_disabled(f'plugins.inara.journal.event.{entry["event"]}')).disabled:
         logger.warning(f'event {entry["event"]} processing has been disabled via killswitch: {ks.reason}')
 
+    this.on_foot = state['on_foot']
     event_name: str = entry['event']
     this.cmdr = cmdr
     this.FID = state['FID']
@@ -380,6 +382,10 @@ def journal_entry(
         this.system_population = pop
 
     this.station = entry.get('StationName', this.station)
+    # on_foot station detection
+    if not this.station and entry['event'] == 'Location' and entry['BodyType'] == 'Station':
+        this.station = entry['Body']
+
     this.station_marketid = entry.get('MarketID', this.station_marketid) or this.station_marketid
     # We might pick up StationName in DockingRequested, make sure we clear it if leaving
     if event_name in ('Undocked', 'FSDJump', 'SupercruiseEntry'):
@@ -1069,7 +1075,7 @@ def cmdr_data(data: CAPIData, is_beta):
         this.system_link.update_idletasks()
 
     if config.get_str('station_provider') == 'Inara':
-        if data['commander']['docked']:
+        if data['commander']['docked'] or this.on_foot and this.station:
             this.station_link['text'] = this.station
 
         elif data['lastStarport']['name'] and data['lastStarport']['name'] != "":

--- a/shipyard.py
+++ b/shipyard.py
@@ -2,8 +2,8 @@
 
 import time
 
-from companion import ship_map
 from config import config
+from util_ships import ship_map
 
 
 def export(data, filename):

--- a/stats.py
+++ b/stats.py
@@ -8,9 +8,9 @@ from typing import TYPE_CHECKING, Any, AnyStr, Dict, List, NamedTuple, Optional,
 import companion
 import EDMCLogging
 import myNotebook as nb  # noqa: N813
-from companion import ship_map
 from l10n import Locale
 from monitor import monitor
+from util_ships import ship_map
 
 logger = EDMCLogging.get_main_logger()
 

--- a/util_ships.py
+++ b/util_ships.py
@@ -1,0 +1,63 @@
+"""Utility functions relating to ships."""
+
+
+ship_map = {
+    'adder':                        'Adder',
+    'anaconda':                     'Anaconda',
+    'asp':                          'Asp Explorer',
+    'asp_scout':                    'Asp Scout',
+    'belugaliner':                  'Beluga Liner',
+    'cobramkiii':                   'Cobra MkIII',
+    'cobramkiv':                    'Cobra MkIV',
+    'clipper':                      'Panther Clipper',
+    'cutter':                       'Imperial Cutter',
+    'diamondback':                  'Diamondback Scout',
+    'diamondbackxl':                'Diamondback Explorer',
+    'dolphin':                      'Dolphin',
+    'eagle':                        'Eagle',
+    'empire_courier':               'Imperial Courier',
+    'empire_eagle':                 'Imperial Eagle',
+    'empire_fighter':               'Imperial Fighter',
+    'empire_trader':                'Imperial Clipper',
+    'federation_corvette':          'Federal Corvette',
+    'federation_dropship':          'Federal Dropship',
+    'federation_dropship_mkii':     'Federal Assault Ship',
+    'federation_gunship':           'Federal Gunship',
+    'federation_fighter':           'F63 Condor',
+    'ferdelance':                   'Fer-de-Lance',
+    'hauler':                       'Hauler',
+    'independant_trader':           'Keelback',
+    'independent_fighter':          'Taipan Fighter',
+    'krait_mkii':                   'Krait MkII',
+    'krait_light':                  'Krait Phantom',
+    'mamba':                        'Mamba',
+    'orca':                         'Orca',
+    'python':                       'Python',
+    'scout':                        'Taipan Fighter',
+    'sidewinder':                   'Sidewinder',
+    'testbuggy':                    'Scarab',
+    'type6':                        'Type-6 Transporter',
+    'type7':                        'Type-7 Transporter',
+    'type9':                        'Type-9 Heavy',
+    'type9_military':               'Type-10 Defender',
+    'typex':                        'Alliance Chieftain',
+    'typex_2':                      'Alliance Crusader',
+    'typex_3':                      'Alliance Challenger',
+    'viper':                        'Viper MkIII',
+    'viper_mkiv':                   'Viper MkIV',
+    'vulture':                      'Vulture',
+}
+
+
+def ship_file_name(ship_name: str, ship_type: str) -> str:
+    """Return a ship name suitable for a filename."""
+    name = str(ship_name or ship_map.get(ship_type.lower(), ship_type)).strip()
+    if name.endswith('.'):
+        name = name[:-2]
+
+    if name.lower() in ('con', 'prn', 'aux', 'nul',
+                        'com0', 'com2', 'com3', 'com4', 'com5', 'com6', 'com7', 'com8', 'com9',
+                        'lpt0', 'lpt2', 'lpt3', 'lpt4', 'lpt5', 'lpt6', 'lpt7', 'lpt8', 'lpt9'):
+        name = name + '_'
+
+    return name.translate({ord(x): u'_' for x in ('\-1', '<', '>', ':', '"', '/', '\\', '|', '?', '*')})

--- a/util_ships.py
+++ b/util_ships.py
@@ -60,4 +60,4 @@ def ship_file_name(ship_name: str, ship_type: str) -> str:
                         'lpt0', 'lpt2', 'lpt3', 'lpt4', 'lpt5', 'lpt6', 'lpt7', 'lpt8', 'lpt9'):
         name = name + '_'
 
-    return name.translate({ord(x): u'_' for x in ('\-1', '<', '>', ':', '"', '/', '\\', '|', '?', '*')})
+    return name.translate({ord(x): u'_' for x in ('\0', '<', '>', ':', '"', '/', '\\', '|', '?', '*')})


### PR DESCRIPTION
This introduces a new monitor state variable `on_foot`.

Currently this will only be true when you login at a station.  There's only `Disembark` when you get off a shuttle at one, with no new `Location`/`Docked` event to fill in the necessary data to check against CAPI data.