### PR TITLE
l10n: Use locale.format_string() instead of deprecated locale.format()

### DIFF
--- a/l10n.py
+++ b/l10n.py
@@ -284,10 +284,10 @@ class _Locale:
             return self.float_formatter.stringFromNumber_(number)
 
         if not decimals and isinstance(number, numbers.Integral):
-            return locale.format('%d', number, True)
+            return locale.format_string('%d', number, True)
 
         else:
-            return locale.format('%.*f', (decimals, number), True)  # type: ignore  # It ends up working out
+            return locale.format_string('%.*f', (decimals, number), True)
 
     def number_from_string(self, string: str) -> Union[int, float, None]:
         """


### PR DESCRIPTION
As per 3.10.6's https://docs.python.org/3/library/locale.html#locale.format

> Deprecated since version 3.7: Use [format_string()](https://docs.python.org/3/library/locale.html#locale.format_string) instead.

Closes #1061 