### PR TITLE
Add helper methods around trace-on and override options

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -409,20 +409,27 @@ In addition to that we utilise one of the user-defined levels as:
   selected from Settings in the UI.
 
   As well as just using bare `logger.trace(...)` you can also gate it to only
-  log if asked to at invocation time by utilising the `--trace-on ...` 
+  log if asked to at invocation time by utilising the `--trace-on ...`
   command-line argument.  e.g.
  `EDMarketConnector.py --trace --trace-on edsm-cmdr-events`.  Note how you
-  still need to include `--trace`. The code to check and log would be like:
+  still need to include `--trace`.
+
+  `--trace-on` stores its arguments in `config.trace_on`.
+  To make use of `--trace-on`, you can either check `config.trace_on` yourself:
+  
+    ```python
+      import config
+      if 'my-trace-rule' in config.trace_on:
+        logger.trace('my log message')
+    ```
+
+  or you can use the helper method provided on `logger`:
 
     ```python
-    import config as conf_module  # Necessary to see the same config.trace_on as elsewhere
+      logger.trace_if('my-trace-rule', 'my-log-message')
+    ```
   
-    if 'edsm-cmdr-events' in conf_module.trace_on:
-        logger.trace(f'De-queued ({cmdr=}, {entry["event"]=})')
-  ```
-  
-  This way you can set up TRACE logging that won't spam just because of 
-  `--trace` being used.
+  This way you can set up TRACE logging that won't spam just because `--trace` is used.
 
 ---
 

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -77,6 +77,12 @@ if __name__ == '__main__':  # noqa: C901
     )
 
     parser.add_argument(
+        "--trace-all",
+        help="Disable trace-on functionality",
+        action='store_true'
+    )
+
+    parser.add_argument(
         '--reset-ui',
         help='reset UI theme and transparency to defaults',
         action='store_true'
@@ -123,9 +129,16 @@ if __name__ == '__main__':  # noqa: C901
 
     args = parser.parse_args()
 
+    level_to_set: Optional[int] = None
     if args.trace:
-        logger.setLevel(logging.TRACE)
-        edmclogger.set_channels_loglevel(logging.TRACE)
+        level_to_set = logging.TRACE  # type: ignore # it exists
+
+    elif args.trace_all:
+        level_to_set = logging.TRACE_ALL  # type: ignore # it exists
+
+    if level_to_set is not None:
+        logger.setLevel(level_to_set)
+        edmclogger.set_channels_loglevel(level_to_set)
 
     if args.force_localserver_for_auth:
         config.set_auth_force_localserver()

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -78,7 +78,7 @@ if __name__ == '__main__':  # noqa: C901
 
     parser.add_argument(
         "--trace-all",
-        help="Disable trace-on functionality",
+        help="Disable trace-on functionality (show any and all trace messages, regardless of trace-on gates)",
         action='store_true'
     )
 
@@ -107,7 +107,7 @@ if __name__ == '__main__':  # noqa: C901
 
     parser.add_argument(
         '--trace-on',
-        help='Mark the selected trace logging as active.',
+        help='Mark the selected trace logging as active. * or all will ensure that every possible trace log appears (in the same way as --trace-all)',
         action='append',
     )
 
@@ -133,7 +133,7 @@ if __name__ == '__main__':  # noqa: C901
     if args.trace:
         level_to_set = logging.TRACE  # type: ignore # it exists
 
-    elif args.trace_all:
+    if args.trace_all or '*' in args.trace_on or 'all' in args.trace_on:
         level_to_set = logging.TRACE_ALL  # type: ignore # it exists
 
     if level_to_set is not None:

--- a/monitor.py
+++ b/monitor.py
@@ -25,6 +25,7 @@ from edmc_data import edmc_suit_shortnames, edmc_suit_symbol_localised
 from EDMCLogging import get_main_logger
 
 logger = get_main_logger()
+STARTUP = 'startup'
 
 if TYPE_CHECKING:
     def _(x: str) -> str:
@@ -519,8 +520,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.live = True  # First event in 3.0
                 self.cmdr = entry['Name']
                 self.state['FID'] = entry['FID']
-                if 'startup' in conf_module.trace_on:
-                    logger.trace(f'"Commander" event, {monitor.cmdr=}, {monitor.state["FID"]=}')
+                logger.trace_if(STARTUP, f'"Commander" event, {monitor.cmdr=}, {monitor.state["FID"]=}')
 
             elif event_type == 'loadgame':
                 # Odyssey Release Update 5 -- This contains data that doesn't match the format used in FileHeader above
@@ -531,9 +531,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.cmdr = entry['Commander']
                 # 'Open', 'Solo', 'Group', or None for CQC (and Training - but no LoadGame event)
                 if not entry.get('Ship') and not entry.get('GameMode') or entry.get('GameMode', '').lower() == 'cqc':
-                    if 'cqc-loadgame-events' in conf_module.trace_on:
-                        logger.trace(f'loadgame to cqc: {entry}')
-
+                    logger.trace_if('cqc-loadgame-events', f'loadgame to cqc: {entry}')
                     self.mode = 'CQC'
 
                 else:
@@ -570,8 +568,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 if entry.get('Ship') is not None and self._RE_SHIP_ONFOOT.search(entry['Ship']):
                     self.state['OnFoot'] = True
 
-                if 'startup' in conf_module.trace_on:
-                    logger.trace(f'"LoadGame" event, {monitor.cmdr=}, {monitor.state["FID"]=}')
+                logger.trace_if(STARTUP, f'"LoadGame" event, {monitor.cmdr=}, {monitor.state["FID"]=}')
 
             elif event_type == 'newcommander':
                 self.cmdr = entry['Name']

--- a/monitor.py
+++ b/monitor.py
@@ -18,7 +18,6 @@ from typing import Tuple
 if TYPE_CHECKING:
     import tkinter
 
-import config as conf_module  # Necessary to see the same config.trace_on as elsewhere
 import util_ships
 from config import config
 from edmc_data import edmc_suit_shortnames, edmc_suit_symbol_localised

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -23,7 +23,7 @@ import killswitch
 import myNotebook as nb  # noqa: N813
 import plug
 from companion import CAPIData
-from config import applongname, appversion, config, debug_senders, trace_on
+from config import applongname, appversion, config, debug_senders
 from edmc_data import DEBUG_WEBSERVER_HOST, DEBUG_WEBSERVER_PORT
 from EDMCLogging import get_main_logger
 from ttkHyperlinkLabel import HyperlinkLabel


### PR DESCRIPTION
This adds a `trace_if` method to loggers that does the same as checking for trace-on contents, however, it _also_ logs all messages that otherwise wouldnt be logged to a new `trace-all` log level, below trace, which can be activated using --trace-all

closes #1237 