### PR TITLE
Fix BackPack event support to actually work.

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -599,6 +599,7 @@ Content of `state` (updated to the current journal entry):
 | `Consumable`   |           `dict`            | 'Consumable' MicroResources in Odyssey, `int` count each.                                                       |
 | `Data`         |           `dict`            | 'Data' MicroResources in Odyssey, `int` count each.                                                             |
 | `BackPack`     |           `dict`            | `dict` of Odyssey MicroResources in backpack.                                                                   |
+| `BackpackJSON` |           `dict`            | Content of Backpack.json as of last read.                                                                       |
 | `SuitCurrent`  |           `dict`            | CAPI-returned data of currently worn suit.  NB: May be `None` if no data.                                       |
 | `Suits`        |           `dict`[1]         | CAPI-returned data of owned suits.  NB: May be `None` if no data.                                               |
 | `SuitLoadoutCurrent` |     `dict`            | CAPI-returned data of current Suit Loadout.  NB: May be `None` if no data.                                      |

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -432,6 +432,11 @@ def journal_entry(
     elif entry['event'] == 'NavBeaconScan':
         this.navbeaconscan = entry['NumBodies']
 
+    elif entry['event'] == 'BackPack':
+        # Use the stored file contents, not the empty journal event
+        if state['BackpackJSON']:
+            entry = state['BackpackJSON']
+
     # Send interesting events to EDSM
     if (
         config.get_int('edsm_out') and not is_beta and not this.multicrew and credentials(cmdr) and


### PR DESCRIPTION
* Surprise!  The new event is `BackPack`, not `Backpack`, although the filename *is* `Backpack.json`.
* Store the loaded JSON dict in `monitor.state['BackpackJSON']`.  That `p` is lower case to match with the filename, not the event name.
* Document this in PLUGINS.md.

Unless EDSM is telling us to discard this we should now be sending it.