### PR TITLE
CAPI: Fix not utilising Refresh Token

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -1165,6 +1165,8 @@ class AppWindow(object):
             if companion.session.login():
                 logger.debug('Initial query failed, but login() just worked, trying again...')
                 companion.session.retrying = True
+                self.w.after(int(SERVER_RETRY * 1000), lambda: self.capi_request_data(event))
+                return  # early exit to avoid starting cooldown count
 
         except companion.CredentialsError:
             companion.session.retrying = False

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -1160,6 +1160,8 @@ class AppWindow(object):
             self.status['text'] = _('Frontier CAPI server error')
 
         except companion.CredentialsRequireRefresh:
+            # We need to 'close' the auth else it'll see STATE_OK and think login() isn't needed
+            companion.session.close()
             # LANG: Frontier CAPI Access Token expired, trying to get a new one
             self.status['text'] = _('CAPI: Refreshing access token...')
             if companion.session.login():

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -152,6 +152,12 @@ if __name__ == '__main__':  # noqa: C901
     )
 
     parser.add_argument(
+        '--capi-use-debug-access-token',
+        help='Load a debug Access Token from disk (from config.app_dir_pathapp_dir_path / access_token.txt)',
+        action='store_true'
+    )
+
+    parser.add_argument(
         '--eddn-url',
         help='Specify an alternate EDDN upload URL',
     )
@@ -169,6 +175,11 @@ if __name__ == '__main__':  # noqa: C901
         import config as conf_module
         logger.info('Pretending CAPI is down')
         conf_module.capi_pretend_down = True
+
+    if args.capi_use_debug_access_token:
+        import config as conf_module
+        with open(conf_module.config.app_dir_path / 'access_token.txt', 'r') as at:
+            conf_module.capi_debug_access_token = at.readline().strip()
 
     level_to_set: Optional[int] = None
     if args.trace or args.trace_on:

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -1159,6 +1159,13 @@ class AppWindow(object):
             # LANG: Frontier CAPI server error when fetching data
             self.status['text'] = _('Frontier CAPI server error')
 
+        except companion.CredentialsRequireRefresh:
+            # LANG: Frontier CAPI Access Token expired, trying to get a new one
+            self.status['text'] = _('CAPI: Refreshing access token...')
+            if companion.session.login():
+                logger.debug('Initial query failed, but login() just worked, trying again...')
+                companion.session.retrying = True
+
         except companion.CredentialsError:
             companion.session.retrying = False
             companion.session.invalidate()

--- a/companion.py
+++ b/companion.py
@@ -784,7 +784,7 @@ class Session(object):
                     # TODO: This needs to try a REFRESH, not a full re-auth
                     # No need for translation, we'll go straight into trying new Auth
                     # and thus any message would be overwritten.
-                    raise CredentialsError('Frontier CAPI said Auth required') from e
+                    raise CredentialsRequireRefresh('Frontier CAPI said "unauthorized"') from e
 
                 if r.status_code == 418:  # "I'm a teapot" - used to signal maintenance
                     # LANG: Frontier CAPI returned 418, meaning down for maintenance

--- a/companion.py
+++ b/companion.py
@@ -265,6 +265,15 @@ class CredentialsError(Exception):
             self.args = (_('Error: Invalid Credentials'),)
 
 
+class CredentialsRequireRefresh(Exception):
+    """Exception Class for CAPI credentials requiring refresh."""
+
+    def __init__(self, *args) -> None:
+        self.args = args
+        if not args:
+            self.args = ('CAPI: Requires refresh of Access Token',)
+
+
 class CmdrError(Exception):
     """Exception Class for CAPI Commander error.
 
@@ -772,6 +781,7 @@ class Session(object):
                 self.dump(r)
 
                 if r.status_code == 401:  # CAPI doesn't think we're Auth'd
+                    # TODO: This needs to try a REFRESH, not a full re-auth
                     # No need for translation, we'll go straight into trying new Auth
                     # and thus any message would be overwritten.
                     raise CredentialsError('Frontier CAPI said Auth required') from e

--- a/companion.py
+++ b/companion.py
@@ -759,7 +759,13 @@ class Session(object):
                 if conf_module.capi_pretend_down:
                     raise ServerConnectionError(f'Pretending CAPI down: {capi_endpoint}')
 
+                if conf_module.capi_debug_access_token is not None:
+                    self.requests_session.headers['Authorization'] = f'Bearer {conf_module.capi_debug_access_token}'  # type: ignore # noqa: E501
+                    # This is one-shot
+                    conf_module.capi_debug_access_token = None
+
                 r = self.requests_session.get(self.server + capi_endpoint, timeout=timeout)  # type: ignore
+
                 logger.trace_if('capi.worker', '... got result...')
                 r.raise_for_status()  # Typically 403 "Forbidden" on token expiry
                 # May also fail here if token expired since response is empty

--- a/config.py
+++ b/config.py
@@ -46,7 +46,7 @@ debug_senders: List[str] = []
 trace_on: List[str] = []
 
 capi_pretend_down: bool = False
-capi_debug_access_token: Optional[str]
+capi_debug_access_token: Optional[str] = None
 # This must be done here in order to avoid an import cycle with EDMCLogging.
 # Other code should use EDMCLogging.get_main_logger
 if os.getenv("EDMC_NO_UI"):

--- a/config.py
+++ b/config.py
@@ -46,6 +46,7 @@ debug_senders: List[str] = []
 trace_on: List[str] = []
 
 capi_pretend_down: bool = False
+capi_debug_access_token: Optional[str]
 # This must be done here in order to avoid an import cycle with EDMCLogging.
 # Other code should use EDMCLogging.get_main_logger
 if os.getenv("EDMC_NO_UI"):

--- a/monitor.py
+++ b/monitor.py
@@ -1210,6 +1210,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                         }
 
                     except KeyError:
+                        # TODO: Log the exception details too, for some clue about *which* key
                         logger.error(f"LoadoutEquipModule: {entry}")
 
             elif event_type == 'loadoutremovemodule':


### PR DESCRIPTION
The threaded CAPI refactor erroneously caused "CAPI server says Unauthorized" to always request a **full** re-auth, not use of the Refresh Token.

This should fix that.

Closes #1330 