### PR TITLE
Ensure status text not stuck when on foot

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -779,8 +779,9 @@ class AppWindow(object):
                 self.status['text'] = _("Who are you?!")  # Shouldn't happen
 
             elif (not data.get('lastSystem', {}).get('name')
-                  or (data['commander'].get('docked')
-                      and not data.get('lastStarport', {}).get('name'))):  # Only care if docked
+                  or (data['commander'].get('docked') or monitor.state['OnFoot']
+                      and not data.get('lastStarport', {}).get('name'))
+                  or (monitor.state['OnFoot'] and data['lastStarport']['name'] != monitor.station)):
                 self.status['text'] = _("Where are you?!")  # Shouldn't happen
 
             elif not data.get('ship', {}).get('name') or not data.get('ship', {}).get('modules'):

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -753,8 +753,8 @@ class AppWindow(object):
 
         if not retrying:
             if time() < self.holdofftime:  # Was invoked by key while in cooldown
-                self.status['text'] = ''
                 if play_sound and (self.holdofftime - time()) < companion.holdoff * 0.75:
+                    self.status['text'] = ''
                     hotkeymgr.play_bad()  # Don't play sound in first few seconds to prevent repeats
 
                 return

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -780,7 +780,7 @@ class AppWindow(object):
                 err = self.status['text'] = _("Who are you?!")  # Shouldn't happen
 
             elif (not data.get('lastSystem', {}).get('name')
-                  or (data['commander'].get('docked') or monitor.state['OnFoot']
+                  or (data['commander'].get('docked')
                       and not data.get('lastStarport', {}).get('name'))):
                 err = self.status['text'] = _("Where are you?!")  # Shouldn't happen
 


### PR DESCRIPTION
Initially I was looking into why, on Alpha, you got stuck on 'Fetching data...' if hitting Update button when in a taxi.

This turned into then also tracking down why 'Last updated at: ' would disappear when logging into Alpga, quitting, and then logging into Live.