### PR TITLE
Align ShipLocker and BackPack code with ED 4.0.0.400

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -683,10 +683,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
                 # We can't now have anything in the BackPack, it's all in the
                 # ShipLocker.
-                self.state['BackPack']['Component'] = defaultdict(int)
-                self.state['BackPack']['Consumable'] = defaultdict(int)
-                self.state['BackPack']['Item'] = defaultdict(int)
-                self.state['BackPack']['Data'] = defaultdict(int)
+                self.backpack_set_empty()
 
             elif event_type == 'Disembark':
                 # This event is logged when the player steps out of a ship or SRV
@@ -934,10 +931,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     self.state['BackpackJSON'] = entry
 
                     # Assume this reflects the current state when written
-                    self.state['BackPack']['Component'] = defaultdict(int)
-                    self.state['BackPack']['Consumable'] = defaultdict(int)
-                    self.state['BackPack']['Item'] = defaultdict(int)
-                    self.state['BackPack']['Data'] = defaultdict(int)
+                    self.backpack_set_empty()
 
                     clean_components = self.coalesce_cargo(entry['Components'])
                     self.state['BackPack']['Component'].update(
@@ -1587,6 +1581,13 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         except Exception as ex:
             logger.debug(f'Invalid journal entry:\n{line!r}\n', exc_info=ex)
             return {'event': None}
+
+    def backpack_set_empty(self):
+        """Set the BackPack contents to be empty."""
+        self.state['BackPack']['Component'] = defaultdict(int)
+        self.state['BackPack']['Consumable'] = defaultdict(int)
+        self.state['BackPack']['Item'] = defaultdict(int)
+        self.state['BackPack']['Data'] = defaultdict(int)
 
     def suit_sane_name(self, name: str) -> str:
         """

--- a/monitor.py
+++ b/monitor.py
@@ -1073,21 +1073,8 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 pass
 
             elif event_type == 'DropItems':
-                # alpha4
-                # Parameters:
-                #     • Name
-                #     • Type
-                #     • OwnerID
-                #     • MissionID
-                #     • Count
-
-                # This is handled by BackpackChange.
-                # for i in self.state['BackPack'][entry['Type']]:
-                #     if i == entry['Name']:
-                #         self.state['BackPack'][entry['Type']][i] -= entry['Count']
-                #         # Paranoia in case we lost track
-                #         if self.state['BackPack'][entry['Type']][i] < 0:
-                #             self.state['BackPack'][entry['Type']][i] = 0
+                # 4.0.0.400 (still) has a BackpackChange event as well, so
+                # ignore this for inventory purposes.
                 pass
 
             elif event_type == 'UseConsumable':

--- a/monitor.py
+++ b/monitor.py
@@ -681,6 +681,13 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.state['OnFoot'] = False
                 self.state['Taxi'] = entry['Taxi']
 
+                # We can't now have anything in the BackPack, it's all in the
+                # ShipLocker.
+                self.state['BackPack']['Component'] = defaultdict(int)
+                self.state['BackPack']['Consumable'] = defaultdict(int)
+                self.state['BackPack']['Item'] = defaultdict(int)
+                self.state['BackPack']['Data'] = defaultdict(int)
+
             elif event_type == 'Disembark':
                 # This event is logged when the player steps out of a ship or SRV
                 #

--- a/monitor.py
+++ b/monitor.py
@@ -1571,6 +1571,9 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             elif event_type == 'Resurrect':
                 self.state['Credits'] -= entry.get('Cost', 0)
 
+                # There should be a `Backpack` event as you 'come to' in the
+                # new location, so no need to zero out BackPack here.
+
             # HACK (not game related / 2021-06-2): self.planet is moved into a more general self.state['Body'].
             # This exists to help plugins doing what they SHOULDN'T BE cope. It will be removed at some point.
             if self.state['Body'] is None or self.state['BodyType'] == 'Planet':

--- a/monitor.py
+++ b/monitor.py
@@ -1016,12 +1016,10 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                             self.state['BackPack'][c][m] = 0
 
             elif event_type == 'BuyMicroResources':
-                # Buying from a Pioneer Supplies, goes directly to ShipLocker.
-                # One event per Item, not an array.
-                category = self.category(entry['Category'])
-                name = self.canonicalise(entry['Name'])
-                self.state[category][name] += entry['Count']
+                # From 4.0.0.400 we get an empty (see file) `ShipLocker` event,
+                # so we can ignore this for inventory purposes.
 
+                # But do record the credits balance change.
                 self.state['Credits'] -= entry.get('Price', 0)
 
             elif event_type == 'SellMicroResources':

--- a/monitor.py
+++ b/monitor.py
@@ -1068,17 +1068,8 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                             self.state['BackPack'][c][m] = 0
 
             elif event_type == 'CollectItems':
-                # alpha4
-                # When picking up items from the ground
-                # Parameters:
-                #     • Name
-                #     • Type
-                #     • OwnerID
-
-                # Handled by BackpackChange
-                # for i in self.state['BackPack'][entry['Type']]:
-                #     if i == entry['Name']:
-                #         self.state['BackPack'][entry['Type']][i] += entry['Count']
+                # 4.0.0.400 (still) has a BackpackChange event as well, so
+                # ignore this for inventory purposes.
                 pass
 
             elif event_type == 'DropItems':

--- a/monitor.py
+++ b/monitor.py
@@ -1106,21 +1106,8 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 # suit backpack – note this can be written at the same time as other
                 # events like UseConsumable
 
-                # In 4.0.0.100 it is observed that:
-                #
-                #  1. Throw of any grenade type *only* causes a BackpackChange event, no
-                #     accompanying 'UseConsumable'.
-                #  2. Using an Energy Cell causes both UseConsumable and BackpackChange,
-                #     in that order.
-                #  3. Medkit acts the same as Energy Cell.
-                #
-                #  Thus we'll just ignore 'UseConsumable' for now.
-                #  for c in self.state['BackPack']['Consumable']:
-                #      if c == entry['Name']:
-                #          self.state['BackPack']['Consumable'][c] -= 1
-                #          # Paranoia in case we lost track
-                #          if self.state['BackPack']['Consumable'][c] < 0:
-                #              self.state['BackPack']['Consumable'][c] = 0
+                # In 4.0.0.400 we do get this event, but *also* a `BackpackChange` event,
+                # so we ignore this for inventory purposes.
                 pass
 
             # TODO:

--- a/monitor.py
+++ b/monitor.py
@@ -1288,8 +1288,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             elif event_type == 'UpgradeWeapon':
                 # We're not actually keeping track of all owned weapons, only those in
                 # Suit Loadouts.
-                # alpha4 - credits?  Shouldn't cost any!
-                pass
+                self.state['Credits'] -= entry.get('Cost', 0)
 
             elif event_type == 'ScanOrganic':
                 # Nothing of interest to our state.

--- a/monitor.py
+++ b/monitor.py
@@ -1023,13 +1023,11 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.state['Credits'] -= entry.get('Price', 0)
 
             elif event_type == 'SellMicroResources':
-                # Selling to a Bar Tender on-foot.
+                # As of 4.0.0.400 we can ignore this as an empty (see file)
+                # `ShipLocker` event is written for the full new inventory.
+
+                # But still record the credits balance change.
                 self.state['Credits'] += entry.get('Price', 0)
-                # One event per whole sale, so it's an array.
-                for mr in entry['MicroResources']:
-                    category = self.category(mr['Category'])
-                    name = self.canonicalise(mr['Name'])
-                    self.state[category][name] -= mr['Count']
 
             elif event_type == 'TradeMicroResources':
                 # As of 4.0.0.400 we can ignore this as an empty (see file)

--- a/monitor.py
+++ b/monitor.py
@@ -1032,17 +1032,9 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     self.state[category][name] -= mr['Count']
 
             elif event_type == 'TradeMicroResources':
-                # Trading some MicroResources for another at a Bar Tender
-                # 'Offered' is what we traded away
-                for offer in entry['Offered']:
-                    category = self.category(offer['Category'])
-                    name = self.canonicalise(offer['Name'])
-                    self.state[category][name] -= offer['Count']
-
-                # For a single item name received
-                category = self.category(entry['Category'])
-                name = self.canonicalise(entry['Received'])
-                self.state[category][name] += entry['Count']
+                # As of 4.0.0.400 we can ignore this as an empty (see file)
+                # `ShipLocker` event is written for the full new inventory.
+                pass
 
             elif event_type == 'TransferMicroResources':
                 # Moving Odyssey MicroResources between ShipLocker and BackPack

--- a/monitor.py
+++ b/monitor.py
@@ -1010,25 +1010,10 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 pass
 
             elif event_type == 'TransferMicroResources':
-                # Moving Odyssey MicroResources between ShipLocker and BackPack
-                # Backpack dropped as its done in BackpackChange
-                #
-                #  from: 4.0.0.200 -- Locker(Old|New)Count is now a thing.
-                for mr in entry['Transfers']:
-                    category = self.category(mr['Category'])
-                    name = self.canonicalise(mr['Name'])
-
-                    self.state[category][name] = mr['LockerNewCount']
-                    if mr['Direction'] not in ('ToShipLocker', 'ToBackpack'):
-                        logger.warning(f'TransferMicroResources with unexpected Direction {mr["Direction"]=}: {mr=}')
-
-                # Paranoia check to see if anything has gone negative.
-                # As of Odyssey Alpha Phase 1 Hotfix 2 keeping track of BackPack
-                # materials is impossible when used/picked up anyway.
-                for c in self.state['BackPack']:
-                    for m in self.state['BackPack'][c]:
-                        if self.state['BackPack'][c][m] < 0:
-                            self.state['BackPack'][c][m] = 0
+                # Defunct in 4.0.0.400 ?  Not seen in testing, and we get a
+                # new empty/file `ShipLocker` event, along with a
+                # `BackpackChange` event per item type transferred.
+                pass
 
             elif event_type == 'CollectItems':
                 # 4.0.0.400 (still) has a BackpackChange event as well, so

--- a/monitor.py
+++ b/monitor.py
@@ -895,34 +895,9 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
             # Journal v31 implies this was removed before Odyssey launch
             elif event_type == 'BackPackMaterials':
-                # alpha4 -
-                # Lists the contents of the backpack, eg when disembarking from ship
-
-                # Assume this reflects the current state when written
-                self.state['BackPack']['Component'] = defaultdict(int)
-                self.state['BackPack']['Consumable'] = defaultdict(int)
-                self.state['BackPack']['Item'] = defaultdict(int)
-                self.state['BackPack']['Data'] = defaultdict(int)
-
-                clean_components = self.coalesce_cargo(entry['Components'])
-                self.state['BackPack']['Component'].update(
-                    {self.canonicalise(x['Name']): x['Count'] for x in clean_components}
-                )
-
-                clean_consumables = self.coalesce_cargo(entry['Consumables'])
-                self.state['BackPack']['Consumable'].update(
-                    {self.canonicalise(x['Name']): x['Count'] for x in clean_consumables}
-                )
-
-                clean_items = self.coalesce_cargo(entry['Items'])
-                self.state['BackPack']['Item'].update(
-                    {self.canonicalise(x['Name']): x['Count'] for x in clean_items}
-                )
-
-                clean_data = self.coalesce_cargo(entry['Data'])
-                self.state['BackPack']['Data'].update(
-                    {self.canonicalise(x['Name']): x['Count'] for x in clean_data}
-                )
+                # Last seen in a 4.0.0.102 journal file.
+                logger.warning(f'We have a BackPackMaterials event, defunct since > 4.0.0.102 ?:\n{entry}\n')
+                pass
 
             elif event_type in ('BackPack', 'Backpack'):  # WORKAROUND 4.0.0.200: BackPack becomes Backpack
                 # TODO: v31 doc says this is`backpack.json` ... but Howard Chalkley

--- a/monitor.py
+++ b/monitor.py
@@ -863,15 +863,10 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.state['Consumable'] = defaultdict(int)
                 self.state['Item'] = defaultdict(int)
                 self.state['Data'] = defaultdict(int)
-                # TODO: Really we need a full BackPackMaterials event at the same time.
-                #       In lieu of that, empty the backpack.  This will explicitly
-                #       be wrong if Cmdr relogs at a Settlement with anything in
-                #       backpack.
-                #       Still no BackPackMaterials at the same time in 4.0.0.31
-                self.state['BackPack']['Component'] = defaultdict(int)
-                self.state['BackPack']['Consumable'] = defaultdict(int)
-                self.state['BackPack']['Item'] = defaultdict(int)
-                self.state['BackPack']['Data'] = defaultdict(int)
+
+                # 4.0.0.400 - No longer zeroing out the BackPack in this event,
+                # as we should now always get either `Backpack` event/file or
+                # `BackpackChange` as needed.
 
                 clean_components = self.coalesce_cargo(entry['Components'])
                 self.state['Component'].update(


### PR DESCRIPTION
This should now allow for perfect tracking of both ShipLocker and BackPack.

My findings as [on Discord:EDCD:#odyssey-specific](https://discord.com/channels/164411426939600896/825041324121784401/852503268864688136):

4.0.0.400 (2021-06-10 update) findings about odyssey inventory events.

1. `ShipLocker` event written (and the file) on login in-ship in a station.

2. Disembark on body surface.
2a. *Empty* `ShipLocker` event triggers on *Disembark* on a body surface  (not docked).  File written.
2b. Full `Backpack`event written on *Disembark* on body surface.  File written.

3. Disembark at station - the same `ShipLocker` and `Backpack` as for body surface.

4. Transferred 2x Electrical Fuse *to* suit *from* ship using menu whilst on foot.
4a. *Empty* `ShipLocker` event, and file update.
4b. `BackpackChange`/Added or /Removed as appropriate.  *One event per specific inventory changed, whether in the same category or not*.
4c. No `Backpack` event for this, or file update.

5. Boarding ship from body-surface on-foot.
5a. First an empty `ShipLocker` *before* the `Embark` event. File updated?  Too quick to know for sure.
5b. But also then a full `ShipLocker` *after*: `Embark`, `Loadout`, `Music`.  File updated.

6. Throwing a grenade causes a `BackpackChange`/Removed event.  Backpack.json also written with updated full inventory.
6b. Using a medkit, or energy cell, causes both `UseConsumable` and `BackpackChange`/Removed.

7. Picking up an item out of a container.
7a. `CollectItems` event.
7b. `BackpackChange`/Added event as well. File updated (frag grenade from case).

8. Dropping an item.
8a. `DropItems` event.
8b. `BackpackChange`/Removed - file written.

9. Buying more consumables from Pioneer Supplies.
9a. `BuyMicroResource` - you can only buy one type before confirming, so only ever one event.
9b. *Empty* `ShipLocker` and file written.

10. Accepting a mission that provides a Power Regulator. *Three* **empty** `ShipLocker` events written - file written.

11. Trading with bar tender.
11a. *Empty* `ShipLocker` event - file written.
11b. `TradeMicroResources` event.

12. Selling to a bar tender.
12a. *Empty* `ShipLocker` event - file written.
12b. `SellMicroResources` event.