### PR TITLE
Be more paranoid about companion.Session.station() queries

### DIFF
--- a/companion.py
+++ b/companion.py
@@ -604,7 +604,17 @@ class Session(object):
         return data
 
     def station(self) -> CAPIData:  # noqa: CCR001
-        """Perform CAPI /profile endpoint query for station data."""
+        """
+        Perform CAPI quer(y|ies) for station data.
+
+        A /profile query is performed to check that we are docked (or on foot)
+        and the station name and marketid match the prior Docked event.
+        If they do match, and the services list says they're present, also
+        retrieve CAPI market and/or shipyard/outfitting data and merge into
+        the /profile data.
+
+        :return: Possibly augmented CAPI data.
+        """
         data = self.query(URL_QUERY)
         if 'commander' not in data:
             logger.error('No commander in returned data')
@@ -613,17 +623,33 @@ class Session(object):
         if not data['commander'].get('docked') and not monitor.state['OnFoot']:
             return data
 
-        services = data['lastStarport'].get('services', {})
+        # Sanity checks in case data isn't as we expect, and maybe 'docked' flag
+        # is also lagging.
+        if (last_starport := data.get('lastStarport')) is None:
+            logger.error("No lastStarport in data!")
+            return data
+
+        if ((last_starport_name := last_starport.get('name')) is None
+                or last_starport_name == ''):
+            # This could well be valid if you've been out exploring for a long
+            # time.
+            logger.warning("No lastStarport name!")
+            return data
+
+        services = last_starport.get('services', {})
         if not isinstance(services, dict):
-            # This happens if you're in-ship in-space and force an Update
+            # Odyssey Alpha Phase 3 4.0.0.20 has been observed having
+            # this be an empty list when you've jumped to another system
+            # and not yet docked.  As opposed to no services key at all
+            # or an empty dict.
             logger.error(f'services is "{type(services)}", not dict !')
             if __debug__:
                 self.dump_capi_data(data)
 
+            # Set an empty dict so as to not have to retest below.
             services = {}
 
-        last_starport_name = data['lastStarport']['name']
-        last_starport_id = int(data['lastStarport']['id'])
+        last_starport_id = int(last_starport.get('id'))
 
         if services.get('commodities'):
             marketdata = self.query(URL_MARKET)


### PR DESCRIPTION
This could just be the Odyssey PTS CAPI being crap... but what's been observed is the commander->docked flag not properly updating.  This then leads to companion.Session.station() thinking we're still docked when we're not.  That then has the knock-on effect of trying to use lastStarport data when we normally wouldn't in this situation.

If not docked and you've jumped to a new system the lastStarport data is mostly empty, including 'services' being an empty array, instead of the usual dictionary.

So, add paranoia checks, even if this is just PTS CAPI being crap.