### PR TITLE
Log git's absence at the INFO level, not ERROR

### DIFF
--- a/config.py
+++ b/config.py
@@ -116,7 +116,7 @@ def git_shorthash_from_head() -> str:
         out, err = git_cmd.communicate()
 
     except Exception as e:
-        logger.error(f"Couldn't run git command for short hash: {e!r}")
+        logger.info(f"Couldn't run git command for short hash: {e!r}")
 
     else:
         shorthash = out.decode().rstrip('\n')


### PR DESCRIPTION
The ERROR log level is needlessly high for complaining about git not being installed, especially when running from an extracted source archive rather than a repo. Let's keep things calm and avoid polluting desktop session logs. The INFO log level is plenty.