### PR TITLE
Move back to latest `setuptools`, with workaround

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,9 +5,7 @@ wheel
 # We can't rely on just picking this up from either the base (not venv),
 # or venv-init-time version.  Specify here so that dependabot will prod us
 # about new versions.
-## Anything later than 60.10.0 complains about auto-discovering multiple
-## packages. ref: <https://github.com/py2exe/py2exe/issues/136>
-setuptools==60.10.0
+setuptools==62.6.0
 
 # Static analysis tools
 flake8==4.0.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -37,7 +37,7 @@ lxml==4.9.0
 # We only need py2exe on windows.
 # Pre-release version addressing semantic_version 2.9.0+ issues:
 # <https://github.com/py2exe/py2exe/issues/126>
-py2exe==0.11.1.0; sys_platform == 'win32'
+py2exe==0.11.1.1; sys_platform == 'win32'
 
 # Testing
 pytest==7.1.2

--- a/setup.py
+++ b/setup.py
@@ -268,6 +268,7 @@ setup(
     ],
     data_files=DATA_FILES,
     options=OPTIONS,
+    py_modules=[],
 )
 
 package_filename = None


### PR DESCRIPTION
Whilst the actual `py2exe` build process now works with this workaround and latest `setuptools`, we're now hitting another issue with `infi.systray`'s use of `pkg_resources`, see https://github.com/py2exe/py2exe/issues/139