### PR TITLE
EDDN: Fix `horizons` flag for CAPI-sourced data

### DIFF
--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -1395,6 +1395,22 @@ def is_horizons(economies: MAP_STR_ANY, modules: MAP_STR_ANY, ships: MAP_STR_ANY
     :param ships: Ships available at the docked station.
     :return: bool - True if the Cmdr has Horizons access.
     """
+    # First check the Journal-sourced flag
+    # NB: This assumes game currently running, rather than "old
+    #     journal file".  `LoadGame` determines monitor.cmdr, which determines
+    #     the account used for CAPI, so it *should* match.
+    #
+    #     For this to be wrong, the user would have had to have, e.g.:
+    #
+    #       1. Logged into Cmdr in Horizons/Odyssey, then back out again.
+    #       2. Logged into Cmdr in base game, either on another machine, or
+    #          have removed the Journal file after.
+    #       3. Re-run EDMC and triggered a manual CAPI update.
+    #
+    #  This seems unlikely.
+    if this.horizons:
+        return True
+
     economies_colony = False
     modules_horizons = False
     ship_horizons = False


### PR DESCRIPTION
I *think* we can literally just use `monitor.state['Horizons']` (which is now `this.horizons` in this plugin) in place of the function `is_horizons()`.

See the comment *in* `is_horizons()`.