### PR TITLE
Ensure that Section exists on linuxconf

### DIFF
--- a/config.py
+++ b/config.py
@@ -836,14 +836,10 @@ class LinuxConfig(AbstractConfig):
         self.filename.parent.mkdir(exist_ok=True, parents=True)
 
         self.config: Optional[ConfigParser] = ConfigParser(comment_prefixes=('#',), interpolation=None)
+        self.config.read(self.filename)  # read() ignores files that dont exist
 
-        try:
-            self.config.read(self.filename)
-        except Exception as e:
-            logger.debug(f'Error occurred while reading in file. Assuming that we are creating a new one: {e}')
-            self.config.add_section(self.SECTION)
-
-        # Ensure that our section exists
+        # Ensure that our section exists. This is here because configparser will happily create files for us, but it
+        # does not magically create sections
         try:
             self.config[self.SECTION].get("this_does_not_exist", fallback=None)
         except KeyError:

--- a/config.py
+++ b/config.py
@@ -843,6 +843,16 @@ class LinuxConfig(AbstractConfig):
             logger.debug(f'Error occurred while reading in file. Assuming that we are creating a new one: {e}')
             self.config.add_section(self.SECTION)
 
+        # Ensure that our section exists
+        try:
+            self.config[self.SECTION].get("this_does_not_exist", fallback=None)
+        except KeyError:
+            logger.info("Config section not found. Backing up existing file (if any) and readding a section header")
+            if self.filename.exists():
+                (self.filename.parent / f'{appname}.ini.backup').write_bytes(self.filename.read_bytes())
+
+            self.config.add_section(self.SECTION)
+
         if (outdir := self.get_str('outdir')) is None or not pathlib.Path(outdir).is_dir():
             self.set('outdir', self.home)
 


### PR DESCRIPTION
When starting EDMC for the first time, linuxconf creates the required
file automatically but does _not_ create our config section. This causes
a keyerror on any access to config.

Simple solution, test that the section exists, if it doesnt, create it
(and backup any existing file beforehand)