### PR TITLE
monitor.py: Initialise EDLogs self.systempopulation

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -563,6 +563,9 @@ running. In this case you won't receive initial events such as "LoadGame",
 "Rank", "Location", etc. However the `state` dictionary will reflect the
 cumulative effect of these missed events.
 
+**NB: Any of the values in this might be `None` if the Cmdr has loaded into
+Arena (CQC) from the Main Menu.**
+
 Similarly, a special "ShutDown" entry is sent when the game stops writing
 to the Journal without writing a "Shutdown" event.
 This might happen, for example, when the game client crashes.

--- a/monitor.py
+++ b/monitor.py
@@ -105,6 +105,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         self.stationtype: Optional[str] = None
         self.coordinates: Optional[Tuple[float, float, float]] = None
         self.systemaddress: Optional[int] = None
+        self.systempopulation: Optional[int] = None
         self.started: Optional[int] = None  # Timestamp of the LoadGame event
 
         self.__init_state()


### PR DESCRIPTION
This is the *one* field that wasn't always initialised.