### PR TITLE
Suits: Ensure a succinct and sane name for Suits in UI

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -629,7 +629,7 @@ class AppWindow(object):
             self.suit['text'] = f'<{_("Unknown")}>'
             return
 
-        suitname = suit['locName']
+        suitname = suit['edmcName']
 
         if (suitloadout := monitor.state.get('SuitLoadoutCurrent')) is None:
             self.suit['text'] = ''
@@ -927,7 +927,7 @@ class AppWindow(object):
                 if monitor.state.get('SuitCurrent') is not None:
                     if (loadout := data.get('loadout')) is not None:
                         if (suit := loadout.get('suit')) is not None:
-                            if (suitname := suit.get('locName')) is not None:
+                            if (suitname := suit.get('edmcName')) is not None:
                                 # We've been paranoid about loadout->suit->suitname, now just assume loadouts is there
                                 loadout_name = index_possibly_sparse_list(
                                     data['loadouts'], loadout['loadoutSlotId']

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -655,6 +655,11 @@ this is **NOT** the same as the return from
 because CAPI data doesn't (didn't always?) have an indication of Horizons or
 not.
 
+New in version 5.0.3:
+
+The `Suits` members have an additional key:value pair `edmcName` which is our
+preferred name for display on the UI, for the in-use game language.
+
 ##### Synthetic Events
 
 A special "StartUp" entry is sent if EDMC is started while the game is already

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -566,6 +566,9 @@ Content of `state` (updated to the current journal entry):
 
 | Field          |            Type             | Description                                                                                                     |
 | :------------- | :-------------------------: | :-------------------------------------------------------------------------------------------------------------- |
+| `GameLanguage` |       `Optional[str]`       | `language` value from `Fileheader` event.                                                                       |
+| `GameVersion`  |       `Optional[str]`       | `version` value from `Fileheader` event.                                                                        |
+| `GameBuild`    |       `Optional[str]`       | `build` value from `Fileheader` event.                                                                          |
 | `Captain`      |       `Optional[str]`       | Name of the commander who's crew you're on, if any                                                              |
 | `Cargo`        |           `dict`            | Current cargo. Note that this will be totals, and any mission specific duplicates will be counted together      |
 | `CargoJSON`    |           `dict`            | content of cargo.json as of last read.                                                                          |

--- a/config.py
+++ b/config.py
@@ -96,7 +96,7 @@ def git_shorthash_from_head() -> str:
     """
     Determine short hash for current git HEAD.
 
-    Includes -DIRTY if any changes have been made from HEAD
+    Includes +DIRTY if any changes have been made from HEAD
 
     :return: str - None if we couldn't determine the short hash.
     """
@@ -122,7 +122,7 @@ def git_shorthash_from_head() -> str:
         with contextlib.suppress(Exception):
             result = subprocess.run('git diff --stat HEAD'.split(), capture_output=True)
             if len(result.stdout) > 0:
-                shorthash += '-WORKING-DIR-IS-DIRTY'
+                shorthash += '+DIRTY'
 
             if len(result.stderr) > 0:
                 logger.warning(f'Data from git on stderr:\n{str(result.stderr)}')

--- a/edmc_data.py
+++ b/edmc_data.py
@@ -499,20 +499,28 @@ ship_name_map = {
 # Odyssey Suit Names
 edmc_suit_shortnames = {
     'Flight Suit':      'Flight',     # EN
-    'Flug-Anzug':       'Flug',       # DE
-    'Летный комбинезон': 'Летный',    # RU
-    'Traje de vuelo':   'de vuelo',   # ES
     'Artemis Suit':     'Artemis',    # EN
-    'Artemis-Anzug':    'Artemis',    # DE
-    'Traje Artemis':    'Artemis',    # ES
-    'Комбинезон Artemis': 'Artemis',  # RU
     'Dominator Suit':   'Dominator',  # EN
-    'Dominator-Anzug':  'Dominator',  # DE
-    'Traje Dominator':  'Dominator',  # ES
-    'Комбинезон Dominator': 'Dominator',  # RU
     'Maverick Suit':    'Maverick',   # EN
+
+    'Flug-Anzug':       'Flug',       # DE
+    'Artemis-Anzug':    'Artemis',    # DE
+    'Dominator-Anzug':  'Dominator',  # DE
     'Maverick-Anzug':   'Maverick',   # DE
+
+    'Traje de vuelo':   'de vuelo',   # ES
+    'Traje Artemis':    'Artemis',    # ES
+    'Traje Dominator':  'Dominator',  # ES
     'Traje Maverick':   'Maverick',   # ES
+
+    'Combinaison de vol': 'de vol',  # FR
+    'Combinaison Artemis': 'Artemis',  # FR
+    'Combinaison Dominator': 'Dominator',  # FR
+    'Combinaison Maverick': 'Maverick',  # FR
+
+    'Летный комбинезон': 'Летный',    # RU
+    'Комбинезон Artemis': 'Artemis',  # RU
+    'Комбинезон Dominator': 'Dominator',  # RU
     'Комбинезон Maverick':  'Maverick',  # RU
 }
 
@@ -525,17 +533,23 @@ edmc_suit_symbol_localised = {
         'tacticalsuit':    'Dominator Suit',
         'utilitysuit':     'Maverick Suit',
     },
-    r'Russian\RU': {
-        'flightsuit':      'Летный комбинезон',
-        'explorationsuit': 'Комбинезон Artemis',
-        'tacticalsuit':    'Комбинезон Dominator',
-        'utilitysuit':     'Комбинезон Maverick',
-    },
     r'German\DE': {
         'flightsuit':      'Flug-Anzug',
         'explorationsuit': 'Artemis-Anzug',
         'tacticalsuit':    'Dominator-Anzug',
         'utilitysuit':     'Maverick-Anzug',
+    },
+    r'French\FR': {
+        'flightsuit':      'Combinaison de vol',
+        'explorationsuit': 'Combinaison Artemis',
+        'tacticalsuit':    'Combinaison Dominator',
+        'utilitysuit':     'Combinaison Maverick',
+    },
+    r'Russian\RU': {
+        'flightsuit':      'Летный комбинезон',
+        'explorationsuit': 'Комбинезон Artemis',
+        'tacticalsuit':    'Комбинезон Dominator',
+        'utilitysuit':     'Комбинезон Maverick',
     },
     r'Spanish\ES': {
         'flightsuit':      'Traje de vuelo',

--- a/edmc_data.py
+++ b/edmc_data.py
@@ -495,3 +495,18 @@ ship_name_map = {
     'viper_mkiv':                   'Viper MkIV',
     'vulture':                      'Vulture',
 }
+
+# Odyssey Suit Names
+edmc_suit_shortnames = {
+    'Artemis Suit':   'Artemis',
+    'Dominator Suit': 'Dominator',
+    'Flight Suit':    'Flight',
+    'Maverick Suit':  'Maverick',
+}
+
+edmc_suit_symbol_to_en = {
+    'explorationsuit': 'Artemis Suit',
+    'flightsuit':      'Flight Suit',
+    'tacticalsuit':    'Dominator Suit',
+    'utilitysuit':     'Maverick Suit',
+}

--- a/edmc_data.py
+++ b/edmc_data.py
@@ -500,16 +500,20 @@ ship_name_map = {
 edmc_suit_shortnames = {
     'Flight Suit':      'Flight',     # EN
     'Flug-Anzug':       'Flug',       # DE
+    'Летный комбинезон': 'Летный',    # RU
     'Traje de vuelo':   'de vuelo',   # ES
     'Artemis Suit':     'Artemis',    # EN
     'Artemis-Anzug':    'Artemis',    # DE
-    'Traje Artemis':    'Artemis',   # ES
+    'Traje Artemis':    'Artemis',    # ES
+    'Комбинезон Artemis': 'Artemis',  # RU
     'Dominator Suit':   'Dominator',  # EN
     'Dominator-Anzug':  'Dominator',  # DE
     'Traje Dominator':  'Dominator',  # ES
+    'Комбинезон Dominator': 'Dominator',  # RU
     'Maverick Suit':    'Maverick',   # EN
     'Maverick-Anzug':   'Maverick',   # DE
     'Traje Maverick':   'Maverick',   # ES
+    'Комбинезон Maverick':  'Maverick',  # RU
 }
 
 edmc_suit_symbol_localised = {
@@ -521,19 +525,12 @@ edmc_suit_symbol_localised = {
         'tacticalsuit':    'Dominator Suit',
         'utilitysuit':     'Maverick Suit',
     },
-    # r'Russian\RU': {
-    # { "timestamp":"2021-05-25T19:04:54Z", "event":"SwitchSuitLoadout", "SuitID":1700222635552764, "SuitName":"flightsuit", "SuitName_Localised":"Летный комбинезон", "LoadoutID":4293000000, "LoadoutName":"Снаряжение по умолчанию", "Modules":[ { "SlotName":"SecondaryWeapon", "SuitModuleID":1700222635552854, "ModuleName":"wpn_s_pistol_kinetic_sauto", "ModuleName_Localised":"Karma P-15" } ] }
-    # { "timestamp":"2021-05-25T19:04:58Z", "event":"SwitchSuitLoadout", "SuitID":1700399023825621, "SuitName":"tacticalsuit_class1", "SuitName_Localised":"Комбинезон Dominator", "LoadoutID":4293000001, "LoadoutName":"Боевой 1", "Modules":[ { "SlotName":"PrimaryWeapon1", "SuitModuleID":1700399051643021, "ModuleName":"wpn_m_sniper_plasma_charged", "ModuleName_Localised":"Manticore Executioner" }, { "SlotName":"PrimaryWeapon2", "SuitModuleID":1700399078090377, "ModuleName":"wpn_m_shotgun_plasma_doublebarrel", "ModuleName_Localised":"Manticore Intimidator" }, { "SlotName":"SecondaryWeapon", "SuitModuleID":1700222635552854, "ModuleName":"wpn_s_pistol_kinetic_sauto", "ModuleName_Localised":"Karma P-15" } ] }
-    # { "timestamp":"2021-05-25T19:05:02Z", "event":"SwitchSuitLoadout", "SuitID":1700575627706590, "SuitName":"tacticalsuit_class2", "SuitName_Localised":"$TacticalSuit_Class1_Name;", "LoadoutID":4293000002, "LoadoutName":"Снаряжение: 1", "Modules":[ { "SlotName":"PrimaryWeapon1", "SuitModuleID":1700575634697937, "ModuleName":"wpn_m_assaultrifle_plasma_fauto", "ModuleName_Localised":"Manticore Oppressor" }, { "SlotName":"PrimaryWeapon2", "SuitModuleID":1700399051643021, "ModuleName":"wpn_m_sniper_plasma_charged", "ModuleName_Localised":"Manticore Executioner" }, { "SlotName":"SecondaryWeapon", "SuitModuleID":1700222635552854, "ModuleName":"wpn_s_pistol_kinetic_sauto", "ModuleName_Localised":"Karma P-15" } ] }
-    # { "timestamp":"2021-05-25T19:05:05Z", "event":"SwitchSuitLoadout", "SuitID":1700563770964710, "SuitName":"utilitysuit_class1", "SuitName_Localised":"Комбинезон Maverick", "LoadoutID":4293000003, "LoadoutName":"ывы ", "Modules":[ { "SlotName":"PrimaryWeapon1", "SuitModuleID":1700399078090377, "ModuleName":"wpn_m_shotgun_plasma_doublebarrel", "ModuleName_Localised":"Manticore Intimidator" }, { "SlotName":"SecondaryWeapon", "SuitModuleID":1700222635552854, "ModuleName":"wpn_s_pistol_kinetic_sauto", "ModuleName_Localised":"Karma P-15" } ] }
-    # { "timestamp":"2021-05-25T19:05:07Z", "event":"SwitchSuitLoadout", "SuitID":1700571499909982, "SuitName":"explorationsuit_class2", "SuitName_Localised":"$ExplorationSuit_Class1_Name;", "LoadoutID":4293000004, "LoadoutName":"Снаряжение: 2", "Modules":[ { "SlotName":"PrimaryWeapon1", "SuitModuleID":1700399061224625, "ModuleName":"wpn_m_submachinegun_kinetic_fauto", "ModuleName_Localised":"Karma C-44" }, { "SlotName":"SecondaryWeapon", "SuitModuleID":1700222635552854, "ModuleName":"wpn_s_pistol_kinetic_sauto", "ModuleName_Localised":"Karma P-15" } ] }
-    # { "timestamp":"2021-05-25T19:05:18Z", "event":"SuitLoadout", "SuitID":1700571499909982, "SuitName":"explorationsuit_class2", "SuitName_Localised":"$ExplorationSuit_Class1_Name;", "LoadoutID":4293000004, "LoadoutName":"Снаряжение: 2", "Modules":[ { "SlotName":"PrimaryWeapon1", "SuitModuleID":1700399061224625, "ModuleName":"wpn_m_submachinegun_kinetic_fauto", "ModuleName_Localised":"Karma C-44" }, { "SlotName":"SecondaryWeapon", "SuitModuleID":1700222635552854, "ModuleName":"wpn_s_pistol_kinetic_sauto", "ModuleName_Localised":"Karma P-15" } ] }
-    # { "timestamp":"2021-05-25T19:05:18Z", "event":"BackPack" }
-    # { "timestamp":"2021-05-25T19:05:19Z", "event":"ReceiveText", "From":"Crown Prospect", "Message":"$STATION_NoFireZone_entered;", "Message_Localised":"Вы вошли в зону запрета огня", "Channel":"npc" }
-    # { "timestamp":"2021-05-25T19:05:32Z", "event":"BuySuit", "Name":"ExplorationSuit_Class1", "Name_Localised":"Комбинезон Artemis", "Price":150000, "SuitID":1700758324607786 }
-    # { "timestamp":"2021-05-25T19:05:47Z", "event":"Friends", "Status":"Online", "Name":"Automatic system" }
-    # { "timestamp":"2021-05-25T19:05:51Z", "event":"CreateSuitLoadout", "SuitID":1700758324607786, "SuitName":"explorationsuit_class1", "SuitName_Localised":"Комбинезон Artemis", "LoadoutID":4293000005, "LoadoutName":"Снаряжение: 3", "Modules":[  ] }
-    # { "timestamp":"2021-05-25T19:05:53Z", "event":"SwitchSuitLoadout", "SuitID":1700758324607786, "SuitName":"explorationsuit_class1", "SuitName_Localised":"Комбинезон Artemis", "LoadoutID":4293000005, "LoadoutName":"Снаряжение: 3", "Modules":[  ] }
+    r'Russian\RU': {
+        'flightsuit':      'Летный комбинезон',
+        'explorationsuit': 'Комбинезон Artemis',
+        'tacticalsuit':    'Комбинезон Dominator',
+        'utilitysuit':     'Комбинезон Maverick',
+    },
     r'German\DE': {
         'flightsuit':      'Flug-Anzug',
         'explorationsuit': 'Artemis-Anzug',

--- a/edmc_data.py
+++ b/edmc_data.py
@@ -498,20 +498,42 @@ ship_name_map = {
 
 # Odyssey Suit Names
 edmc_suit_shortnames = {
-    'Artemis Suit':   'Artemis',
-    'Dominator Suit': 'Dominator',
-    'Flight Suit':    'Flight',
-    'Maverick Suit':  'Maverick',
+    'Flight Suit':      'Flight',     # EN
+    'Flug-Anzug':       'Flug',       # DE
+    'Artemis Suit':     'Artemis',    # EN
+    'Artemis-Anzug':    'Artemis',    # DE
+    'Dominator Suit':   'Dominator',  # EN
+    'Dominator-Anzug':  'Dominator',  # DE
+    'Maverick Suit':    'Maverick',   # EN
+    'Maverick-Anzug':   'Maverick',   # DE
 }
 
 edmc_suit_symbol_localised = {
     # The key here should match what's seen in Fileheader 'language', but with
     # any in-file `\\` already unescaped to a single `\`.
     r'English\UK': {
-        'explorationsuit': 'Artemis Suit',
         'flightsuit':      'Flight Suit',
+        'explorationsuit': 'Artemis Suit',
         'tacticalsuit':    'Dominator Suit',
         'utilitysuit':     'Maverick Suit',
     },
     # r'Russian\RU': {
+    # { "timestamp":"2021-05-25T19:04:54Z", "event":"SwitchSuitLoadout", "SuitID":1700222635552764, "SuitName":"flightsuit", "SuitName_Localised":"Летный комбинезон", "LoadoutID":4293000000, "LoadoutName":"Снаряжение по умолчанию", "Modules":[ { "SlotName":"SecondaryWeapon", "SuitModuleID":1700222635552854, "ModuleName":"wpn_s_pistol_kinetic_sauto", "ModuleName_Localised":"Karma P-15" } ] }
+    # { "timestamp":"2021-05-25T19:04:58Z", "event":"SwitchSuitLoadout", "SuitID":1700399023825621, "SuitName":"tacticalsuit_class1", "SuitName_Localised":"Комбинезон Dominator", "LoadoutID":4293000001, "LoadoutName":"Боевой 1", "Modules":[ { "SlotName":"PrimaryWeapon1", "SuitModuleID":1700399051643021, "ModuleName":"wpn_m_sniper_plasma_charged", "ModuleName_Localised":"Manticore Executioner" }, { "SlotName":"PrimaryWeapon2", "SuitModuleID":1700399078090377, "ModuleName":"wpn_m_shotgun_plasma_doublebarrel", "ModuleName_Localised":"Manticore Intimidator" }, { "SlotName":"SecondaryWeapon", "SuitModuleID":1700222635552854, "ModuleName":"wpn_s_pistol_kinetic_sauto", "ModuleName_Localised":"Karma P-15" } ] }
+    # { "timestamp":"2021-05-25T19:05:02Z", "event":"SwitchSuitLoadout", "SuitID":1700575627706590, "SuitName":"tacticalsuit_class2", "SuitName_Localised":"$TacticalSuit_Class1_Name;", "LoadoutID":4293000002, "LoadoutName":"Снаряжение: 1", "Modules":[ { "SlotName":"PrimaryWeapon1", "SuitModuleID":1700575634697937, "ModuleName":"wpn_m_assaultrifle_plasma_fauto", "ModuleName_Localised":"Manticore Oppressor" }, { "SlotName":"PrimaryWeapon2", "SuitModuleID":1700399051643021, "ModuleName":"wpn_m_sniper_plasma_charged", "ModuleName_Localised":"Manticore Executioner" }, { "SlotName":"SecondaryWeapon", "SuitModuleID":1700222635552854, "ModuleName":"wpn_s_pistol_kinetic_sauto", "ModuleName_Localised":"Karma P-15" } ] }
+    # { "timestamp":"2021-05-25T19:05:05Z", "event":"SwitchSuitLoadout", "SuitID":1700563770964710, "SuitName":"utilitysuit_class1", "SuitName_Localised":"Комбинезон Maverick", "LoadoutID":4293000003, "LoadoutName":"ывы ", "Modules":[ { "SlotName":"PrimaryWeapon1", "SuitModuleID":1700399078090377, "ModuleName":"wpn_m_shotgun_plasma_doublebarrel", "ModuleName_Localised":"Manticore Intimidator" }, { "SlotName":"SecondaryWeapon", "SuitModuleID":1700222635552854, "ModuleName":"wpn_s_pistol_kinetic_sauto", "ModuleName_Localised":"Karma P-15" } ] }
+    # { "timestamp":"2021-05-25T19:05:07Z", "event":"SwitchSuitLoadout", "SuitID":1700571499909982, "SuitName":"explorationsuit_class2", "SuitName_Localised":"$ExplorationSuit_Class1_Name;", "LoadoutID":4293000004, "LoadoutName":"Снаряжение: 2", "Modules":[ { "SlotName":"PrimaryWeapon1", "SuitModuleID":1700399061224625, "ModuleName":"wpn_m_submachinegun_kinetic_fauto", "ModuleName_Localised":"Karma C-44" }, { "SlotName":"SecondaryWeapon", "SuitModuleID":1700222635552854, "ModuleName":"wpn_s_pistol_kinetic_sauto", "ModuleName_Localised":"Karma P-15" } ] }
+    # { "timestamp":"2021-05-25T19:05:18Z", "event":"SuitLoadout", "SuitID":1700571499909982, "SuitName":"explorationsuit_class2", "SuitName_Localised":"$ExplorationSuit_Class1_Name;", "LoadoutID":4293000004, "LoadoutName":"Снаряжение: 2", "Modules":[ { "SlotName":"PrimaryWeapon1", "SuitModuleID":1700399061224625, "ModuleName":"wpn_m_submachinegun_kinetic_fauto", "ModuleName_Localised":"Karma C-44" }, { "SlotName":"SecondaryWeapon", "SuitModuleID":1700222635552854, "ModuleName":"wpn_s_pistol_kinetic_sauto", "ModuleName_Localised":"Karma P-15" } ] }
+    # { "timestamp":"2021-05-25T19:05:18Z", "event":"BackPack" }
+    # { "timestamp":"2021-05-25T19:05:19Z", "event":"ReceiveText", "From":"Crown Prospect", "Message":"$STATION_NoFireZone_entered;", "Message_Localised":"Вы вошли в зону запрета огня", "Channel":"npc" }
+    # { "timestamp":"2021-05-25T19:05:32Z", "event":"BuySuit", "Name":"ExplorationSuit_Class1", "Name_Localised":"Комбинезон Artemis", "Price":150000, "SuitID":1700758324607786 }
+    # { "timestamp":"2021-05-25T19:05:47Z", "event":"Friends", "Status":"Online", "Name":"Automatic system" }
+    # { "timestamp":"2021-05-25T19:05:51Z", "event":"CreateSuitLoadout", "SuitID":1700758324607786, "SuitName":"explorationsuit_class1", "SuitName_Localised":"Комбинезон Artemis", "LoadoutID":4293000005, "LoadoutName":"Снаряжение: 3", "Modules":[  ] }
+    # { "timestamp":"2021-05-25T19:05:53Z", "event":"SwitchSuitLoadout", "SuitID":1700758324607786, "SuitName":"explorationsuit_class1", "SuitName_Localised":"Комбинезон Artemis", "LoadoutID":4293000005, "LoadoutName":"Снаряжение: 3", "Modules":[  ] }
+    r'German\DE': {
+        'flightsuit':      'Flug-Anzug',
+        'explorationsuit': 'Artemis-Anzug',
+        'tacticalsuit':    'Dominator-Anzug',
+        'utilitysuit':     'Maverick-Anzug',
+    },
 }

--- a/edmc_data.py
+++ b/edmc_data.py
@@ -498,30 +498,35 @@ ship_name_map = {
 
 # Odyssey Suit Names
 edmc_suit_shortnames = {
-    'Flight Suit':      'Flight',     # EN
-    'Artemis Suit':     'Artemis',    # EN
-    'Dominator Suit':   'Dominator',  # EN
-    'Maverick Suit':    'Maverick',   # EN
+    'Flight Suit':            'Flight',     # EN
+    'Artemis Suit':           'Artemis',    # EN
+    'Dominator Suit':         'Dominator',  # EN
+    'Maverick Suit':          'Maverick',   # EN
 
-    'Flug-Anzug':       'Flug',       # DE
-    'Artemis-Anzug':    'Artemis',    # DE
-    'Dominator-Anzug':  'Dominator',  # DE
-    'Maverick-Anzug':   'Maverick',   # DE
+    'Flug-Anzug':             'Flug',       # DE
+    'Artemis-Anzug':          'Artemis',    # DE
+    'Dominator-Anzug':        'Dominator',  # DE
+    'Maverick-Anzug':         'Maverick',   # DE
 
-    'Traje de vuelo':   'de vuelo',   # ES
-    'Traje Artemis':    'Artemis',    # ES
-    'Traje Dominator':  'Dominator',  # ES
-    'Traje Maverick':   'Maverick',   # ES
+    'Traje de vuelo':         'de vuelo',   # ES
+    'Traje Artemis':          'Artemis',    # ES
+    'Traje Dominator':        'Dominator',  # ES
+    'Traje Maverick':         'Maverick',   # ES
 
-    'Combinaison de vol': 'de vol',  # FR
-    'Combinaison Artemis': 'Artemis',  # FR
-    'Combinaison Dominator': 'Dominator',  # FR
-    'Combinaison Maverick': 'Maverick',  # FR
+    'Combinaison de vol':     'de vol',     # FR
+    'Combinaison Artemis':    'Artemis',    # FR
+    'Combinaison Dominator':  'Dominator',  # FR
+    'Combinaison Maverick':   'Maverick',   # FR
 
-    'Летный комбинезон': 'Летный',    # RU
-    'Комбинезон Artemis': 'Artemis',  # RU
-    'Комбинезон Dominator': 'Dominator',  # RU
-    'Комбинезон Maverick':  'Maverick',  # RU
+    'Traje voador':           'voador',     # PT-BR
+    'Traje Artemis':          'Artemis',    # PT-BR
+    'Traje Dominator':        'Dominator',  # PT-BR
+    'Traje Maverick':         'Maverick',   # PT-BR
+
+    'Летный комбинезон':      'Летный',     # RU
+    'Комбинезон Artemis':     'Artemis',    # RU
+    'Комбинезон Dominator':   'Dominator',  # RU
+    'Комбинезон Maverick':    'Maverick',   # RU
 }
 
 edmc_suit_symbol_localised = {
@@ -544,6 +549,12 @@ edmc_suit_symbol_localised = {
         'explorationsuit': 'Combinaison Artemis',
         'tacticalsuit':    'Combinaison Dominator',
         'utilitysuit':     'Combinaison Maverick',
+    },
+    r'Portuguese\BR': {
+        'flightsuit':      'Traje voador',
+        'explorationsuit': 'Traje Artemis',
+        'tacticalsuit':    'Traje Dominator',
+        'utilitysuit':     'Traje Maverick',
     },
     r'Russian\RU': {
         'flightsuit':      'Летный комбинезон',

--- a/edmc_data.py
+++ b/edmc_data.py
@@ -513,4 +513,5 @@ edmc_suit_symbol_localised = {
         'tacticalsuit':    'Dominator Suit',
         'utilitysuit':     'Maverick Suit',
     },
+    # r'Russian\RU': {
 }

--- a/edmc_data.py
+++ b/edmc_data.py
@@ -500,12 +500,16 @@ ship_name_map = {
 edmc_suit_shortnames = {
     'Flight Suit':      'Flight',     # EN
     'Flug-Anzug':       'Flug',       # DE
+    'Traje de vuelo':   'de vuelo',   # ES
     'Artemis Suit':     'Artemis',    # EN
     'Artemis-Anzug':    'Artemis',    # DE
+    'Traje Artemis':    'Artemis',   # ES
     'Dominator Suit':   'Dominator',  # EN
     'Dominator-Anzug':  'Dominator',  # DE
+    'Traje Dominator':  'Dominator',  # ES
     'Maverick Suit':    'Maverick',   # EN
     'Maverick-Anzug':   'Maverick',   # DE
+    'Traje Maverick':   'Maverick',   # ES
 }
 
 edmc_suit_symbol_localised = {
@@ -535,5 +539,11 @@ edmc_suit_symbol_localised = {
         'explorationsuit': 'Artemis-Anzug',
         'tacticalsuit':    'Dominator-Anzug',
         'utilitysuit':     'Maverick-Anzug',
+    },
+    r'Spanish\ES': {
+        'flightsuit':      'Traje de vuelo',
+        'explorationsuit': 'Traje Artemis',
+        'tacticalsuit':    'Traje Dominator',
+        'utilitysuit':     'Traje Maverick',
     },
 }

--- a/edmc_data.py
+++ b/edmc_data.py
@@ -519,9 +519,10 @@ edmc_suit_shortnames = {
     'Combinaison Maverick':   'Maverick',   # FR
 
     'Traje voador':           'voador',     # PT-BR
-    'Traje Artemis':          'Artemis',    # PT-BR
-    'Traje Dominator':        'Dominator',  # PT-BR
-    'Traje Maverick':         'Maverick',   # PT-BR
+    #  These are duplicates of the ES ones, but kept here for clarity
+    #  'Traje Artemis':          'Artemis',    # PT-BR
+    #  'Traje Dominator':        'Dominator',  # PT-BR
+    #  'Traje Maverick':         'Maverick',   # PT-BR
 
     'Летный комбинезон':      'Летный',     # RU
     'Комбинезон Artemis':     'Artemis',    # RU

--- a/edmc_data.py
+++ b/edmc_data.py
@@ -504,9 +504,13 @@ edmc_suit_shortnames = {
     'Maverick Suit':  'Maverick',
 }
 
-edmc_suit_symbol_to_en = {
-    'explorationsuit': 'Artemis Suit',
-    'flightsuit':      'Flight Suit',
-    'tacticalsuit':    'Dominator Suit',
-    'utilitysuit':     'Maverick Suit',
+edmc_suit_symbol_localised = {
+    # The key here should match what's seen in Fileheader 'language', but with
+    # any in-file `\\` already unescaped to a single `\`.
+    r'English\UK': {
+        'explorationsuit': 'Artemis Suit',
+        'flightsuit':      'Flight Suit',
+        'tacticalsuit':    'Dominator Suit',
+        'utilitysuit':     'Maverick Suit',
+    },
 }

--- a/monitor.py
+++ b/monitor.py
@@ -1135,10 +1135,12 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 # alpha4 :
                 # { "timestamp":"2021-04-29T09:03:37Z", "event":"BuySuit", "Name":"UtilitySuit_Class1",
                 # "Name_Localised":"Maverick Suit", "Price":150000, "SuitID":1698364934364699 }
+                loc_name = entry.get('Name_Localised', entry['Name'])
                 self.state['Suits'][entry['SuitID']] = {
                     'name':      entry['Name'],
-                    'locName':   entry.get('Name_Localised', entry['Name']),
-                    'id': None,  # Is this an FDev ID for suit type ?
+                    'locName':   loc_name,
+                    'edmcName':  self.suit_sane_name(loc_name),
+                    'id':        None,  # Is this an FDev ID for suit type ?
                     'suitId':    entry['SuitID'],
                     'slots':     [],
                 }

--- a/monitor.py
+++ b/monitor.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 import util_ships
 from config import config
-from edmc_data import edmc_suit_shortnames, edmc_suit_symbol_to_en
+from edmc_data import edmc_suit_shortnames, edmc_suit_symbol_localised
 from EDMCLogging import get_main_logger
 
 logger = get_main_logger()
@@ -501,9 +501,9 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.started = None
                 self.__init_state()
                 # In self.state as well, as that's what plugins get
-                self.stat['GameLanguage'] = entry['language']
-                self.stat['GameVersion'] = entry['gameversion']
-                self.stat['GameBuild'] = entry['build']
+                self.state['GameLanguage'] = entry['language']
+                self.state['GameVersion'] = entry['gameversion']
+                self.state['GameBuild'] = entry['build']
 
             elif event_type == 'Commander':
                 self.live = True  # First event in 3.0
@@ -1622,7 +1622,8 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             name = n
 
         # Now turn either of those into an English '<type> Suit' form
-        name = edmc_suit_symbol_to_en.get(name.lower(), name)
+        if loc_lookup := edmc_suit_symbol_localised.get(self.state['GameLanguage']):
+            name = loc_lookup.get(name.lower(), name)
 
         # Finally, map that to a form without the verbose ' Suit' on the end
         name = edmc_suit_shortnames.get(name, name)

--- a/monitor.py
+++ b/monitor.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
 import util_ships
 from config import config
+from edmc_data import edmc_suit_shortnames, edmc_suit_symbol_to_en
 from EDMCLogging import get_main_logger
 
 logger = get_main_logger()
@@ -1604,12 +1605,21 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         """
         # TODO: Localisation ?
         # Stage 1: Is it in `$<type>_Class<X>_Name;` form ?
-        if (m := re.fullmatch(r'^\$([^_]+)_Class([0-9]+)_Name$', name)):
+        if m := re.fullmatch(r'^\$([^_]+)_Class([0-9]+)_Name;$', name):
             n, c = m.group(1, 2)
             name = n
 
         # Stage 2: Is it in `<type>_class<x>` form ?
+        elif m := re.fullmatch(r'^([^_]+)_class([0-9]+)$', name):
+            n, c = m.group(1, 2)
+            name = n
+
+        # Now turn either of those into an English '<type> Suit' form
+        name = edmc_suit_symbol_to_en.get(name.lower(), name)
+
         # Stage 3: Is it in verbose `<type> Suit` form ?
+        name = edmc_suit_shortnames.get(name, name)
+
         return name
 
     def suitloadout_store_from_event(self, entry) -> Tuple[int, int]:

--- a/monitor.py
+++ b/monitor.py
@@ -1605,19 +1605,19 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         """
         # TODO: Localisation ?
         # Stage 1: Is it in `$<type>_Class<X>_Name;` form ?
-        if m := re.fullmatch(r'^\$([^_]+)_Class([0-9]+)_Name;$', name):
+        if m := re.fullmatch(r'(?i)^\$([^_]+)_Class([0-9]+)_Name;$', name):
             n, c = m.group(1, 2)
             name = n
 
         # Stage 2: Is it in `<type>_class<x>` form ?
-        elif m := re.fullmatch(r'^([^_]+)_class([0-9]+)$', name):
+        elif m := re.fullmatch(r'(?i)^([^_]+)_class([0-9]+)$', name):
             n, c = m.group(1, 2)
             name = n
 
         # Now turn either of those into an English '<type> Suit' form
         name = edmc_suit_symbol_to_en.get(name.lower(), name)
 
-        # Stage 3: Is it in verbose `<type> Suit` form ?
+        # Finally, map that to a form without the verbose ' Suit' on the end
         name = edmc_suit_shortnames.get(name, name)
 
         return name

--- a/monitor.py
+++ b/monitor.py
@@ -1603,6 +1603,13 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         :return: Our sane version of this suit's name.
         """
         # TODO: Localisation ?
+        # Stage 1: Is it in `$<type>_Class<X>_Name;` form ?
+        if (m := re.fullmatch(r'^\$([^_]+)_Class([0-9]+)_Name$', name)):
+            n, c = m.group(1, 2)
+            name = n
+
+        # Stage 2: Is it in `<type>_class<x>` form ?
+        # Stage 3: Is it in verbose `<type> Suit` form ?
         return name
 
     def suitloadout_store_from_event(self, entry) -> Tuple[int, int]:

--- a/monitor.py
+++ b/monitor.py
@@ -1600,7 +1600,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         # Check if this looks like a suit we already have stored, so as
         # to avoid 'bad' Journal localised names.
         suit = self.state['Suits'].get(f"{suitid}", None)
-        if not suit:
+        if suit is None:
             # Initial suit containing just the data that is then embedded in
             # the loadout
             suit = {

--- a/monitor.py
+++ b/monitor.py
@@ -115,6 +115,9 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         # Cmdr state shared with EDSM and plugins
         # If you change anything here update PLUGINS.md documentation!
         self.state: Dict = {
+            'GameLanguage':       None,  # From `Fileheader
+            'GameVersion':        None,  # From `Fileheader
+            'GameBuild':          None,  # From `Fileheader
             'Captain':            None,  # On a crew
             'Cargo':              defaultdict(int),
             'Credits':            None,
@@ -497,13 +500,15 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.systemaddress = None
                 self.started = None
                 self.__init_state()
+                # In self.state as well, as that's what plugins get
+                self.stat['GameLanguage'] = entry['language']
+                self.stat['GameVersion'] = entry['gameversion']
+                self.stat['GameBuild'] = entry['build']
 
             elif event_type == 'Commander':
                 self.live = True  # First event in 3.0
 
             elif event_type == 'LoadGame':
-                # alpha4
-                # Odyssey: bool
                 self.cmdr = entry['Commander']
                 # 'Open', 'Solo', 'Group', or None for CQC (and Training - but no LoadGame event)
                 self.mode = entry.get('GameMode')


### PR DESCRIPTION
The aim here is to use the well-localised CAPI-sourced names whenever we can.

Further work in this branch/PR will look at constructing a lookup table/regex to map the symbolic names to **English** readable names.