### PR TITLE
Enhancement/odyssey update 5

### DIFF
--- a/edmc_data.py
+++ b/edmc_data.py
@@ -574,8 +574,14 @@ edmc_suit_symbol_localised = {
 # WORKAROUND 2021-07-03 | 4.0.0.600 Update 5: duplicates of `fileheader` keys in `LoadGame`,
 # but the GameLanguage in the latter has doubled up the `\`, so cater for either here.
 # This is only run once when this file is imported by something, no runtime cost or repeated expansions will occur
-for lang, new_lang in map(lambda k: (k, k.replace('\\', r'\\')), list(edmc_suit_symbol_localised.keys())):
+__keys = list(edmc_suit_symbol_localised.keys())
+for lang in __keys:
+    new_lang = lang.replace('\\', r'\\')
+    new_lang_2 = lang.replace('\\', '/')
+
     edmc_suit_symbol_localised[new_lang] = edmc_suit_symbol_localised[lang]
+    edmc_suit_symbol_localised[new_lang_2] = edmc_suit_symbol_localised[lang]
+
 
 # Local webserver for debugging. See implementation in debug_webserver.py
 DEBUG_WEBSERVER_HOST = '127.0.0.1'

--- a/edmc_data.py
+++ b/edmc_data.py
@@ -573,6 +573,8 @@ edmc_suit_symbol_localised = {
 
 # WORKAROUND 2021-07-03 | 4.0.0.600 Update 5: duplicates of `fileheader` keys in `LoadGame`,
 # but the GameLanguage in the latter has doubled up the `\`, so cater for either here.
+# This is sourced from what the game is passed by the launcher, caveat emptor. It was mentioned that / is also
+# an option
 # This is only run once when this file is imported by something, no runtime cost or repeated expansions will occur
 __keys = list(edmc_suit_symbol_localised.keys())
 for lang in __keys:

--- a/edmc_data.py
+++ b/edmc_data.py
@@ -571,6 +571,11 @@ edmc_suit_symbol_localised = {
     },
 }
 
+# 4.0.0.600 Update 5 introduced duplicates of `fileheader` keys into `LoadGame`,
+# but the GameLanguage in the latter has doubled up the `\`, so cater for either.
+for lang, new_lang in map(lambda k: (k, k.replace('\\', r'\\')), list(edmc_suit_symbol_localised.keys())):
+    edmc_suit_symbol_localised[new_lang] = edmc_suit_symbol_localised[lang]
+
 # Local webserver for debugging. See implementation in debug_webserver.py
 DEBUG_WEBSERVER_HOST = '127.0.0.1'
 DEBUG_WEBSERVER_PORT = 9090

--- a/edmc_data.py
+++ b/edmc_data.py
@@ -571,8 +571,9 @@ edmc_suit_symbol_localised = {
     },
 }
 
-# 4.0.0.600 Update 5 introduced duplicates of `fileheader` keys into `LoadGame`,
-# but the GameLanguage in the latter has doubled up the `\`, so cater for either.
+# WORKAROUND 2021-07-03 | 4.0.0.600 Update 5: duplicates of `fileheader` keys in `LoadGame`,
+# but the GameLanguage in the latter has doubled up the `\`, so cater for either here.
+# This is only run once when this file is imported by something, no runtime cost or repeated expansions will occur
 for lang, new_lang in map(lambda k: (k, k.replace('\\', r'\\')), list(edmc_suit_symbol_localised.keys())):
     edmc_suit_symbol_localised[new_lang] = edmc_suit_symbol_localised[lang]
 

--- a/monitor.py
+++ b/monitor.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 import util_ships
 from config import config
+from dashboard import dashboard
 from edmc_data import edmc_suit_shortnames, edmc_suit_symbol_localised
 from EDMCLogging import get_main_logger
 
@@ -517,6 +518,13 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.live = True  # First event in 3.0
 
             elif event_type == 'loadgame':
+                # Odyssey Release Update 5
+                self.state['GameLanguage'] = entry.get('language', self.state['GameLanguage'])
+                self.state['GameVersion'] = entry.get('gameversion', self.state['GameVersion'])
+                self.state['GameBuild'] = entry.get('build', self.state['GameBuild'])
+                self.version = self.state['GameVersion']  # Update this just in case things above changed.
+                self.is_beta = any(v in str(self.version).lower() for v in ('alpha', 'beta'))
+
                 # alpha4
                 # Odyssey: bool
                 self.cmdr = entry['Commander']

--- a/monitor.py
+++ b/monitor.py
@@ -512,8 +512,8 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.live = True  # First event in 3.0
 
             elif event_type == 'loadgame':
-                # Odyssey Release Update 5
-                self.populate_version_info(entry, suppress=True)
+                # Odyssey Release Update 5 -- This contains data that doesn't match the format used in FileHeader above
+                # self.populate_version_info(entry, suppress=True)
 
                 # alpha4
                 # Odyssey: bool

--- a/monitor.py
+++ b/monitor.py
@@ -1667,10 +1667,13 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             suit = {
                 'edmcName': edmc_suitname,
                 'locName':  suitname,
-                'suitId':   entry['SuitID'],
-                'name':     entry['SuitName'],
-                'mods':     entry['SuitMods']
             }
+
+        # Overwrite with latest data, just in case, as this can be from CAPI which may or may not have had
+        # all the data we wanted
+        suit['suitId'] = entry['SuitID']
+        suit['name'] = entry['SuitName']
+        suit['mods'] = entry['SuitMods']
 
         suitloadout_slotid = self.suit_loadout_id_from_loadoutid(entry['LoadoutID'])
         # Make the new loadout, in the CAPI format

--- a/monitor.py
+++ b/monitor.py
@@ -513,7 +513,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
             elif event_type == 'loadgame':
                 # Odyssey Release Update 5 -- This contains data that doesn't match the format used in FileHeader above
-                # self.populate_version_info(entry, suppress=True)
+                self.populate_version_info(entry, suppress=True)
 
                 # alpha4
                 # Odyssey: bool

--- a/monitor.py
+++ b/monitor.py
@@ -912,7 +912,11 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 logger.warning(f'We have a BackPackMaterials event, defunct since > 4.0.0.102 ?:\n{entry}\n')
                 pass
 
-            elif event_type == 'backpack':
+            elif event_type in ('backpack', 'resupply'):
+                # as of v4.0.0.600, a `resupply` event is dropped when resupplying your suit at your ship.
+                # This event writes the same data as a backpack event. It will also be followed by a ShipLocker
+                # but that follows normal behaviour in its handler.
+
                 # TODO: v31 doc says this is`backpack.json` ... but Howard Chalkley
                 #       said it's `Backpack.json`
                 backpack_file = pathlib.Path(str(self.currentdir)) / 'Backpack.json'

--- a/monitor.py
+++ b/monitor.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
 
 import util_ships
 from config import config
-from dashboard import dashboard
 from edmc_data import edmc_suit_shortnames, edmc_suit_symbol_localised
 from EDMCLogging import get_main_logger
 

--- a/monitor.py
+++ b/monitor.py
@@ -1118,6 +1118,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     'edmcName':  self.suit_sane_name(loc_name),
                     'id':        None,  # Is this an FDev ID for suit type ?
                     'suitId':    entry['SuitID'],
+                    'mods':      entry['SuitMods'],  # Suits can (rarely) be bought with modules installed
                     'slots':     [],
                 }
 
@@ -1183,6 +1184,8 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                             'id':             None,
                             'weaponrackId':   entry['SuitModuleID'],
                             'locDescription': '',
+                            'class':          entry['Class'],
+                            'mods':           entry['WeaponMods']
                         }
 
                     except KeyError:
@@ -1657,6 +1660,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 'locName':  suitname,
                 'suitId':   entry['SuitID'],
                 'name':     entry['SuitName'],
+                'mods':     entry['SuitMods']
             }
 
         suitloadout_slotid = self.suit_loadout_id_from_loadoutid(entry['LoadoutID'])
@@ -2105,6 +2109,8 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 'weaponrackId':   loadout_slots[s]['SuitModuleID'],
                 'locName':        loadout_slots[s].get('ModuleName_Localised', loadout_slots[s]['ModuleName']),
                 'locDescription': '',
+                'class':          loadout_slots[s]['Class'],
+                'mods':           loadout_slots[s]['WeaponMods'],
             }
 
         return slots

--- a/monitor.py
+++ b/monitor.py
@@ -1109,7 +1109,6 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     'id':        None,  # Is this an FDev ID for suit type ?
                     'suitId':    entry['SuitID'],
                     'mods':      entry['SuitMods'],  # Suits can (rarely) be bought with modules installed
-                    'slots':     [],
                 }
 
                 # update credits
@@ -1682,7 +1681,6 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
         # Now add in the extra fields for new_suit to be a 'full' Suit structure
         suit['id'] = suit.get('id')  # Not available in 4.0.0.100 journal event
-        suit['slots'] = new_loadout['slots']  # 'slots', not 'Modules', to match CAPI
         # Ensure the suit is in self.state['Suits']
         self.state['Suits'][f"{suitid}"] = suit
 

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -341,6 +341,8 @@ def journal_entry(  # noqa: C901, CCR001
 
     elif (ks := killswitch.get_disabled(f'plugins.inara.journal.event.{entry["event"]}')).disabled:
         logger.warning(f'event {entry["event"]} processing has been disabled via killswitch: {ks.reason}')
+        # this can and WILL break state, but if we're concerned about it sending bad data, we'd disable globally anyway
+        return ''
 
     this.on_foot = state['OnFoot']
     event_name: str = entry['event']


### PR DESCRIPTION
This adds support for the new fields and things added in patch 5. It does not include the status.json changes noted in #1185, and does not add special storage for `LandingPad` fields that exist on some events.