### PR TITLE
Inara: Trigger off 'Progress' for sending setCommanderRankPilot

### DIFF
--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -519,7 +519,7 @@ def journal_entry(  # noqa: C901, CCR001
                     new_add_event('setCommanderShipLoadout', entry['timestamp'], this.loadout)
 
             # Login-time Ranks
-            elif event_name == 'Rank':
+            elif event_name == 'Progress':
                 # Send rank info to Inara on startup
                 new_add_event(
                     'setCommanderRankPilot',

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -518,7 +518,8 @@ def journal_entry(  # noqa: C901, CCR001
                     this.loadout = make_loadout(state)
                     new_add_event('setCommanderShipLoadout', entry['timestamp'], this.loadout)
 
-            # Login-time Ranks
+            # Trigger off the "only observed as being after Ranks" event so that
+            # we have both current Ranks *and* current Progress within them.
             elif event_name == 'Progress':
                 # Send rank info to Inara on startup
                 new_add_event(


### PR DESCRIPTION
Doing so from 'Rank' means the 'Progress' event hadn't happened yet, so of course we only ever sent all zeroes for progress.

NB: Journal-v32 doc makes *no guarantee* about the order of the events.  Is it worth trying to be paranoid about that ?  For a 100% new player everything would be "all zeroes", so we would likely need to tweak things to store `None` as default values, and check for such.