### PR TITLE
Address EDMC.py journal name fallout & misc fixes

### DIFF
--- a/EDMC.py
+++ b/EDMC.py
@@ -7,9 +7,8 @@ import json
 import locale
 import os
 import queue
-import re
 import sys
-from os.path import getmtime, join
+from os.path import getmtime
 from time import sleep, time
 from typing import TYPE_CHECKING, Any, List, Optional
 
@@ -64,8 +63,6 @@ l10n.Translations.install_dummy()
 
 SERVER_RETRY = 5  # retry pause for Companion servers [s]
 EXIT_SUCCESS, EXIT_SERVER, EXIT_CREDENTIALS, EXIT_VERIFICATION, EXIT_LAGGING, EXIT_SYS_ERR, EXIT_ARGS = range(7)
-
-JOURNAL_RE = re.compile(r'^Journal(Beta)?\.[0-9]{12}\.[0-9]{2}\.log$')
 
 
 def versioncmp(versionstring) -> List:
@@ -225,10 +222,7 @@ sys.path: {sys.path}'''
                     monitor.currentdir = config.default_journal_dir
 
                 logger.debug(f'logdir = "{monitor.currentdir}"')
-                logfiles = sorted((x for x in os.listdir(monitor.currentdir) if JOURNAL_RE.search(x)),
-                                  key=lambda x: x.split('.')[1:])
-
-                logfile = join(monitor.currentdir, logfiles[-1])
+                logfile = monitor.journal_newest_filename(monitor.currentdir)
 
                 logger.debug(f'Using logfile "{logfile}"')
                 with open(logfile, 'r', encoding='utf-8') as loghandle:

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -1672,15 +1672,19 @@ class AppWindow(object):
 
     def exit_tray(self, systray: 'SysTrayIcon') -> None:
         """Tray icon is shutting down."""
-        exit_thread = threading.Thread(target=self.onexit)
-        exit_thread.setDaemon(True)
+        exit_thread = threading.Thread(
+            target=self.onexit,
+            daemon=True,
+        )
         exit_thread.start()
 
     def onexit(self, event=None) -> None:
         """Application shutdown procedure."""
         if sys.platform == 'win32':
-            shutdown_thread = threading.Thread(target=self.systray.shutdown)
-            shutdown_thread.setDaemon(True)
+            shutdown_thread = threading.Thread(
+                target=self.systray.shutdown,
+                daemon=True,
+            )
             shutdown_thread.start()
 
         config.set_shutdown()  # Signal we're in shutdown now.

--- a/monitor.py
+++ b/monitor.py
@@ -2236,7 +2236,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         if self._navroute_retries_remaining == 0:
             return False
 
-        logger.info(f'Navroute read retry [{self._navroute_retries_remaining}]')
+        logger.debug(f'Navroute read retry [{self._navroute_retries_remaining}]')
         self._navroute_retries_remaining -= 1
 
         if self._last_navroute_journal_timestamp is None:

--- a/monitor.py
+++ b/monitor.py
@@ -430,7 +430,8 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
             # Check whether new log file started, e.g. client (re)started.
             if emitter and emitter.is_alive():
-                new_journal_file = self.logfile  # updated by on_created watchdog callback
+                new_journal_file: Optional[str] = self.logfile  # updated by on_created watchdog callback
+
             else:
                 # Poll
                 try:

--- a/monitor.py
+++ b/monitor.py
@@ -268,6 +268,10 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         :param journals_dir: The directory to check
         :return: The `str` form of the full path to the newest Journal file
         """
+        # os.listdir(None) returns CWD's contents
+        if journals_dir is None:
+            return None
+
         journal_files = (x for x in listdir(journals_dir) if self._RE_LOGFILE.search(x))
         if journal_files:
             # Odyssey Update 11 has, e.g.    Journal.2022-03-15T152503.01.log


### PR DESCRIPTION
This mostly is closing #1511 , but at the same time I've fixed a few niggles:

* Old use of thread `setDaemon()` which is deprecated.
* Fix monitor.py type for variable taking the return from `journal_newest_filename()` as python was guessing badly.
* Make `journal_newest_filename()` correctly handle an input of `None`.
* Quieten the navroute retry from INFO to DEBUG to make EDMC.py less spammy if there's a NavRoute event.