### PR TITLE
Add support for all ShipLocker and BackPack related events

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -107,6 +107,9 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         self.systemaddress: Optional[int] = None
         self.started: Optional[int] = None  # Timestamp of the LoadGame event
 
+        self.__init_state()
+
+    def __init_state(self) -> None:
         # Cmdr state shared with EDSM and plugins
         # If you change anything here update PLUGINS.md documentation!
         self.state: Dict = {
@@ -476,34 +479,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.coordinates = None
                 self.systemaddress = None
                 self.started = None
-                self.state = {
-                    'Captain':      None,
-                    'Cargo':        defaultdict(int),
-                    'Credits':      None,
-                    'FID':          None,
-                    'Horizons':     None,
-                    'Loan':         None,
-                    'Raw':          defaultdict(int),
-                    'Manufactured': defaultdict(int),
-                    'Encoded':      defaultdict(int),
-                    'Component':    defaultdict(int),
-                    'Engineers':    {},
-                    'Rank':         {},
-                    'Reputation':   {},
-                    'Statistics':   {},
-                    'Role':         None,
-                    'Friends':      set(),
-                    'ShipID':       None,
-                    'ShipIdent':    None,
-                    'ShipName':     None,
-                    'ShipType':     None,
-                    'HullValue':    None,
-                    'ModulesValue': None,
-                    'Rebuy':        None,
-                    'Modules':      None,
-                    'Route':        None,
-                }
-                self.state['OnFoot'] = False
+                self.__init_state()
 
             elif event_type == 'Commander':
                 self.live = True  # First event in 3.0

--- a/monitor.py
+++ b/monitor.py
@@ -803,6 +803,14 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     else:
                         logger.warning(f'TransferMicroResources with unexpected Direction {mr["Direction"]=}: {mr=}')
 
+                # Paranoia check to see if anything has gone negative.
+                # As of Odyssey Alpha Phase 1 Hotfix 2 keeping track of BackPack
+                # materials is impossible when used/picked up anyway.
+                for c in self.state['BackPack']:
+                    for m in self.state['BackPack'][c]:
+                        if self.state['BackPack'][c][m] < 0:
+                            self.state['BackPack'][c][m] = 0
+
             elif event_type == 'NavRoute':
                 # Added in ED 3.7 - multi-hop route details in NavRoute.json
                 with open(join(self.currentdir, 'NavRoute.json'), 'rb') as rf:  # type: ignore

--- a/monitor.py
+++ b/monitor.py
@@ -717,7 +717,11 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.state['Component'] = defaultdict(int)
                 self.state['Consumable'] = defaultdict(int)
                 self.state['Item'] = defaultdict(int)
-                # TODO: Assume backpack is empty?
+                # TODO: Really we need a full BackPackMaterials event at the same time.
+                #       In lieu of that, empty the backpack.  This will explicitly
+                #       be wrong if Cmdr relogs at a Settlement with anything in
+                #       backpack.  We can't track when they use/pick up items
+                #       anyway (Odyssey Alpha Phase 1 Hotfix 2).
                 self.state['BackPack']['Component'] = defaultdict(int)
                 self.state['BackPack']['Consumable'] = defaultdict(int)
                 self.state['BackPack']['Item'] = defaultdict(int)

--- a/monitor.py
+++ b/monitor.py
@@ -707,6 +707,21 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
                 self.state['Cargo'].update({self.canonicalise(x['Name']): x['Count'] for x in clean})
 
+            elif event_type == 'ShipLockerMaterials':
+                # This event has the current totals, so drop any current data
+                self.state['Component'] = defaultdict(int)
+                self.state['Consumable'] = defaultdict(int)
+                self.state['Item'] = defaultdict(int)
+
+                clean_components = self.coalesce_cargo(entry['Components'])
+                self.state['Component'].update({self.canonicalise(x['Name']): x['Count'] for x in clean_components})
+
+                clean_consumables = self.coalesce_cargo(entry['Consumables'])
+                self.state['Consumable'].update({self.canonicalise(x['Name']): x['Count'] for x in clean_consumables})
+
+                clean_items = self.coalesce_cargo(entry['Items'])
+                self.state['Item'].update({self.canonicalise(x['Name']): x['Count'] for x in clean_items})
+
             elif event_type == 'NavRoute':
                 # Added in ED 3.7 - multi-hop route details in NavRoute.json
                 with open(join(self.currentdir, 'NavRoute.json'), 'rb') as rf:  # type: ignore

--- a/monitor.py
+++ b/monitor.py
@@ -782,6 +782,23 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 name = self.canonicalise(entry['Received'])
                 self.state[category][name] += entry['Count']
 
+            elif event_type == 'TransferMicroResources':
+                # Moving Odyssey MicroResources between ShipLocker and BackPack
+                for mr in entry['Transfers']:
+                    category = self.category(mr['Category'])
+                    name = self.canonicalise(mr['Name'])
+
+                    if mr['Direction'] == 'ToShipLocker':
+                        self.state[category][name] += mr['Count']
+                        self.state['BackPack'][category][name] -= mr['Count']
+
+                    elif mr['Direction'] == 'ToBackpack':
+                        self.state[category][name] -= mr['Count']
+                        self.state['BackPack'][category][name] += mr['Count']
+
+                    else:
+                        logger.warning(f'TransferMicroResources with unexpected Direction {mr["Direction"]=}: {mr=}')
+
             elif event_type == 'NavRoute':
                 # Added in ED 3.7 - multi-hop route details in NavRoute.json
                 with open(join(self.currentdir, 'NavRoute.json'), 'rb') as rf:  # type: ignore

--- a/monitor.py
+++ b/monitor.py
@@ -122,7 +122,6 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             'Raw':          defaultdict(int),
             'Manufactured': defaultdict(int),
             'Encoded':      defaultdict(int),
-            'Component':    defaultdict(int),  # Odyssey materials
             'Engineers':    {},
             'Rank':         {},
             'Reputation':   {},
@@ -139,7 +138,10 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             'Modules':      None,
             'CargoJSON':    None,  # The raw data from the last time cargo.json was read
             'Route':        None,  # Last plotted route from Route.json file
-            'OnFoot':      False,  # Whether we think you're on-foot
+            'OnFoot':       False,  # Whether we think you're on-foot
+            'Component':    defaultdict(int),  # Odyssey Components in Ship Locker
+            'Items':        defaultdict(int),  # Odyssey Items in Ship Locker
+            'Consumables':  defaultdict(int),  # Odyssey Consumables in Ship Locker
         }
 
     def start(self, root: 'tkinter.Tk') -> bool:  # noqa: CCR001

--- a/monitor.py
+++ b/monitor.py
@@ -139,9 +139,14 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             'CargoJSON':    None,  # The raw data from the last time cargo.json was read
             'Route':        None,  # Last plotted route from Route.json file
             'OnFoot':       False,  # Whether we think you're on-foot
-            'Component':    defaultdict(int),  # Odyssey Components in Ship Locker
-            'Items':        defaultdict(int),  # Odyssey Items in Ship Locker
-            'Consumables':  defaultdict(int),  # Odyssey Consumables in Ship Locker
+            'Component':    defaultdict(int),    # Odyssey Components in Ship Locker
+            'Item':         defaultdict(int),    # Odyssey Items in Ship Locker
+            'Consumable':   defaultdict(int),    # Odyssey Consumables in Ship Locker
+            'BackPack':     {                    # Odyssey BackPack contents
+                'Component':  defaultdict(int),  # BackPack Components
+                'Consumable': defaultdict(int),  # BackPack Consumables
+                'Item':       defaultdict(int),  # BackPack Items
+            },
         }
 
     def start(self, root: 'tkinter.Tk') -> bool:  # noqa: CCR001
@@ -714,13 +719,40 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.state['Item'] = defaultdict(int)
 
                 clean_components = self.coalesce_cargo(entry['Components'])
-                self.state['Component'].update({self.canonicalise(x['Name']): x['Count'] for x in clean_components})
+                self.state['Component'].update(
+                    {self.canonicalise(x['Name']): x['Count'] for x in clean_components}
+                )
 
                 clean_consumables = self.coalesce_cargo(entry['Consumables'])
-                self.state['Consumable'].update({self.canonicalise(x['Name']): x['Count'] for x in clean_consumables})
+                self.state['Consumable'].update(
+                    {self.canonicalise(x['Name']): x['Count'] for x in clean_consumables}
+                )
 
                 clean_items = self.coalesce_cargo(entry['Items'])
-                self.state['Item'].update({self.canonicalise(x['Name']): x['Count'] for x in clean_items})
+                self.state['Item'].update(
+                    {self.canonicalise(x['Name']): x['Count'] for x in clean_items}
+                )
+
+            elif event_type == 'BackPackMaterials':
+                # Assume this reflects the current state when written
+                self.state['BackPack']['Component'] = defaultdict(int)
+                self.state['BackPack']['Consumable'] = defaultdict(int)
+                self.state['BackPack']['Item'] = defaultdict(int)
+
+                clean_components = self.coalesce_cargo(entry['Components'])
+                self.state['BackPack']['Component'].update(
+                    {self.canonicalise(x['Name']): x['Count'] for x in clean_components}
+                )
+
+                clean_consumables = self.coalesce_cargo(entry['Consumables'])
+                self.state['BackPack']['Consumable'].update(
+                    {self.canonicalise(x['Name']): x['Count'] for x in clean_consumables}
+                )
+
+                clean_items = self.coalesce_cargo(entry['Items'])
+                self.state['BackPack']['Item'].update(
+                    {self.canonicalise(x['Name']): x['Count'] for x in clean_items}
+                )
 
             elif event_type == 'NavRoute':
                 # Added in ED 3.7 - multi-hop route details in NavRoute.json

--- a/monitor.py
+++ b/monitor.py
@@ -757,7 +757,18 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             elif event_type == 'BuyMicroResources':
                 # Buying from a Pioneer Supplies, goes directly to ShipLocker.
                 # One event per Item, not an array.
-                self.state[entry['Category']][entry['Name']] += entry['Count']
+                category = self.category(entry['Category'])
+                name = self.canonicalise(entry['Name'])
+                self.state[category][name] += entry['Count']
+
+            elif event_type == 'SellMicroResources':
+                # Selling to a Bar Tender on-foot.
+                # One event per whole sale, so it's an array.
+                for mr in entry['MicroResources']:
+                    category = self.category(mr['Category'])
+                    name = self.canonicalise(mr['Name'])
+
+                    self.state[category][name] -= mr['Count']
 
             elif event_type == 'NavRoute':
                 # Added in ED 3.7 - multi-hop route details in NavRoute.json

--- a/monitor.py
+++ b/monitor.py
@@ -717,6 +717,10 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.state['Component'] = defaultdict(int)
                 self.state['Consumable'] = defaultdict(int)
                 self.state['Item'] = defaultdict(int)
+                # TODO: Assume backpack is empty?
+                self.state['BackPack']['Component'] = defaultdict(int)
+                self.state['BackPack']['Consumable'] = defaultdict(int)
+                self.state['BackPack']['Item'] = defaultdict(int)
 
                 clean_components = self.coalesce_cargo(entry['Components'])
                 self.state['Component'].update(

--- a/monitor.py
+++ b/monitor.py
@@ -767,8 +767,20 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 for mr in entry['MicroResources']:
                     category = self.category(mr['Category'])
                     name = self.canonicalise(mr['Name'])
-
                     self.state[category][name] -= mr['Count']
+
+            elif event_type == 'TradeMicroResources':
+                # Trading some MicroResources for another at a Bar Tender
+                # 'Offered' is what we traded away
+                for offer in entry['Offered']:
+                    category = self.category(offer['Category'])
+                    name = self.canonicalise(offer['Name'])
+                    self.state[category][name] -= offer['Count']
+
+                # For a single item name received
+                category = self.category(entry['Category'])
+                name = self.canonicalise(entry['Received'])
+                self.state[category][name] += entry['Count']
 
             elif event_type == 'NavRoute':
                 # Added in ED 3.7 - multi-hop route details in NavRoute.json

--- a/monitor.py
+++ b/monitor.py
@@ -139,13 +139,15 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             'CargoJSON':    None,  # The raw data from the last time cargo.json was read
             'Route':        None,  # Last plotted route from Route.json file
             'OnFoot':       False,  # Whether we think you're on-foot
-            'Component':    defaultdict(int),    # Odyssey Components in Ship Locker
-            'Item':         defaultdict(int),    # Odyssey Items in Ship Locker
-            'Consumable':   defaultdict(int),    # Odyssey Consumables in Ship Locker
-            'BackPack':     {                    # Odyssey BackPack contents
-                'Component':  defaultdict(int),  # BackPack Components
-                'Consumable': defaultdict(int),  # BackPack Consumables
-                'Item':       defaultdict(int),  # BackPack Items
+            'Component':    defaultdict(int),      # Odyssey Components in Ship Locker
+            'Item':         defaultdict(int),      # Odyssey Items in Ship Locker
+            'Consumable':   defaultdict(int),      # Odyssey Consumables in Ship Locker
+            'Data':         defaultdict(int),      # Odyssey Data in Ship Locker
+            'BackPack':     {                      # Odyssey BackPack contents
+                'Component':  defaultdict(int),    # BackPack Components
+                'Consumable': defaultdict(int),    # BackPack Consumables
+                'Item':       defaultdict(int),    # BackPack Items
+                'Data':         defaultdict(int),  # Backpack Data
             },
         }
 

--- a/monitor.py
+++ b/monitor.py
@@ -754,6 +754,11 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     {self.canonicalise(x['Name']): x['Count'] for x in clean_items}
                 )
 
+            elif event_type == 'BuyMicroResources':
+                # Buying from a Pioneer Supplies, goes directly to ShipLocker.
+                # One event per Item, not an array.
+                self.state[entry['Category']][entry['Name']] += entry['Count']
+
             elif event_type == 'NavRoute':
                 # Added in ED 3.7 - multi-hop route details in NavRoute.json
                 with open(join(self.currentdir, 'NavRoute.json'), 'rb') as rf:  # type: ignore


### PR DESCRIPTION
ShipLocker is where items not currently with you in your BackPack are stored.

There are three categories: 'Component', 'Consumable', and 'Item'.  Those in the ShipLocker are stored directly under those names in monitor.state.  Those in the BackPack are stored as keys of monitor.state['BackPack'].

There are some assumptions about some events only interacting with ShipLocker inventory, not BackPack.  Will test this.