### PR TITLE
Ensure UI 'Suit' line is shown when it should be, and not otherwise

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -620,6 +620,11 @@ class AppWindow(object):
 
     def update_suit_text(self) -> None:
         """Update the suit text for current type and loadout."""
+        if not monitor.state['Odyssey']:
+            # Odyssey not detected, no text should be set so it will hide
+            self.suit['text'] = ''
+            return
+
         if (suit := monitor.state.get('SuitCurrent')) is None:
             self.suit['text'] = f'<{_("Unknown")}>'
             return

--- a/monitor.py
+++ b/monitor.py
@@ -1076,27 +1076,17 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.store_suitloadout_from_event(entry)
 
             elif event_type == 'CreateSuitLoadout':
-                # We know we won't have data for this new one
-                # Parameters:
-                #     • SuitID
-                #     • SuitName
-                #     • LoadoutID
-                #     • LoadoutName
-                # alpha4:
-                # { "timestamp":"2021-04-29T09:37:08Z", "event":"CreateSuitLoadout", "SuitID":1698364940285172,
-                # "SuitName":"tacticalsuit_class1", "SuitName_Localised":"Dominator Suit", "LoadoutID":4293000001,
-                # "LoadoutName":"Dom L/K/K", "Modules":[
-                # {
-                #   "SlotName":"PrimaryWeapon1",
-                #   "SuitModuleID":1698364962722310,
-                #   "ModuleName":"wpn_m_assaultrifle_laser_fauto",
-                #   "ModuleName_Localised":"TK Aphelion"
-                # },
-                # { "SlotName":"PrimaryWeapon2",
-                # "SuitModuleID":1698364956302993, "ModuleName":"wpn_m_assaultrifle_kinetic_fauto",
-                # "ModuleName_Localised":"Karma AR-50" }, { "SlotName":"SecondaryWeapon",
-                # "SuitModuleID":1698292655291850, "ModuleName":"wpn_s_pistol_kinetic_sauto",
-                # "ModuleName_Localised":"Karma P-15" } ] }
+                # 4.0.0.101
+                #
+                # { "timestamp":"2021-05-21T11:13:15Z", "event":"CreateSuitLoadout", "SuitID":1700216165682989,
+                # "SuitName":"tacticalsuit_class1", "SuitName_Localised":"Dominator Suit", "LoadoutID":4293000004,
+                # "LoadoutName":"P/P/K", "Modules":[ { "SlotName":"PrimaryWeapon1", "SuitModuleID":1700216182854765,
+                # "ModuleName":"wpn_m_assaultrifle_plasma_fauto", "ModuleName_Localised":"Manticore Oppressor" },
+                # { "SlotName":"PrimaryWeapon2", "SuitModuleID":1700216190363340,
+                # "ModuleName":"wpn_m_shotgun_plasma_doublebarrel", "ModuleName_Localised":"Manticore Intimidator" },
+                # { "SlotName":"SecondaryWeapon", "SuitModuleID":1700217869872834,
+                # "ModuleName":"wpn_s_pistol_kinetic_sauto", "ModuleName_Localised":"Karma P-15" } ] }
+                #
                 new_loadout = {
                     'loadoutSlotId': self.suit_loadout_id_from_loadoutid(entry['LoadoutID']),
                     'suit': {

--- a/monitor.py
+++ b/monitor.py
@@ -1087,6 +1087,19 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.state['SuitCurrent'] = new_suit
 
             elif event_type == 'SwitchSuitLoadout':
+                # 4.0.0.101
+                #
+                # { "timestamp":"2021-05-21T10:39:43Z", "event":"SwitchSuitLoadout",
+                #   "SuitID":1700217809818876, "SuitName":"utilitysuit_class1",
+                #   "SuitName_Localised":"Maverick Suit", "LoadoutID":4293000002,
+                #   "LoadoutName":"K/P", "Modules":[ { "SlotName":"PrimaryWeapon1",
+                #   "SuitModuleID":1700217863661544,
+                #   "ModuleName":"wpn_m_assaultrifle_kinetic_fauto",
+                #   "ModuleName_Localised":"Karma AR-50" },
+                #   { "SlotName":"SecondaryWeapon", "SuitModuleID":1700216180036986,
+                #   "ModuleName":"wpn_s_pistol_plasma_charged",
+                #   "ModuleName_Localised":"Manticore Tormentor" } ] }
+                #
                 loadoutid = entry['LoadoutID']
                 new_slot = self.suit_loadout_id_from_loadoutid(loadoutid)
                 # If this application is run with the latest Journal showing such an event then we won't

--- a/monitor.py
+++ b/monitor.py
@@ -1058,7 +1058,8 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             # when disembarking from a ship, with the same info as found in "CreateSuitLoadout"
             elif event_type == 'SuitLoadout':
                 suit_slotid, suitloadout_slotid = self.suitloadout_store_from_event(entry)
-                self.suit_and_loadout_setcurrent(suit_slotid, suitloadout_slotid)
+                if not self.suit_and_loadout_setcurrent(suit_slotid, suitloadout_slotid):
+                    logger.error(f"Event was: {entry}")
 
             elif event_type == 'SwitchSuitLoadout':
                 # 4.0.0.101
@@ -1075,7 +1076,8 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 #   "ModuleName_Localised":"Manticore Tormentor" } ] }
                 #
                 suit_slotid, suitloadout_slotid = self.suitloadout_store_from_event(entry)
-                self.suit_and_loadout_setcurrent(suit_slotid, suitloadout_slotid)
+                if not self.suit_and_loadout_setcurrent(suit_slotid, suitloadout_slotid):
+                    logger.error(f"Event was: {entry}")
 
             elif event_type == 'CreateSuitLoadout':
                 # 4.0.0.101
@@ -1636,6 +1638,8 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             self.state['SuitLoadoutCurrent'] = self.state['SuitLoadouts'][str_suitloadoutid]
             return True
 
+        logger.error(f"Tried to set a suit and suitloadout where we didn't know about both: {suit_slotid=}, "
+                     f"{str_suitloadoutid=}")
         return False
 
     # TODO: *This* will need refactoring and a proper validation infrastructure


### PR DESCRIPTION
And also change the displayed suit "type (loadout)" in reaction to journal events.

I *think* things are now working as best they can in abscence of CAPI data, and we should always use these journal events anyway.