### PR TITLE
Inara: Don't send a setCommanderReputationMajorFaction if we have no Reputations

### DIFF
--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -410,14 +410,16 @@ def journal_entry(
                     ]
                 )
 
-                new_add_event(
-                    'setCommanderReputationMajorFaction',
-                    entry['timestamp'],
-                    [
-                        {'majorfactionName': k.lower(), 'majorfactionReputation': v / 100.0}
-                        for k, v in state['Reputation'].items() if v is not None
-                    ]
-                )
+                # Don't send the API call with no values.
+                if state['Reputation']:
+                    new_add_event(
+                        'setCommanderReputationMajorFaction',
+                        entry['timestamp'],
+                        [
+                            {'majorfactionName': k.lower(), 'majorfactionReputation': v / 100.0}
+                            for k, v in state['Reputation'].items() if v is not None
+                        ]
+                    )
 
                 if state['Engineers']:  # Not populated < 3.3
                     to_send: List[Mapping[str, Any]] = []


### PR DESCRIPTION
When you're on a fresh character you have no reputations yet, so avoid causing an Inara API error, including status line text.