### PR TITLE
Attempt to prevent plugin widget issues from bringing down whole UI

### DIFF
--- a/theme.py
+++ b/theme.py
@@ -14,6 +14,9 @@ from tkinter import ttk
 
 from config import config
 from ttkHyperlinkLabel import HyperlinkLabel
+from EDMCLogging import get_main_logger
+
+logger = get_main_logger()
 
 if __debug__:
     from traceback import print_exc
@@ -266,50 +269,64 @@ class _Theme(object):
             widget.winfo_class(), widget, 'text' in widget.keys() and widget['text'])
         attribs = self.widgets.get(widget, [])
 
-        if isinstance(widget, tk.BitmapImage):
-            # not a widget
-            if 'fg' not in attribs:
-                widget.configure(foreground=self.current['foreground']),
-            if 'bg' not in attribs:
-                widget.configure(background=self.current['background'])
-        elif 'cursor' in widget.keys() and str(widget['cursor']) not in ['', 'arrow']:
-            # Hack - highlight widgets like HyperlinkLabel with a non-default cursor
-            if 'fg' not in attribs:
-                widget.configure(foreground=self.current['highlight']),
-                if 'insertbackground' in widget.keys():  # tk.Entry
-                    widget.configure(insertbackground=self.current['foreground']),
-            if 'bg' not in attribs:
-                widget.configure(background=self.current['background'])
-                if 'highlightbackground' in widget.keys():  # tk.Entry
-                    widget.configure(highlightbackground=self.current['background'])
-            if 'font' not in attribs:
-                widget.configure(font=self.current['font'])
-        elif 'activeforeground' in widget.keys():
-            # e.g. tk.Button, tk.Label, tk.Menu
-            if 'fg' not in attribs:
-                widget.configure(foreground=self.current['foreground'],
-                                 activeforeground=self.current['activeforeground'],
-                                 disabledforeground=self.current['disabledforeground'])
-            if 'bg' not in attribs:
-                widget.configure(background=self.current['background'],
-                                 activebackground=self.current['activebackground'])
-                if sys.platform == 'darwin' and isinstance(widget, tk.Button):
-                    widget.configure(highlightbackground=self.current['background'])
-            if 'font' not in attribs:
-                widget.configure(font=self.current['font'])
-        elif 'foreground' in widget.keys():
-            # e.g. ttk.Label
-            if 'fg' not in attribs:
-                widget.configure(foreground=self.current['foreground']),
-            if 'bg' not in attribs:
-                widget.configure(background=self.current['background'])
-            if 'font' not in attribs:
-                widget.configure(font=self.current['font'])
-        elif 'background' in widget.keys() or isinstance(widget, tk.Canvas):
-            # e.g. Frame, Canvas
-            if 'bg' not in attribs:
-                widget.configure(background=self.current['background'],
-                                 highlightbackground=self.current['disabledforeground'])
+        try:
+            if isinstance(widget, tk.BitmapImage):
+                # not a widget
+                if 'fg' not in attribs:
+                    widget.configure(foreground=self.current['foreground']),
+
+                if 'bg' not in attribs:
+                    widget.configure(background=self.current['background'])
+
+            elif 'cursor' in widget.keys() and str(widget['cursor']) not in ['', 'arrow']:
+                # Hack - highlight widgets like HyperlinkLabel with a non-default cursor
+                if 'fg' not in attribs:
+                    widget.configure(foreground=self.current['highlight']),
+                    if 'insertbackground' in widget.keys():  # tk.Entry
+                        widget.configure(insertbackground=self.current['foreground']),
+
+                if 'bg' not in attribs:
+                    widget.configure(background=self.current['background'])
+                    if 'highlightbackground' in widget.keys():  # tk.Entry
+                        widget.configure(highlightbackground=self.current['background'])
+
+                if 'font' not in attribs:
+                    widget.configure(font=self.current['font'])
+
+            elif 'activeforeground' in widget.keys():
+                # e.g. tk.Button, tk.Label, tk.Menu
+                if 'fg' not in attribs:
+                    widget.configure(foreground=self.current['foreground'],
+                                     activeforeground=self.current['activeforeground'],
+                                     disabledforeground=self.current['disabledforeground'])
+
+                if 'bg' not in attribs:
+                    widget.configure(background=self.current['background'],
+                                     activebackground=self.current['activebackground'])
+                    if sys.platform == 'darwin' and isinstance(widget, tk.Button):
+                        widget.configure(highlightbackground=self.current['background'])
+
+                if 'font' not in attribs:
+                    widget.configure(font=self.current['font'])
+            elif 'foreground' in widget.keys():
+                # e.g. ttk.Label
+                if 'fg' not in attribs:
+                    widget.configure(foreground=self.current['foreground']),
+
+                if 'bg' not in attribs:
+                    widget.configure(background=self.current['background'])
+
+                if 'font' not in attribs:
+                    widget.configure(font=self.current['font'])
+
+            elif 'background' in widget.keys() or isinstance(widget, tk.Canvas):
+                # e.g. Frame, Canvas
+                if 'bg' not in attribs:
+                    widget.configure(background=self.current['background'],
+                                     highlightbackground=self.current['disabledforeground'])
+
+        except Exception:
+            logger.exception('Plugin widget issue ?')
 
     # Apply configured theme
 

--- a/theme.py
+++ b/theme.py
@@ -326,7 +326,7 @@ class _Theme(object):
                                      highlightbackground=self.current['disabledforeground'])
 
         except Exception:
-            logger.exception('Plugin widget issue ?')
+            logger.exception(f'Plugin widget issue ? {widget=}')
 
     # Apply configured theme
 

--- a/theme.py
+++ b/theme.py
@@ -195,17 +195,35 @@ class _Theme(object):
     def _enter(self, event, image):
         widget = event.widget
         if widget and widget['state'] != tk.DISABLED:
-            widget.configure(state=tk.ACTIVE)
+            try:
+                widget.configure(state=tk.ACTIVE)
+
+            except Exception:
+                logger.exception(f'Failure setting widget active: {widget=}')
+
             if image:
-                image.configure(foreground=self.current['activeforeground'],
-                                background=self.current['activebackground'])
+                try:
+                    image.configure(foreground=self.current['activeforeground'],
+                                    background=self.current['activebackground'])
+
+                except Exception:
+                    logger.exception(f'Failure configuring image: {image=}')
 
     def _leave(self, event, image):
         widget = event.widget
         if widget and widget['state'] != tk.DISABLED:
-            widget.configure(state=tk.NORMAL)
+            try:
+                widget.configure(state=tk.NORMAL)
+
+            except Exception:
+                logger.exception(f'Failure setting widget normal: {widget=}')
+
             if image:
-                image.configure(foreground=self.current['foreground'], background=self.current['background'])
+                try:
+                    image.configure(foreground=self.current['foreground'], background=self.current['background'])
+
+                except Exception:
+                    logger.exception(f'Failure configuring image: {image=}')
 
     # Set up colors
     def _colors(self, root, theme):


### PR DESCRIPTION
This adds a try/except around a bunch of .configure() calls on widgets. Yes, sure, this could then leave the widget in question in a broken state,but at least our entire UI won't fall flat on its face.

There may well be other places we should add such guards.  We should check for such before merging this.

If only we had plugins running in their own process with IPC for all UI poking, eh ?

Closing #1479 