### PR TITLE
Fix game_running() doc in PLUGINS.md

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -83,9 +83,16 @@ from the original files unless specified as allowed in this section.
 
 `import plug` - For using `plug.show_error()` only.
 
-`from monitor import game_running` - in case a plugin needs to know if we
+ Use `monitor.game_running()` as follows in case a plugin needs to know if we
  think the game is running.  *NB: This is a function, and should be called as
  such.  Using the bare word `game_running` will always be `True`.*
+ 
+```
+from monitor import monitor
+...
+if monitor.game_running():
+  ...
+``` 
 
 `import timeout_session` - provides a method called `new_session` that creates
 a requests.session with a default timeout on all requests. Recommended to


### PR DESCRIPTION
Using game_running() as documented yields `ImportError: cannot import name 'game_running' from 'monitor'`.  Update PLUGINS.md with the correct syntax.

Discord discussion: https://discord.com/channels/164411426939600896/726419472772235306/879787636284338306