### PR TITLE
Suits: Set edmcName in suits from CAPI, and ensure displayed

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -983,6 +983,8 @@ class AppWindow(object):
         if play_sound and play_bad:
             hotkeymgr.play_bad()
 
+        self.update_suit_text()
+        self.suit_show_if_set()
         self.cooldown()
 
     def journal_event(self, event):  # noqa: C901, CCR001 # Currently not easily broken up.

--- a/companion.py
+++ b/companion.py
@@ -688,6 +688,9 @@ class Session(object):
         else:
             monitor.state['Suits'] = suits
 
+        # We need to be setting our edmcName for all suits
+        monitor.state['SuitCurrent']['edmcName'] = monitor.suit_sane_name(monitor.state['SuitCurrent']['locName'])
+
         if (suit_loadouts := data.get('loadouts')) is None:
             logger.warning('CAPI data had "suit" but no (suit) "loadouts"')
 

--- a/companion.py
+++ b/companion.py
@@ -689,7 +689,11 @@ class Session(object):
             monitor.state['Suits'] = suits
 
         # We need to be setting our edmcName for all suits
-        monitor.state['SuitCurrent']['edmcName'] = monitor.suit_sane_name(monitor.state['SuitCurrent']['locName'])
+        loc_name = monitor.state['SuitCurrent'].get('locName', monitor.state['SuitCurrent']['name'])
+        monitor.state['SuitCurrent']['edmcName'] = monitor.suit_sane_name(loc_name)
+        for s in monitor.state['Suits']:
+            loc_name = monitor.state['Suits'][s].get('locName', monitor.state['Suits'][s]['name'])
+            monitor.state['Suits'][s]['edmcName'] = monitor.suit_sane_name(loc_name)
 
         if (suit_loadouts := data.get('loadouts')) is None:
             logger.warning('CAPI data had "suit" but no (suit) "loadouts"')


### PR DESCRIPTION
I failed to ensure we were also doing this for the CAPI-sourced data.  If you login in-ship, and never change loadout or go on foot, it will stay showing as '<Unknown>' (which it starts as correctly, as without CAPI data if you're only in ship there's no Journal events for suits either).