### PR TITLE
monitor: Don't re-init Enginers/Rank/Reputation on LoadGame

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -554,10 +554,12 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     'Horizons':   entry['Horizons'],  # From 3.0
                     'Odyssey':    entry.get('Odyssey', False),  # From 4.0 Odyssey
                     'Loan':       entry['Loan'],
-                    'Engineers':  {},
-                    'Rank':       {},
-                    'Reputation': {},
-                    'Statistics': {},
+                    # For Odyssey, by 4.0.0.100, and at least from Horizons 3.8.0.201 the order of events changed
+                    # to LoadGame being after some 'status' events.
+                    # 'Engineers':  {},  # 'EngineerProgress' event now before 'LoadGame'
+                    # 'Rank':       {},  # 'Rank'/'Progress' events now before 'LoadGame'
+                    # 'Reputation': {},  # 'Reputation' event now before 'LoadGame'
+                    'Statistics': {},  # Still after 'LoadGame' in 4.0.0.903
                     'Role':       None,
                     'Taxi':       None,
                     'Dropship':   None,


### PR DESCRIPTION
The order of Journal events changed from:

  1. LoadGame
  2. Rank
  3. Progress

to:

  1. Rank
  2. Progress
  3. LoadGame

in Odyssey, and in at least current 'base game' and Horizons clients as
well.  Also 'Reputation' event is before 'LoadGame' now.  So simply
allow those events to have populated the data, don't re-init on
LoadGame.

Yes, I'm preferring to leave the lines in, but commented, so it's clear
why those aren't being init'd, *and* why 'Statistics' still is, and as
of what game version.