### PR TITLE
inara: Don't send a generic setCommanderTravelLocation - be specific

### DIFF
--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -451,15 +451,17 @@ def journal_entry(  # noqa: C901, CCR001
                 # Update location
                 # Might not be available if this event is a 'StartUp' and we're replaying
                 # a log.
-                if system:
-                    new_add_event(
-                        'setCommanderTravelLocation',
-                        entry['timestamp'],
-                        OrderedDict([
-                            ('starsystemName', system),
-                            ('stationName', station),  # Can be None
-                        ])
-                    )
+                # XXX: This interferes with other more specific setCommanderTravelLocation events in the same
+                #      batch.
+                #  if system:
+                #      new_add_event(
+                #          'setCommanderTravelLocation',
+                #          entry['timestamp'],
+                #          OrderedDict([
+                #              ('starsystemName', system),
+                #              ('stationName', station),  # Can be None
+                #          ])
+                #      )
 
                 # Update ship
                 if state['ShipID']:  # Unknown if started in Fighter or SRV
@@ -1511,7 +1513,6 @@ def send_data(url: str, data: Mapping[str, Any]) -> bool:  # noqa: CCR001
     :param data: the data to POST
     :return: success state
     """
-
     r = this.session.post(url, data=json.dumps(data, separators=(',', ':')), timeout=_TIMEOUT)
     r.raise_for_status()
     reply = r.json()

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -630,14 +630,17 @@ def journal_entry(  # noqa: C901, CCR001
                 new_add_event('setCommanderTravelLocation', entry['timestamp'], to_send)
 
             elif event_name == 'ApproachSettlement':
-                to_send = {
-                    'starsystemName':       system,
-                    'stationName':          entry['Name'],
-                    'marketid':             entry['MarketID'],
-                    'starsystemBodyName':   entry['BodyName'],
-                    'starsystemBodyCoords': [entry['Latitude'], entry['Longitude']]
-                }
-                new_add_event('setCommanderTravelLocation', entry['timestamp'], to_send)
+                # If you're near a Settlement on login this event is recorded, but
+                # we might not yet have system logged for use.
+                if system:
+                    to_send = {
+                        'starsystemName':       system,
+                        'stationName':          entry['Name'],
+                        'marketid':             entry['MarketID'],
+                        'starsystemBodyName':   entry['BodyName'],
+                        'starsystemBodyCoords': [entry['Latitude'], entry['Longitude']]
+                    }
+                    new_add_event('setCommanderTravelLocation', entry['timestamp'], to_send)
 
             elif event_name == 'FSDJump':
                 this.undocked = False
@@ -1197,7 +1200,7 @@ def journal_entry(  # noqa: C901, CCR001
                 # These were included thus we are landed
                 to_send['starsystemBodyCoords'] = [entry['Latitude'], entry['Longitude']]
                 # if we're not Docked, but have these, we're either landed or close enough that it doesn't matter.
-                to_send['starSystemBodyName'] = entry['Body']
+                to_send['starsystemBodyName'] = entry['Body']
 
             new_add_event('setCommanderTravelLocation', entry['timestamp'], to_send)
 
@@ -1483,6 +1486,7 @@ def new_worker():
                 ]
             }
             logger.info(f'sending {len(data["events"])} events for {creds.cmdr}')
+            logger.trace(f'Events:\n{json.dumps(data)}\n')
             try_send_data(TARGET_URL, data)
 
         time.sleep(WORKER_WAIT_TIME)

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -619,6 +619,26 @@ def journal_entry(  # noqa: C901, CCR001
 
                 this.undocked = False
 
+            elif event_name == 'SupercruiseExit':
+                to_send = {
+                    'starsystemName':   entry['StarSystem'],
+                }
+
+                if entry['BodyType'] == 'Planet':
+                    to_send['starsystemBodyName'] = entry['Body']
+
+                new_add_event('setCommanderTravelLocation', entry['timestamp'], to_send)
+
+            elif event_name == 'ApproachSettlement':
+                to_send = {
+                    'starsystemName':       system,
+                    'stationName':          entry['Name'],
+                    'marketid':             entry['MarketID'],
+                    'starsystemBodyName':   entry['BodyName'],
+                    'starsystemBodyCoords': [entry['Latitude'], entry['Longitude']]
+                }
+                new_add_event('setCommanderTravelLocation', entry['timestamp'], to_send)
+
             elif event_name == 'FSDJump':
                 this.undocked = False
                 to_send = {

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -605,18 +605,6 @@ def journal_entry(  # noqa: C901, CCR001
                 this.station = None
 
             elif event_name == 'SupercruiseEntry':
-                if this.undocked:
-                    # Staying in system after undocking - send any pending events from in-station action
-                    new_add_event(
-                        'setCommanderTravelLocation',
-                        entry['timestamp'],
-                        {
-                            'starsystemName': system,
-                            'shipType': state['ShipType'],
-                            'shipGameID': state['ShipID'],
-                        }
-                    )
-
                 this.undocked = False
 
             elif event_name == 'SupercruiseExit':

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -624,7 +624,7 @@ def journal_entry(  # noqa: C901, CCR001
                     to_send = {
                         'starsystemName':       system,
                         'stationName':          entry['Name'],
-                        'marketid':             entry['MarketID'],
+                        'marketID':             entry['MarketID'],
                         'starsystemBodyName':   entry['BodyName'],
                         'starsystemBodyCoords': [entry['Latitude'], entry['Longitude']]
                     }


### PR DESCRIPTION
The generic one interferes with more specific such events, i.e. from Journal `Location` event, if sent in the same batch.

But that means ensuring we send for *all* the actual Journal "changed location" events.