### PR TITLE
Handle NavRouteClear

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -698,6 +698,18 @@ New in version 5.1.1:
 `state` now has a `ShipLockerJSON` member containing the un-changed, loaded,
 JSON from the `ShipLockerJSON.json` file.
 
+New in version 5.4.2+:
+
+We now handle the 'Update 13' `NavRouteClear` event by detecting if that's what
+is in the `NavRoute.json` file.  If this is the case then we log that, **but
+do NOT clear `state['NavRoute']`**.  Plugins will get sent the Journal
+`NavRouteClear` event anyway, and there might be some value to them retaining
+access to the prior plotted route.
+
+NB: It *is* possible, if a player is quick enough, to plot and clear a route
+before we load it, in which case we'd be retaining the *previous* plotted
+route.
+
 ___
 
 ##### Synthetic Events

--- a/monitor.py
+++ b/monitor.py
@@ -1469,7 +1469,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                                 self.state[category].pop(material)
 
                 module = self.state['Modules'][entry['Slot']]
-                assert(module['Item'] == self.canonicalise(entry['Module']))
+                assert module['Item'] == self.canonicalise(entry['Module'])
                 module['Engineering'] = {
                     'Engineer':      entry['Engineer'],
                     'EngineerID':    entry['EngineerID'],
@@ -2300,9 +2300,15 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             )
             return False
 
-        # everything is good, lets set what we need to and make sure we dont try again
-        logger.info('Successfully read NavRoute file for last NavRoute event.')
-        self.state['NavRoute'] = file
+        # Handle it being `NavRouteClear`d already
+        if file['event'].lower() == 'navrouteclear':
+            logger.info('NavRoute file contained a NavRouteClear')
+            # We do *NOT* copy into/clear the `self.state['NavRoute']`
+        else:
+            # everything is good, lets set what we need to and make sure we dont try again
+            logger.info('Successfully read NavRoute file for last NavRoute event.')
+            self.state['NavRoute'] = file
+
         self._navroute_retries_remaining = 0
         self._last_navroute_journal_timestamp = None
         return True

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -1111,8 +1111,10 @@ class EDDN:
         # Sanity check - Ref Issue 1342
         if 'Route' not in entry:
             logger.warning(f"NavRoute didn't contain a Route array!\n{entry!r}")
-            # LANG: No 'Route' found in NavRoute.json file
-            return _("No 'Route' array in NavRoute.json contents")
+            # This can happen if first-load of the file failed, and we're simply
+            # passing through the bare Journal event, so no need to alert
+            # the user.
+            return None
 
         #######################################################################
         # Elisions


### PR DESCRIPTION
If the `NavRoute.json` contains a `NavClearRoute` event, then simply consider that a success and discontinue loading attempts.

Closes #1634 