### PR TITLE
Don't spam a stacktrace on requests.ConnectionError

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -979,6 +979,11 @@ class AppWindow(object):
             companion.session.invalidate()
             self.login()
 
+        except companion.ServerConnectionError as e:
+            logger.debug(f'Exception while contacting server: {e}')
+            err = self.status['text'] = str(e)
+            play_bad = True
+
         except Exception as e:  # Including CredentialsError, ServerError
             logger.debug('"other" exception', exc_info=e)
             err = self.status['text'] = str(e)

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -980,7 +980,7 @@ class AppWindow(object):
             self.login()
 
         except companion.ServerConnectionError as e:
-            logger.debug(f'Exception while contacting server: {e}')
+            logger.warning(f'Exception while contacting server: {e}')
             err = self.status['text'] = str(e)
             play_bad = True
 

--- a/companion.py
+++ b/companion.py
@@ -17,6 +17,7 @@ import random
 import time
 import urllib.parse
 import webbrowser
+import socket
 from builtins import object, range, str
 from email.utils import parsedate
 from os.path import join
@@ -168,6 +169,10 @@ class ServerError(Exception):
         self.args = args
         if not args:
             self.args = (_("Error: Frontier CAPI didn't respond"),)
+
+
+class ServerConnectionError(ServerError):
+    """Exception class for CAPI connection errors."""
 
 
 class ServerLagging(Exception):
@@ -536,6 +541,10 @@ class Session(object):
         try:
             logger.trace('Trying...')
             r = self.session.get(self.server + endpoint, timeout=timeout)  # type: ignore
+
+        except requests.ConnectionError as e:
+            logger.debug(f'Unable to resolve name for CAPI: {e} (for request: {endpoint})')
+            raise ServerConnectionError(f'Unable to connect to endpoint {endpoint}') from e
 
         except Exception as e:
             logger.debug('Attempting GET', exc_info=e)

--- a/companion.py
+++ b/companion.py
@@ -17,7 +17,6 @@ import random
 import time
 import urllib.parse
 import webbrowser
-import socket
 from builtins import object, range, str
 from email.utils import parsedate
 from os.path import join

--- a/companion.py
+++ b/companion.py
@@ -542,7 +542,7 @@ class Session(object):
             r = self.session.get(self.server + endpoint, timeout=timeout)  # type: ignore
 
         except requests.ConnectionError as e:
-            logger.debug(f'Unable to resolve name for CAPI: {e} (for request: {endpoint})')
+            logger.warning(f'Unable to resolve name for CAPI: {e} (for request: {endpoint})')
             raise ServerConnectionError(f'Unable to connect to endpoint {endpoint}') from e
 
         except Exception as e:


### PR DESCRIPTION
ConnectionErrors are expected and not something we can fix. The
exception handler that was catching these previously is a catchall
intended to stop EDMC as a whole from crashing from something
unexpected.

Closes #1082