### PR TITLE
CAPI: Don't blindly dump r(equest.Response) on failure

### DIFF
--- a/companion.py
+++ b/companion.py
@@ -343,6 +343,7 @@ class Auth(object):
 
             logger.debug('Attempting refresh with Frontier...')
             try:
+                r: Optional[requests.Response] = None
                 r = self.requests_session.post(
                     FRONTIER_AUTH_SERVER + self.FRONTIER_AUTH_PATH_TOKEN,
                     data=data,
@@ -360,9 +361,10 @@ class Auth(object):
                     logger.error(f"Frontier CAPI Auth: Can't refresh token for \"{self.cmdr}\"")
                     self.dump(r)
 
-            except (ValueError, requests.RequestException, ):
-                logger.exception(f"Frontier CAPI Auth: Can't refresh token for \"{self.cmdr}\"")
-                self.dump(r)
+            except (ValueError, requests.RequestException, ) as e:
+                logger.exception(f"Frontier CAPI Auth: Can't refresh token for \"{self.cmdr}\"\n{e!r}")
+                if r is not None:
+                    self.dump(r)
 
         else:
             logger.error(f"Frontier CAPI Auth: No token for \"{self.cmdr}\"")


### PR DESCRIPTION
It turns out this was just the blind `self.dump(r)` causing a bare exception splat, and then the status line error.  So, initialise `r` to `None` and check it isn't still that before the dump.  Also, explicitly logs the exception now.

Closes #1132