### PR TITLE
Add CL arg `--capi-pretend-down` in order to pretend that CAPI is down

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -130,7 +130,8 @@ if __name__ == '__main__':  # noqa: C901
     parser.add_argument(
         '--capi-pretend-down',
         help='Force to raise ServerError on any CAPI query',
-        action='store_true')
+        action='store_true'
+    )
 
     args = parser.parse_args()
 

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -127,7 +127,17 @@ if __name__ == '__main__':  # noqa: C901
                         nargs='*'
                         )
 
+    parser.add_argument(
+        '--capi-pretend-down',
+        help='Force to raise ServerError on any CAPI query',
+        action='store_true')
+
     args = parser.parse_args()
+
+    if args.capi_pretend_down:
+        import config as conf_module
+        logger.info('Pretending CAPI is down')
+        conf_module.capi_pretend_down = True
 
     level_to_set: Optional[int] = None
     if args.trace or args.trace_on:

--- a/companion.py
+++ b/companion.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, OrderedDic
 import requests
 
 from config import appname, appversion, config
+import config as conf_module
 from edmc_data import companion_category_map as category_map
 from EDMCLogging import get_main_logger
 from monitor import monitor
@@ -276,6 +277,9 @@ class Auth(object):
 
             logger.debug('Attempting refresh with Frontier...')
             try:
+                if conf_module.capi_pretend_down:
+                    raise ServerError(_('Pretending CAPI is down'))
+
                 r = self.session.post(SERVER_AUTH + URL_TOKEN, data=data, timeout=auth_timeout)
                 if r.status_code == requests.codes.ok:
                     data = r.json()
@@ -359,6 +363,9 @@ class Auth(object):
             # requests_log = logging.getLogger("requests.packages.urllib3")
             # requests_log.setLevel(logging.DEBUG)
             # requests_log.propagate = True
+
+            if conf_module.capi_pretend_down:
+                raise ServerError(_('Pretending CAPI is down'))
 
             r = self.session.post(SERVER_AUTH + URL_TOKEN, data=request_data, timeout=auth_timeout)
             data_token = r.json()
@@ -565,6 +572,9 @@ class Session(object):
 
         try:
             logger.trace('Trying...')
+            if conf_module.capi_pretend_down:
+                raise ServerError('Pretending CAPI is down')
+
             r = self.session.get(self.server + endpoint, timeout=timeout)  # type: ignore
 
         except requests.ConnectionError as e:

--- a/companion.py
+++ b/companion.py
@@ -564,11 +564,11 @@ class Session(object):
             logger.error('cannot make a query when unauthorized')
             raise CredentialsError('cannot make a query when unauthorized')
 
-        try:
-            logger.trace_if('capi.query', 'Trying...')
-            if conf_module.capi_pretend_down:
-                raise ServerConnectionError(f'Pretending CAPI down: {endpoint}')
+        logger.trace_if('capi.query', 'Trying...')
+        if conf_module.capi_pretend_down:
+            raise ServerConnectionError(f'Pretending CAPI down: {endpoint}')
 
+        try:
             r = self.session.get(self.server + endpoint, timeout=timeout)  # type: ignore
 
         except requests.ConnectionError as e:

--- a/companion.py
+++ b/companion.py
@@ -567,7 +567,7 @@ class Session(object):
         try:
             logger.trace_if('capi.query', 'Trying...')
             if conf_module.capi_pretend_down:
-                raise ServerError(f'Pretending CAPI is down for {endpoint} endpoint')
+                raise ServerConnectionError(f'Pretending CAPI down: {endpoint}')
 
             r = self.session.get(self.server + endpoint, timeout=timeout)  # type: ignore
 

--- a/companion.py
+++ b/companion.py
@@ -277,9 +277,6 @@ class Auth(object):
 
             logger.debug('Attempting refresh with Frontier...')
             try:
-                if conf_module.capi_pretend_down:
-                    raise ServerError(_('Pretending CAPI is down'))
-
                 r = self.session.post(SERVER_AUTH + URL_TOKEN, data=data, timeout=auth_timeout)
                 if r.status_code == requests.codes.ok:
                     data = r.json()
@@ -363,9 +360,6 @@ class Auth(object):
             # requests_log = logging.getLogger("requests.packages.urllib3")
             # requests_log.setLevel(logging.DEBUG)
             # requests_log.propagate = True
-
-            if conf_module.capi_pretend_down:
-                raise ServerError(_('Pretending CAPI is down'))
 
             r = self.session.post(SERVER_AUTH + URL_TOKEN, data=request_data, timeout=auth_timeout)
             data_token = r.json()
@@ -573,7 +567,7 @@ class Session(object):
         try:
             logger.trace_if('capi.query', 'Trying...')
             if conf_module.capi_pretend_down:
-                raise ServerError('Pretending CAPI is down')
+                raise ServerError(f'Pretending CAPI is down for {endpoint} endpoint')
 
             r = self.session.get(self.server + endpoint, timeout=timeout)  # type: ignore
 

--- a/companion.py
+++ b/companion.py
@@ -24,8 +24,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, OrderedDic
 
 import requests
 
-from config import appname, appversion, config
 import config as conf_module
+from config import appname, appversion, config
 from edmc_data import companion_category_map as category_map
 from EDMCLogging import get_main_logger
 from monitor import monitor

--- a/config.py
+++ b/config.py
@@ -45,6 +45,7 @@ debug_senders: List[str] = []
 # *all* if only interested in some things.
 trace_on: List[str] = []
 
+capi_pretend_down: bool = False
 # This must be done here in order to avoid an import cycle with EDMCLogging.
 # Other code should use EDMCLogging.get_main_logger
 if os.getenv("EDMC_NO_UI"):


### PR DESCRIPTION
Closes #1096 
This PR adds CL arg for EDMarketConnector.py `--capi-pretend-down`, using this arg will make any request to CAPI raise `companion.ServerError` as if CAPI indeed down.
Also it will require add new phrase to translations but now I just want to get feedback about implemnation if all is ok then I'll add translation.