### PR TITLE
EDMarketConnector.py: Move chdir as early as possible

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -6,6 +6,7 @@ import argparse
 import html
 import json
 import locale
+import pathlib
 import re
 import sys
 import webbrowser
@@ -26,6 +27,11 @@ if getattr(sys, 'frozen', False):
         # Allow executable to be invoked from any cwd
         environ['TCL_LIBRARY'] = join(dirname(sys.path[0]), 'lib', 'tcl')
         environ['TK_LIBRARY'] = join(dirname(sys.path[0]), 'lib', 'tk')
+
+else:
+    # We still want to *try* to have CWD be where the main script is, even if
+    # not frozen.
+    chdir(pathlib.Path(__file__).parent)
 
 from constants import applongname, appname, protocolhandler_redirect
 

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -16,6 +16,17 @@ from sys import platform
 from time import localtime, strftime, time
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Tuple
 
+# Have this as early as possible for people running EDMarketConnector.exe
+# from cmd.exe or a bat file or similar.  Else they might not be in the correct
+# place for things like config.py reading .gitversion
+if getattr(sys, 'frozen', False):
+    # Under py2exe sys.path[0] is the executable name
+    if platform == 'win32':
+        chdir(dirname(sys.path[0]))
+        # Allow executable to be invoked from any cwd
+        environ['TCL_LIBRARY'] = join(dirname(sys.path[0]), 'lib', 'tcl')
+        environ['TK_LIBRARY'] = join(dirname(sys.path[0]), 'lib', 'tk')
+
 from constants import applongname, appname, protocolhandler_redirect
 
 # config will now cause an appname logger to be set up, so we need the
@@ -235,14 +246,6 @@ if TYPE_CHECKING:
     def _(x: str) -> str:
         """Fake the l10n translation functions for typing."""
         return x
-
-if getattr(sys, 'frozen', False):
-    # Under py2exe sys.path[0] is the executable name
-    if platform == 'win32':
-        chdir(dirname(sys.path[0]))
-        # Allow executable to be invoked from any cwd
-        environ['TCL_LIBRARY'] = join(dirname(sys.path[0]), 'lib', 'tcl')
-        environ['TK_LIBRARY'] = join(dirname(sys.path[0]), 'lib', 'tk')
 
 import tkinter as tk
 import tkinter.filedialog

--- a/config.py
+++ b/config.py
@@ -134,10 +134,8 @@ def appversion() -> semantic_version.Version:
     """
     if getattr(sys, 'frozen', False):
         # Running frozen, so we should have a .gitversion file
-        with open(GITVERSION_FILE, 'r', encoding='utf-8') as gitv:
+        with open(pathlib.Path(sys.path[0]).parent / GITVERSION_FILE, 'r', encoding='utf-8') as gitv:
             shorthash = gitv.read()
-
-        # TODO: Check if there was already a build meta data in static_appversion ?
 
     else:
         # Running from source

--- a/config.py
+++ b/config.py
@@ -134,6 +134,7 @@ def appversion() -> semantic_version.Version:
     """
     if getattr(sys, 'frozen', False):
         # Running frozen, so we should have a .gitversion file
+        # Yes, .parent because if frozen we're inside library.zip
         with open(pathlib.Path(sys.path[0]).parent / GITVERSION_FILE, 'r', encoding='utf-8') as gitv:
             shorthash = gitv.read()
 


### PR DESCRIPTION
We need the config.py read of .gitversion to be from the right place.

However, should this actually be gated purely on frozen?  Sure, for the specific check we have right now, but we do need cwd to be correct for other things.  Plugin loading is basing it off the parent of `__file__`, and this chdir ought to do the same.