### PR TITLE
Set a custom User-Agent header everywhere

### DIFF
--- a/companion.py
+++ b/companion.py
@@ -30,7 +30,7 @@ import requests
 
 import config as conf_module
 import protocol
-from config import appname, appversion, config
+from config import config, user_agent
 from edmc_data import companion_category_map as category_map
 from EDMCLogging import get_main_logger
 from monitor import monitor
@@ -54,7 +54,6 @@ auth_timeout = 30  # timeout for initial auth
 
 # Used by both class Auth and Session
 FRONTIER_AUTH_SERVER = 'https://auth.frontierstore.net'
-USER_AGENT = f'EDCD-{appname}-{appversion()}'
 
 SERVER_LIVE = 'https://companion.orerve.net'
 SERVER_BETA = 'https://pts-companion.orerve.net'
@@ -305,7 +304,7 @@ class Auth(object):
     def __init__(self, cmdr: str) -> None:
         self.cmdr: str = cmdr
         self.requests_session = requests.Session()
-        self.requests_session.headers['User-Agent'] = USER_AGENT
+        self.requests_session.headers['User-Agent'] = user_agent
         self.verifier: Union[bytes, None] = None
         self.state: Union[str, None] = None
 
@@ -644,7 +643,7 @@ class Session(object):
         logger.debug('Starting session')
         self.requests_session = requests.Session()
         self.requests_session.headers['Authorization'] = f'Bearer {access_token}'
-        self.requests_session.headers['User-Agent'] = USER_AGENT
+        self.requests_session.headers['User-Agent'] = user_agent
         self.state = Session.STATE_OK
 
     def login(self, cmdr: str = None, is_beta: Optional[bool] = None) -> bool:

--- a/config.py
+++ b/config.py
@@ -164,6 +164,9 @@ def appversion() -> semantic_version.Version:
     return _cached_version
 
 
+user_agent = f'EDCD-{appname}-{appversion()}'
+
+
 def appversion_nobuild() -> semantic_version.Version:
     """
     Determine app version without *any* build meta data.

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -21,7 +21,7 @@ import killswitch
 import myNotebook as nb  # noqa: N813
 import plug
 from companion import CAPIData, category_map
-from config import applongname, appversion_nobuild, config, debug_senders
+from config import applongname, appname, appversion, appversion_nobuild, config, debug_senders
 from EDMCLogging import get_main_logger
 from monitor import monitor
 from myNotebook import Frame
@@ -101,6 +101,9 @@ HORIZONS_SKU = 'ELITE_HORIZONS_V_PLANETARY_LANDINGS'
 # Thus do **NOT** use either of these in addition to the PLANETARY_LANDINGS
 # one.
 
+# Custom user agent, to be clear in EDDN logs
+USER_AGENT = f'EDCD-{appname}-{appversion()}'
+
 
 # TODO: a good few of these methods are static or could be classmethods. they should be created as such.
 
@@ -125,6 +128,7 @@ class EDDN:
     def __init__(self, parent: tk.Tk):
         self.parent: tk.Tk = parent
         self.session = requests.Session()
+        self.session.headers['User-Agent'] = USER_AGENT
         self.replayfile: Optional[TextIO] = None  # For delayed messages
         self.replaylog: List[str] = []
 

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -21,7 +21,7 @@ import killswitch
 import myNotebook as nb  # noqa: N813
 import plug
 from companion import CAPIData, category_map
-from config import applongname, appname, appversion, appversion_nobuild, config, debug_senders
+from config import applongname, appversion_nobuild, config, debug_senders, user_agent
 from EDMCLogging import get_main_logger
 from monitor import monitor
 from myNotebook import Frame
@@ -101,9 +101,6 @@ HORIZONS_SKU = 'ELITE_HORIZONS_V_PLANETARY_LANDINGS'
 # Thus do **NOT** use either of these in addition to the PLANETARY_LANDINGS
 # one.
 
-# Custom user agent, to be clear in EDDN logs
-USER_AGENT = f'EDCD-{appname}-{appversion()}'
-
 
 # TODO: a good few of these methods are static or could be classmethods. they should be created as such.
 
@@ -128,7 +125,7 @@ class EDDN:
     def __init__(self, parent: tk.Tk):
         self.parent: tk.Tk = parent
         self.session = requests.Session()
-        self.session.headers['User-Agent'] = USER_AGENT
+        self.session.headers['User-Agent'] = user_agent
         self.replayfile: Optional[TextIO] = None  # For delayed messages
         self.replaylog: List[str] = []
 

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -23,7 +23,7 @@ import killswitch
 import myNotebook as nb  # noqa: N813
 import plug
 from companion import CAPIData
-from config import applongname, appversion, config, debug_senders
+from config import applongname, appname, appversion, config, debug_senders
 from edmc_data import DEBUG_WEBSERVER_HOST, DEBUG_WEBSERVER_PORT
 from EDMCLogging import get_main_logger
 from ttkHyperlinkLabel import HyperlinkLabel
@@ -37,6 +37,8 @@ logger = get_main_logger()
 EDSM_POLL = 0.1
 _TIMEOUT = 20
 DISCARDED_EVENTS_SLEEP = 10
+# Custom user agent
+USER_AGENT = f'EDCD-{appname}-{appversion()}'
 
 # trace-if events
 CMDR_EVENTS = 'plugin.edsm.cmdr-events'
@@ -49,6 +51,7 @@ class This:
         self.shutting_down = False  # Plugin is shutting down.
 
         self.session: requests.Session = requests.Session()
+        self.session.headers['User-Agent'] = USER_AGENT
         self.queue: Queue = Queue()		# Items to be sent to EDSM by worker thread
         self.discarded_events: Set[str] = []  # List discarded events from EDSM
         self.lastlookup: requests.Response  # Result of last system lookup

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -23,7 +23,7 @@ import killswitch
 import myNotebook as nb  # noqa: N813
 import plug
 from companion import CAPIData
-from config import applongname, appname, appversion, config, debug_senders
+from config import applongname, appversion, config, debug_senders, user_agent
 from edmc_data import DEBUG_WEBSERVER_HOST, DEBUG_WEBSERVER_PORT
 from EDMCLogging import get_main_logger
 from ttkHyperlinkLabel import HyperlinkLabel
@@ -37,8 +37,6 @@ logger = get_main_logger()
 EDSM_POLL = 0.1
 _TIMEOUT = 20
 DISCARDED_EVENTS_SLEEP = 10
-# Custom user agent
-USER_AGENT = f'EDCD-{appname}-{appversion()}'
 
 # trace-if events
 CMDR_EVENTS = 'plugin.edsm.cmdr-events'
@@ -51,7 +49,7 @@ class This:
         self.shutting_down = False  # Plugin is shutting down.
 
         self.session: requests.Session = requests.Session()
-        self.session.headers['User-Agent'] = USER_AGENT
+        self.session.headers['User-Agent'] = user_agent
         self.queue: Queue = Queue()		# Items to be sent to EDSM by worker thread
         self.discarded_events: Set[str] = []  # List discarded events from EDSM
         self.lastlookup: requests.Response  # Result of last system lookup

--- a/timeout_session.py
+++ b/timeout_session.py
@@ -1,22 +1,24 @@
-
+"""A requests.session with a TimeoutAdapter."""
 import requests
 from requests.adapters import HTTPAdapter
+
+from config import user_agent
 
 REQUEST_TIMEOUT = 10  # reasonable timeout that all HTTP requests should use
 
 
 class TimeoutAdapter(HTTPAdapter):
-    """
-    TimeoutAdapter is an HTTP Adapter that enforces an overridable default timeout on HTTP requests.
-    """
-    def __init__(self, timeout, *args, **kwargs):
+    """An HTTP Adapter that enforces an overridable default timeout on HTTP requests."""
+
+    def __init__(self, timeout: int, *args, **kwargs):
         self.default_timeout = timeout
         if kwargs.get("timeout") is not None:
             del kwargs["timeout"]
 
         super().__init__(*args, **kwargs)
 
-    def send(self, *args, **kwargs):
+    def send(self, *args, **kwargs) -> requests.Response:
+        """Send, but with a timeout always set."""
         if kwargs["timeout"] is None:
             kwargs["timeout"] = self.default_timeout
 
@@ -25,7 +27,7 @@ class TimeoutAdapter(HTTPAdapter):
 
 def new_session(timeout: int = REQUEST_TIMEOUT, session: requests.Session = None) -> requests.Session:
     """
-    new_session creates a new requests.Session and overrides the default HTTPAdapter with a TimeoutAdapter.
+    Create a new requests.Session and override the default HTTPAdapter with a TimeoutAdapter.
 
     :param timeout: the timeout to set the TimeoutAdapter to, defaults to REQUEST_TIMEOUT
     :param session: the Session object to attach the Adapter to, defaults to a new session
@@ -33,6 +35,7 @@ def new_session(timeout: int = REQUEST_TIMEOUT, session: requests.Session = None
     """
     if session is None:
         session = requests.Session()
+        session.headers['User-Agent'] = user_agent
 
     adapter = TimeoutAdapter(timeout)
     session.mount("http://", adapter)


### PR DESCRIPTION
This was initially going to be just for EDDN, but then I decided to ensure we were doing this for any other requests sessions, and then it made sense to centralise it to just config.user_agent rather than setting the same thing in multiple places.  Also time_session now always sets this.

I've done a basic "run it, check no errors logged, hit 'Update' for EDDN sends" check.

Closes #1324 