### PR TITLE
Add support for --eddn-url CL arg

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -151,6 +151,11 @@ if __name__ == '__main__':  # noqa: C901
         help='Force to raise ServerError on any CAPI query',
         action='store_true'
     )
+
+    parser.add_argument(
+        '--eddn-url',
+        help='Specify an alternate EDDN upload URL',
+    )
     ###########################################################################
 
     args = parser.parse_args()
@@ -175,6 +180,9 @@ if __name__ == '__main__':  # noqa: C901
 
     if args.force_localserver_for_auth:
         config.set_auth_force_localserver()
+
+    if args.eddn_url:
+        config.set_eddn_url(args.eddn_url)
 
     if args.force_edmc_protocol:
         if sys.platform == 'win32':

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -70,6 +70,28 @@ if __name__ == '__main__':  # noqa: C901
                     "such as EDSM, Inara.cz and EDDB."
     )
 
+    ###########################################################################
+    # Permanent config changes
+    ###########################################################################
+    parser.add_argument(
+        '--reset-ui',
+        help='reset UI theme and transparency to defaults',
+        action='store_true'
+    )
+    ###########################################################################
+
+    ###########################################################################
+    # User 'utility' args
+    ###########################################################################
+    parser.add_argument('--suppress-dupe-process-popup',
+                        help='Suppress the popup from when the application detects another instance already running',
+                        action='store_true'
+                        )
+    ###########################################################################
+
+    ###########################################################################
+    # Adjust logging
+    ###########################################################################
     parser.add_argument(
         '--trace',
         help='Set the Debug logging loglevel to TRACE',
@@ -89,26 +111,19 @@ if __name__ == '__main__':  # noqa: C901
     )
 
     parser.add_argument(
-        '--reset-ui',
-        help='reset UI theme and transparency to defaults',
-        action='store_true'
+        '--debug-sender',
+        help='Mark the selected sender as in debug mode. This generally results in data being written to disk',
+        action='append',
     )
+    ###########################################################################
 
+    ###########################################################################
+    # Frontier Auth
+    ###########################################################################
     parser.add_argument(
         '--forget-frontier-auth',
         help='resets all authentication tokens',
         action='store_true'
-    )
-
-    parser.add_argument('--suppress-dupe-process-popup',
-                        help='Suppress the popup from when the application detects another instance already running',
-                        action='store_true'
-                        )
-
-    parser.add_argument(
-        '--debug-sender',
-        help='Mark the selected sender as in debug mode. This generally results in data being written to disk',
-        action='append',
     )
 
     auth_options = parser.add_mutually_exclusive_group(required=False)
@@ -126,12 +141,17 @@ if __name__ == '__main__':  # noqa: C901
                         help='Callback from Frontier Auth',
                         nargs='*'
                         )
+    ###########################################################################
 
+    ###########################################################################
+    # Developer 'utility' args
+    ###########################################################################
     parser.add_argument(
         '--capi-pretend-down',
         help='Force to raise ServerError on any CAPI query',
         action='store_true'
     )
+    ###########################################################################
 
     args = parser.parse_args()
 

--- a/config.py
+++ b/config.py
@@ -207,6 +207,7 @@ class AbstractConfig(abc.ABC):
     __in_shutdown = False  # Is the application currently shutting down ?
     __auth_force_localserver = False  # Should we use localhost for auth callback ?
     __auth_force_edmc_protocol = False  # Should we force edmc:// protocol ?
+    __eddn_url = None  # Non-default EDDN URL
 
     def __init__(self) -> None:
         self.home_path = pathlib.Path.home()
@@ -249,6 +250,19 @@ class AbstractConfig(abc.ABC):
         :return: bool - True if we should use localhost web server.
         """
         return self.__auth_force_edmc_protocol
+
+    def set_eddn_url(self, eddn_url: str):
+        """Set the specified eddn URL."""
+        self.__eddn_url = eddn_url
+
+    @property
+    def eddn_url(self) -> Optional[str]:
+        """
+        Provide the custom EDDN URL.
+
+        :return: str - Custom EDDN URL to use.
+        """
+        return self.__eddn_url
 
     @property
     def app_dir(self) -> str:


### PR DESCRIPTION
We sometimes need to test against, e.g. beta.eddn.edcd.io:4431 instead, so make that easy.

Closes #1281