### PR TITLE
monitor.py: Access trace_on via whole-config import

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -18,8 +18,9 @@ from typing import Tuple
 if TYPE_CHECKING:
     import tkinter
 
+import config as conf_module  # Necessary to see the same config.trace_on as elsewhere
 import util_ships
-from config import config, trace_on
+from config import config
 from edmc_data import edmc_suit_shortnames, edmc_suit_symbol_localised
 from EDMCLogging import get_main_logger
 
@@ -518,7 +519,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.live = True  # First event in 3.0
                 self.cmdr = entry['Name']
                 self.state['FID'] = entry['FID']
-                if 'startup' in trace_on:
+                if 'startup' in conf_module.trace_on:
                     logger.trace(f'"Commander" event, {monitor.cmdr=}, {monitor.state["FID"]=}')
 
             elif event_type == 'loadgame':
@@ -530,7 +531,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.cmdr = entry['Commander']
                 # 'Open', 'Solo', 'Group', or None for CQC (and Training - but no LoadGame event)
                 if not entry.get('Ship') and not entry.get('GameMode') or entry.get('GameMode', '').lower() == 'cqc':
-                    if 'cqc-loadgame-events' in trace_on:
+                    if 'cqc-loadgame-events' in conf_module.trace_on:
                         logger.trace(f'loadgame to cqc: {entry}')
 
                     self.mode = 'CQC'
@@ -569,7 +570,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 if entry.get('Ship') is not None and self._RE_SHIP_ONFOOT.search(entry['Ship']):
                     self.state['OnFoot'] = True
 
-                if 'startup' in trace_on:
+                if 'startup' in conf_module.trace_on:
                     logger.trace(f'"LoadGame" event, {monitor.cmdr=}, {monitor.state["FID"]=}')
 
             elif event_type == 'newcommander':


### PR DESCRIPTION
This is necessary so as to see the same instance of config.trace_on as is set up by EDMarketConnector.py.

I've not actually tested this in-game, but debugger showed monitor.py as seeing the same conf_module.trace_on as confirmed parsed in EDMarketConnector.py.