### PR TITLE
EDMCLogging: No fn.__qualname__ ?  Just use `name`.

### DIFF
--- a/EDMCLogging.py
+++ b/EDMCLogging.py
@@ -363,6 +363,9 @@ class EDMCContextFilter(logging.Filter):
                                 else:
                                     caller_qualname = f"<property {name} on {class_name}>"
 
+                            elif not hasattr(fn, '__qualname__'):
+                                caller_qualname = name
+
                             elif hasattr(fn, '__qualname__') and fn.__qualname__:
                                 caller_qualname = fn.__qualname__
 

--- a/tests/EDMCLogging.py/test_logging_classvar.py
+++ b/tests/EDMCLogging.py/test_logging_classvar.py
@@ -1,3 +1,4 @@
+"""Test that logging works correctly from a class-definition caller."""
 import sys
 
 sys.path += "../"  # Dont ask me why for this one it breaks, it just does.
@@ -15,17 +16,17 @@ class ClassVarLogger:
     """Test class with logger attached."""
 
     @classmethod
-    def set_logger(cls, logger):
+    def set_logger(cls, logger) -> None:
         """Set the passed logger onto the _class_."""
-        ClassVarLogger.logger = logger
+        ClassVarLogger.logger = logger  # type: ignore
 
 
-def log_stuff(msg: str):
-    """Wrapper logger func."""
+def log_stuff(msg: str) -> None:
+    """Wrap logging in another function."""
     ClassVarLogger.logger.debug(msg)  # type: ignore # its there
 
 
-def test_class_logger(caplog: 'LogCaptureFixture'):
+def test_class_logger(caplog: 'LogCaptureFixture') -> None:
     """
     Test that logging from a class variable doesn't explode.
 


### PR DESCRIPTION
Logging being from a global "class definition" function means no `__qualname__` on the function object we find.  So just use `name`.  The `module` bit should take care of the entire thing otherwise being what we want.  Certainly better than *nothing* for `%(qualname)s`.