### PR TITLE
Don't try to generate a shipyard link if we have no known loadout.

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -831,6 +831,13 @@ class AppWindow(object):
                     monitor.state['ShipID'] = data['ship']['id']
                     monitor.state['ShipType'] = data['ship']['name'].lower()
 
+                    if not monitor.state['Modules']:
+                        self.ship.configure(state=tk.DISABLED)
+
+                # We might have disabled this in the conditional above.
+                if monitor.state['Modules']:
+                    self.ship.configure(state=True)
+
                 if data['commander'].get('credits') is not None:
                     monitor.state['Credits'] = data['commander']['credits']
                     monitor.state['Loan'] = data['commander'].get('debt', 0)
@@ -938,7 +945,14 @@ class AppWindow(object):
                 if not ship_text:
                     ship_text = ''
 
-                self.ship.configure(text=ship_text, url=self.shipyard_url)
+                # Ensure the ship type/name text is clickable, if it should be.
+                if monitor.state['Modules']:
+                    ship_state = True
+
+                else:
+                    ship_state = tk.DISABLED
+
+                self.ship.configure(text=ship_text, url=self.shipyard_url, state=ship_state)
 
             else:
                 self.cmdr['text'] = ''

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -1076,16 +1076,20 @@ class AppWindow(object):
 
     def shipyard_url(self, shipname: str) -> str:
         """Despatch a ship URL to the configured handler."""
+        if not (loadout := monitor.ship()):
+            logger.warning('No ship loadout, aborting.')
+            return ''
+
         if not bool(config.get_int("use_alt_shipyard_open")):
             return plug.invoke(config.get_str('shipyard_provider'),
                                'EDSY',
                                'shipyard_url',
-                               monitor.ship(),
+                               loadout,
                                monitor.is_beta)
 
         # Avoid file length limits if possible
         provider = config.get_str('shipyard_provider', default='EDSY')
-        target = plug.invoke(provider, 'EDSY', 'shipyard_url', monitor.ship(), monitor.is_beta)
+        target = plug.invoke(provider, 'EDSY', 'shipyard_url', loadout, monitor.is_beta)
         file_name = join(config.app_dir_path, "last_shipyard.html")
 
         with open(file_name, 'w') as f:


### PR DESCRIPTION
This is currently the case on Odyssey Alpha Phase 1 when logging in on-foot.  There's no Journal 'Loadout' event, but the CAPI update does let us know we have a Sidewinder active.  But `monitor.state['Modules']` is None.

I then applied extra paranoia to both Journal 'Loadout' processing and the CAPI retrieval of data to ensure this ttkHyperlinkLabel is always in the correct state.  So, yes, this means the shipyard provider will never be callable in this state now, but let's leave the paranoia check there anyway.