### PR TITLE
inara.py: put events trace logging under `inara-events` trace_on option

### DIFF
--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -13,6 +13,7 @@ from typing import Sequence, Union, cast
 
 import requests
 
+import config as conf_module  # Necessary to see the same config.trace_on as elsewhere
 import edmc_data
 import killswitch
 import myNotebook as nb  # noqa: N813
@@ -22,7 +23,6 @@ from companion import CAPIData
 from config import applongname, appversion, config, debug_senders
 from EDMCLogging import get_main_logger
 from ttkHyperlinkLabel import HyperlinkLabel
-import config as conf_module  # Necessary to see the same config.trace_on as elsewhere
 
 logger = get_main_logger()
 

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -22,6 +22,7 @@ from companion import CAPIData
 from config import applongname, appversion, config, debug_senders
 from EDMCLogging import get_main_logger
 from ttkHyperlinkLabel import HyperlinkLabel
+import config as conf_module  # Necessary to see the same config.trace_on as elsewhere
 
 logger = get_main_logger()
 
@@ -1491,7 +1492,9 @@ def new_worker():
                 ]
             }
             logger.info(f'sending {len(data["events"])} events for {creds.cmdr}')
-            logger.trace(f'Events:\n{json.dumps(data)}\n')
+            if 'inara-events' in conf_module.trace_on:
+                logger.trace(f'Events:\n{json.dumps(data)}\n')
+
             try_send_data(TARGET_URL, data)
 
         time.sleep(WORKER_WAIT_TIME)

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -13,7 +13,6 @@ from typing import Sequence, Union, cast
 
 import requests
 
-import config as conf_module  # Necessary to see the same config.trace_on as elsewhere
 import edmc_data
 import killswitch
 import myNotebook as nb  # noqa: N813
@@ -1492,8 +1491,7 @@ def new_worker():
                 ]
             }
             logger.info(f'sending {len(data["events"])} events for {creds.cmdr}')
-            if 'inara-events' in conf_module.trace_on:
-                logger.trace(f'Events:\n{json.dumps(data)}\n')
+            logger.trace_if('plugin.inara.events', f'Events:\n{json.dumps(data)}\n')
 
             try_send_data(TARGET_URL, data)
 


### PR DESCRIPTION
Idea from #1239 
Since inara plugin produce very huge trace entries and now debug EDMC log is writings at trace level by default, it will be helpful to hide inara plugin's trace messages.