### PR TITLE
Remove protocol.protocolhandler singleton auto-init

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -377,7 +377,7 @@ from edmc_data import ship_name_map
 from hotkey import hotkeymgr
 from l10n import Translations
 from monitor import monitor
-from protocol import protocolhandler
+import protocol
 from theme import theme
 from ttkHyperlinkLabel import HyperlinkLabel
 
@@ -689,7 +689,7 @@ class AppWindow(object):
         self.w.bind_all('<<Quit>>', self.onexit)  # Updater
 
         # Start a protocol handler to handle cAPI registration. Requires main loop to be running.
-        self.w.after_idle(lambda: protocolhandler.start(self.w))
+        self.w.after_idle(lambda: protocol.protocolhandler.start(self.w))
 
         # Load updater after UI creation (for WinSparkle)
         import update
@@ -1698,7 +1698,7 @@ class AppWindow(object):
 
         # Frontier auth/CAPI handling
         logger.info('Closing protocol handler...')
-        protocolhandler.close()
+        protocol.protocolhandler.close()
 
         logger.info('Closing Frontier CAPI sessions...')
         companion.session.close()
@@ -1899,6 +1899,9 @@ sys.path: {sys.path}'''
     if args.forget_frontier_auth:
         logger.info("Dropping all fdev tokens as --forget-frontier-auth was passed")
         companion.Auth.invalidate(None)
+
+    # Create protocol handler
+    protocol.protocolhandler = protocol.get_handler_impl()()
 
     # TODO: unittests in place of these
     # logger.debug('Test from __main__')

--- a/companion.py
+++ b/companion.py
@@ -33,7 +33,8 @@ from config import appname, appversion, config
 from edmc_data import companion_category_map as category_map
 from EDMCLogging import get_main_logger
 from monitor import monitor
-from protocol import protocolhandler
+# from protocol import protocolhandler
+import protocol
 
 logger = get_main_logger()
 
@@ -375,7 +376,7 @@ class Auth(object):
             f'&code_challenge={challenge}'
             f'&code_challenge_method=S256'
             f'&state={self.state}'
-            f'&redirect_uri={protocolhandler.redirect}'
+            f'&redirect_uri={protocol.protocolhandler.redirect}'
         )
 
         return None
@@ -412,7 +413,7 @@ class Auth(object):
                 'client_id': self.CLIENT_ID,
                 'code_verifier': self.verifier,
                 'code': data['code'][0],
-                'redirect_uri': protocolhandler.redirect,
+                'redirect_uri': protocol.protocolhandler.redirect,
             }
 
             # import http.client as http_client
@@ -698,7 +699,7 @@ class Session(object):
 
         try:
             logger.debug('Trying authorize with payload from handler')
-            self.start_frontier_auth(self.auth.authorize(protocolhandler.lastpayload))  # type: ignore
+            self.start_frontier_auth(self.auth.authorize(protocol.protocolhandler.lastpayload))  # type: ignore
             self.auth = None
 
         except Exception:


### PR DESCRIPTION
In general, doing things like this on import is bad, but this was
changed specifically to remove a bug that causes
--force-localserver-auth to do nothing.

That is caused because while we were careful not to import protocol
until after we were done doing arg things, we did not check to make sure
something else didn't. Companion imports protocol, which thus always
instantiates WindowsProtocolHandler before we can modify some config
state to indicate that we want LinuxProtocolHandler.