### PR TITLE
EDMarketConnector: Add CL arg to force use of edmc:// protocol

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -90,6 +90,11 @@ if __name__ == '__main__':  # noqa: C901
                         action='store_true'
                         )
 
+    parser.add_argument('--force-edmc-protocol',
+                        help='Force use of the edmc:// protocol handler.  Error if not on Windows',
+                        action='store_true',
+                        )
+
     parser.add_argument('edmc',
                         help='Callback from Frontier Auth',
                         nargs='*'

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -85,15 +85,16 @@ if __name__ == '__main__':  # noqa: C901
                         action='store_true'
                         )
 
-    parser.add_argument('--force-localserver-for-auth',
-                        help='Force EDMC to use a localhost webserver for Frontier Auth callback',
-                        action='store_true'
-                        )
+    auth_options = parser.add_mutually_exclusive_group(required=False)
+    auth_options.add_argument('--force-localserver-for-auth',
+                              help='Force EDMC to use a localhost webserver for Frontier Auth callback',
+                              action='store_true'
+                              )
 
-    parser.add_argument('--force-edmc-protocol',
-                        help='Force use of the edmc:// protocol handler.  Error if not on Windows',
-                        action='store_true',
-                        )
+    auth_options.add_argument('--force-edmc-protocol',
+                              help='Force use of the edmc:// protocol handler.  Error if not on Windows',
+                              action='store_true',
+                              )
 
     parser.add_argument('edmc',
                         help='Callback from Frontier Auth',

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -111,6 +111,15 @@ if __name__ == '__main__':  # noqa: C901
     if args.force_localserver_for_auth:
         config.set_auth_force_localserver()
 
+    if args.force_edmc_protocol:
+        if sys.platform == 'win32':
+            config.set_auth_force_edmc_protocol()
+
+        else:
+            print("--force-edmc-protocol is only valid on Windows")
+            parser.print_help()
+            exit(1)
+
     def handle_edmc_callback_or_foregrounding() -> None:  # noqa: CCR001
         """Handle any edmc:// auth callback, else foreground existing window."""
         logger.trace('Begin...')

--- a/config.py
+++ b/config.py
@@ -182,6 +182,7 @@ class AbstractConfig(abc.ABC):
 
     __in_shutdown = False  # Is the application currently shutting down ?
     __auth_force_localserver = False  # Should we use localhost for auth callback ?
+    __auth_force_edmc_protocol = False  # Should we force edmc:// protocol ?
 
     def __init__(self) -> None:
         self.home_path = pathlib.Path.home()
@@ -211,6 +212,19 @@ class AbstractConfig(abc.ABC):
         :return: bool - True if we should use localhost web server.
         """
         return self.__auth_force_localserver
+
+    def set_auth_force_edmc_protocol(self):
+        """Set flag to force use of localhost web server for Frontier Auth callback."""
+        self.__auth_force_edmc_protocol = True
+
+    @property
+    def auth_force_edmc_protocol(self) -> bool:
+        """
+        Determine if use of localhost is forced for Frontier Auth callback.
+
+        :return: bool - True if we should use localhost web server.
+        """
+        return self.__auth_force_edmc_protocol
 
     @property
     def app_dir(self) -> str:

--- a/protocol.py
+++ b/protocol.py
@@ -113,7 +113,13 @@ if sys.platform == 'darwin' and getattr(sys, 'frozen', False):  # noqa: C901 # i
             protocolhandler.master.after(DarwinProtocolHandler.POLL, protocolhandler.poll)  # type: ignore
 
 
-elif sys.platform == 'win32' and getattr(sys, 'frozen', False) and not is_wine and not config.auth_force_localserver:
+elif (config.auth_force_edmc_protocol
+      or (
+              sys.platform == 'win32'
+              and getattr(sys, 'frozen', False)
+              and not is_wine
+              and not config.auth_force_localserver
+      )):
     # spell-checker: words HBRUSH HICON WPARAM wstring WNDCLASS HMENU HGLOBAL
     from ctypes import windll  # type: ignore
     from ctypes import POINTER, WINFUNCTYPE, Structure, byref, c_long, c_void_p, create_unicode_buffer, wstring_at
@@ -415,7 +421,14 @@ protocolhandler: GenericProtocolHandler
 if sys.platform == 'darwin' and getattr(sys, 'frozen', False):
     protocolhandler = DarwinProtocolHandler()  # pyright: reportUnboundVariable=false
 
-elif sys.platform == 'win32' and getattr(sys, 'frozen', False) and not is_wine and not config.auth_force_localserver:
+elif (
+        sys.platform == 'win32'
+        and config.auth_force_edmc_protocol or (
+            getattr(sys, 'frozen', False)
+            and not is_wine
+            and not config.auth_force_localserver
+        )
+        ):
     protocolhandler = WindowsProtocolHandler()
 else:
     protocolhandler = LinuxProtocolHandler()


### PR DESCRIPTION
It's useful to have the edmc:// protocol used on Windows when debugging, if, you know, you're trying to debug the edmc:// code.