### PR TITLE
Update INARA plugin to support new odyssey API endpoints

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -160,6 +160,8 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             'Suits':              {},
             'SuitLoadoutCurrent': None,
             'SuitLoadouts':       {},
+            'Taxi':               None,  # True whenever we are _in_ a taxi. ie, this is reset on Disembark etc.
+            'Dropship':           None,  # Best effort as to whether or not the above taxi is a dropship.
         }
 
     def start(self, root: 'tkinter.Tk') -> bool:  # noqa: CCR001
@@ -535,6 +537,8 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     'Reputation': {},
                     'Statistics': {},
                     'Role':       None,
+                    'Taxi':       None,
+                    'Dropship':   None,
                 })
                 if entry.get('Ship') is not None and self._RE_SHIP_ONFOOT.search(entry['Ship']):
                     self.state['OnFoot'] = True
@@ -668,6 +672,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     self.station = entry.get('StationName', '')
 
                 self.state['OnFoot'] = False
+                self.state['Taxi'] = entry['Taxi']
 
             elif event_type == 'Disembark':
                 # This event is logged when the player steps out of a ship or SRV
@@ -694,16 +699,25 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     self.station = None
 
                 self.state['OnFoot'] = True
+                if self.state['Taxi'] is not None and not self.state['Taxi']:
+                    logger.warning('Disembarked from a taxi but we didn\'t know we were in a taxi?')
+
+                self.state['Taxi'] = False
+                self.state['Dropship'] = False
 
             elif event_type == 'DropshipDeploy':
                 # We're definitely on-foot now
                 self.state['OnFoot'] = True
+                self.state['Taxi'] = False
+                self.state['Dropship'] = False
 
             elif event_type == 'Docked':
                 self.station = entry.get('StationName')  # May be None
                 self.station_marketid = entry.get('MarketID')  # May be None
                 self.stationtype = entry.get('StationType')  # May be None
                 self.stationservices = entry.get('StationServices')  # None under E:D < 2.4
+
+                # No need to set self.state['Taxi'] or Dropship here, if its those, the next event is a Disembark anyway
 
             elif event_type in ('Location', 'FSDJump', 'CarrierJump'):
                 # alpha4 - any changes ?
@@ -741,6 +755,10 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.station_marketid = entry.get('MarketID')  # May be None
                 self.stationtype = entry.get('StationType')  # May be None
                 self.stationservices = entry.get('StationServices')  # None in Odyssey for on-foot 'Location'
+
+                self.state['Taxi'] = entry.get('Taxi', None)
+                if not self.state['Taxi']:
+                    self.state['Dropship'] = None
 
             elif event_type == 'ApproachBody':
                 self.planet = entry['Body']
@@ -1284,6 +1302,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
             elif event_type == 'BookDropship':
                 self.state['Credits'] -= entry.get('Cost', 0)
+                self.state['Dropship'] = True
                 # Technically we *might* now not be OnFoot.
                 # The problem is that this event is recorded both for signing up for
                 # an on-foot CZ, and when you use the Dropship to return after the
@@ -1297,12 +1316,16 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
             elif event_type == 'BookTaxi':
                 self.state['Credits'] -= entry.get('Cost', 0)
+                # Dont set taxi state here, as we're not IN a taxi yet. Set it on Embark
 
             elif event_type == 'CancelDropship':
                 self.state['Credits'] += entry.get('Refund', 0)
+                self.state['Dropship'] = False
+                self.state['Taxi'] = False
 
             elif event_type == 'CancelTaxi':
                 self.state['Credits'] += entry.get('Refund', 0)
+                self.state['Taxi'] = False
 
             elif event_type == 'NavRoute':
                 # Added in ED 3.7 - multi-hop route details in NavRoute.json

--- a/monitor.py
+++ b/monitor.py
@@ -705,7 +705,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     self.station = None
 
                 self.state['OnFoot'] = True
-                if self.state['Taxi'] is not None and not self.state['Taxi']:
+                if self.state['Taxi'] is not None and self.state['Taxi'] != entry.get('Taxi', False):
                     logger.warning('Disembarked from a taxi but we didn\'t know we were in a taxi?')
 
                 self.state['Taxi'] = False

--- a/monitor.py
+++ b/monitor.py
@@ -163,6 +163,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             'Taxi':               None,  # True whenever we are _in_ a taxi. ie, this is reset on Disembark etc.
             'Dropship':           None,  # Best effort as to whether or not the above taxi is a dropship.
             'Body':               None,
+            'BodyType':           None,
         }
 
     def start(self, root: 'tkinter.Tk') -> bool:  # noqa: CCR001

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -20,8 +20,6 @@ import timeout_session
 from companion import CAPIData
 from config import applongname, appversion, config
 from EDMCLogging import get_main_logger
-# Yes I know. Im using it for `monitor.planet` Which probably should be rolled into state as a body and bodyType pair
-from monitor import monitor
 from ttkHyperlinkLabel import HyperlinkLabel
 
 logger = get_main_logger()
@@ -1046,7 +1044,7 @@ def journal_entry(  # noqa: C901, CCR001
             to_send_data: Optional[Dict[str, Any]] = {}  # This is a glorified sentinel until lower down.
             # On Horizons, neither of these exist on TouchDown
             star_system_name = entry.get('StarSystem', this.system)
-            body_name = entry.get('Body', monitor.planet)
+            body_name = entry.get('Body', state['Body'] if state['BodyType'] == 'Planet' else None)
 
             if star_system_name is None:
                 logger.warning('Refusing to update addCommanderTravelLand as we dont have a StarSystem!')
@@ -1150,7 +1148,8 @@ def journal_entry(  # noqa: C901, CCR001
                         'slotName': entry['SlotName'],
                         'itemName': entry['ModuleName'],
                         'itemGameID': entry['SuitModuleID'],
-                        # TODO: As of 4.0.0.200, this event does *NOT* include the class
+                        'itemClass': entry['Class'],
+                        'engineering': [],  # TODO: Check casing of names for this
                     }
                 ],
             }

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -1432,7 +1432,6 @@ def new_worker():
                     'APIkey': creds.api_key,
                     'commanderName': creds.cmdr,
                     'commanderFrontierID': creds.fid,
-                    'isBeingDeveloped': True,  # TODO: Remove once update is complete
                 },
                 'events': [
                     {'eventName': e.name, 'eventTimestamp': e.timestamp, 'eventData': e.data} for e in event_list
@@ -1489,9 +1488,6 @@ def send_data(url: str, data: Mapping[str, Any]) -> bool:  # noqa: CCR001
     :param data: the data to POST
     :return: success state
     """
-    # TODO: Remove this. Its here to ensure we dont forget that we're running test code
-    for x in range(20):
-        logger.info("INARA IS SENDING HEADERS THAT INDICATE DEV MODE!!!!!!!!!!!!!!!!!!!!!!!!!")
 
     r = this.session.post(url, data=json.dumps(data, separators=(',', ':')), timeout=_TIMEOUT)
     r.raise_for_status()

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -1110,14 +1110,14 @@ def journal_entry(  # noqa: C901, CCR001
                 'loadoutName':         entry['LoadoutName'],
                 'suitGameID':          entry['SuitID'],
                 'suitType':            entry['SuitName'],
-                'suitMods':            entry['SuitMods'],
+                'suitMods':            [{'blueprintName': mod} for mod in entry['SuitMods']],
                 'suitLoadout': [
                     {
                         'slotName':    x['SlotName'],
                         'itemName':    x['ModuleName'],
                         'itemClass':   x['Class'],
                         'itemGameID':  x['SuitModuleID'],
-                        'engineering': x['WeaponMods'],  # TODO: Verify.
+                        'engineering': [{'blueprintName': mod} for mod in x['WeaponMods']],
                     } for x in entry['Modules']
                 ],
             }
@@ -1149,7 +1149,7 @@ def journal_entry(  # noqa: C901, CCR001
                         'itemName': entry['ModuleName'],
                         'itemGameID': entry['SuitModuleID'],
                         'itemClass': entry['Class'],
-                        'engineering': [],  # TODO: Check casing of names for this
+                        'engineering': [{'blueprintName': mod} for mod in entry['WeaponMods']],
                     }
                 ],
             }

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -1085,11 +1085,11 @@ def journal_entry(  # noqa: C901, CCR001
                 new_add_event('addCommanderTravelLand', entry['timestamp'], to_send_data)
 
         elif event_name == 'ShipLockerMaterials':
-            odyssey_nonplural_microresource_types = ('Items', 'Components', 'Data', 'Consumables')
+            odyssey_plural_microresource_types = ('Items', 'Components', 'Data', 'Consumables')
             # we're getting new data here. so reset it on inara's side just to be sure that we set everything right
-            reset_data = [{'itemType': t} for t in odyssey_nonplural_microresource_types]
+            reset_data = [{'itemType': t} for t in odyssey_plural_microresource_types]
             set_data = []
-            for typ in odyssey_nonplural_microresource_types:
+            for typ in odyssey_plural_microresource_types:
                 set_data.extend([
                     {'itemName': thing['Name'], 'itemCount': thing['Count'], 'itemType': typ} for thing in entry[typ]
                 ])

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -1156,6 +1156,27 @@ def journal_entry(  # noqa: C901, CCR001
 
             new_add_event('updateCommanderSuitLoadout', entry['timestamp'], to_send)
 
+        elif event_name == "Location":
+            to_send = {
+                'starsystemName': entry['StarSystem'],
+                'starsystemCoords': entry['StarPos'],
+            }
+
+            if entry['Docked']:
+                to_send['stationName'] = entry['StationName']
+                to_send['marketID'] = entry['MarketID']
+
+            if entry['Docked'] and entry['BodyType'] == 'Planet':
+                # we're Docked, but we're not on a Station, thus we're docked at a planetary base of some kind
+                # and thus, we SHOULD include starsystemBodyName
+                to_send['starsystemBodyName'] = entry['Body']
+
+            if 'Longitude' in entry and 'Latitude' in entry:
+                # These were included thus we are landed
+                to_send['starsystemBodyCoords'] = [entry['Latitude'], entry['Longitude']]
+
+            new_add_event('setCommanderTravelLocation', entry['timestamp'], to_send)
+
         # Community Goals
         if event_name == 'CommunityGoal':
             # Remove any unsent

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -587,7 +587,7 @@ def journal_entry(  # noqa: C901, CCR001
                         else:  # we dont know one way or another. Given we were told it IS a taxi, assume its a shuttle.
                             to_send['isTaxiShuttle'] = True
 
-                    if entry.get('MarketID') is not None:
+                    if 'MarketID' in entry:
                         to_send['marketID'] = entry['MarketID']
 
                     # TODO: we _can_ include a Body name here, but I'm not entirely sure how best to go about doing that
@@ -663,7 +663,7 @@ def journal_entry(  # noqa: C901, CCR001
                     'shipGameID': state['ShipID'],
                 }
 
-                if entry.get('StarPos') is not None:
+                if 'StarPos' in entry:
                     to_send['starsystemCoords'] = entry['StarPos']
 
                 new_add_event(
@@ -1110,7 +1110,7 @@ def journal_entry(  # noqa: C901, CCR001
                 'loadoutName':         entry['LoadoutName'],
                 'suitGameID':          entry['SuitID'],
                 'suitType':            entry['SuitName'],
-                'suitMods':            [{'blueprintName': mod} for mod in entry['SuitMods']],
+                'suitMods':            entry['SuitMods'],
                 'suitLoadout': [
                     {
                         'slotName':    x['SlotName'],

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -1126,7 +1126,38 @@ def journal_entry(  # noqa: C901, CCR001
 
             new_add_event('setCommanderSuitLoadout', entry['timestamp'], to_send)
 
-        # Community Goals
+        elif event_name == 'DeleteSuitLoadout':
+            new_add_event('delCommanderSuitLoadout', entry['timestamp'], {'loadoutGameID': entry['LoadoutID']})
+
+        elif event_name == 'RenameSuitLoadout':
+            to_send = {
+                'loadoutGameID': entry['LoadoutID'],
+                'loadoutName':   entry['LoadoutName'],
+                # may as well...
+                'suitType': entry['SuitName'],
+                'suitGameID': entry['SuitID']
+            }
+            new_add_event('updateCommanderSuitLoadout', entry['timestamp'], {})
+
+        elif event_name == 'LoadoutEquipModule':
+            to_send = {
+                'loadoutGameID': entry['LoadoutID'],
+                'loadoutName': entry['LoadoutName'],
+                'suitType': entry['SuitName'],
+                'suitGameID': entry['SuitID'],
+                'suitLoadout': [
+                    {
+                        'slotName': entry['SlotName'],
+                        'itemName': entry['ModuleName'],
+                        'itemGameID': entry['SuitModuleID'],
+                        # TODO: As of 4.0.0.200, this event does *NOT* include the class
+                    }
+                ],
+            }
+
+            new_add_event('updateCommanderSuitLoadout', entry['timestamp'], to_send)
+
+            # Community Goals
         if event_name == 'CommunityGoal':
             # Remove any unsent
             this.filter_events(

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -1157,7 +1157,7 @@ def journal_entry(  # noqa: C901, CCR001
 
             new_add_event('updateCommanderSuitLoadout', entry['timestamp'], to_send)
 
-            # Community Goals
+        # Community Goals
         if event_name == 'CommunityGoal':
             # Remove any unsent
             this.filter_events(


### PR DESCRIPTION
To Do:
- [x] `addCommanderTravelLand` support
    - I believe everything we want is done here.
- [x] Update existing events with new taxi information
    - [x] `addCommanderTravelCarrierJump`
    - [x] `addCommanderTravelDock`
    - [x] `addCommanderTravelFSDJump`
    - [ ] `setCommanderTravelLocation`
        - I dont think there are any actual updates we can do here?
- [x] `setCommanderInventory` support
    - This SHOULD be done, it currently only sends on ShipLockerMaterials as thats the only time we can be sure data is correct.
- [x] Suit Loadouts
    - [x] `setCommanderSuitLoadout`
    - [x] `updateCommanderSuitLoadout`
    - [x] `delCommanderSuitLoadout`


Do **BEFORE** merging
- [x] Currently log is spammed to remind me to disable development mode in the headers we send
- [x] Disable development mode in the headers we send


Closes #1127 