### PR TITLE
Automatically create releases with github actions

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -47,6 +47,7 @@ jobs:
     name: Release new version
     runs-on: ubuntu-latest
     needs: test
+    if: "${{ github.event_name != 'workflow_dispatch' }}"
 
     steps:
       - name: Download binary

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -42,3 +42,27 @@ jobs:
         with:
           name: Built files
           path: EDMarketConnector_win*.msi
+
+  release:
+    name: Release new version
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - name: Download binary
+        uses: actions/download-artifact@v2
+        with:
+          name: Built files
+          path: ./
+          
+      - name: Hash files
+        run: sha256sum EDMarketConnector_win*.msi > ./hashes.sum
+
+      - name: Create Draft Release
+        uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{secrets.GITHUB_TOKEN}}"
+          draft: true
+          files: |
+            ./EDMarketConnector_win*.msi
+            ./hashes.sum

--- a/docs/Automatic Builds.md
+++ b/docs/Automatic Builds.md
@@ -26,3 +26,12 @@ When the workflow is (successfully) completed, it will upload the msi file it bu
 Within the `Built Files` zip file is the installer msi
 
 **Please ensure you test the built msi before creating a release.**
+
+## Automatic release creation
+
+Github Actions can automatically create a release after finishing a build (as mentioned above). To make this happen,
+simply push a tag to the repo with the format `v1.2.3` where 1.2.3 is the semver for the version (Note that this is
+**DISTINCT** from the normal `Release/1.2.3` format for release tags).
+
+Once the push is completed, a build will start, and once that is complete, a draft release will be created. Edit the
+release as needed and publish it. **Note that you should still test the built msi before publishing the release**


### PR DESCRIPTION
Waits until after normal build is completed, then hashes the MSI, creates a new draft release, and uploads both the msi and the hashes file