### PR TITLE
inara: ApproachSettlement: Only set marketID if present in event

### DIFF
--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -673,7 +673,7 @@ def journal_entry(  # noqa: C901, CCR001
                         'starsystemBodyCoords': [entry['Latitude'], entry['Longitude']]
                     }
                     # Not present on, e.g. Ancient Ruins
-                    if market_id := entry.get('MarketID') is not None:
+                    if (market_id := entry.get('MarketID')) is not None:
                         to_send['marketID'] = market_id
 
                     new_add_event('setCommanderTravelLocation', entry['timestamp'], to_send)

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -669,10 +669,13 @@ def journal_entry(  # noqa: C901, CCR001
                     to_send = {
                         'starsystemName':       system,
                         'stationName':          entry['Name'],
-                        'marketID':             entry['MarketID'],
                         'starsystemBodyName':   entry['BodyName'],
                         'starsystemBodyCoords': [entry['Latitude'], entry['Longitude']]
                     }
+                    # Not present on, e.g. Ancient Ruins
+                    if market_id := entry.get('MarketID') is not None:
+                        to_send['marketID'] = market_id
+
                     new_add_event('setCommanderTravelLocation', entry['timestamp'], to_send)
 
             elif event_name == 'FSDJump':


### PR DESCRIPTION
At least 'Ancient Ruins' generate an `ApproachSettlement` event without a `MarketID` in the event.  Not even a key with `null` value.