### PR TITLE
Fix up the journal_lock tests for pytest temporary directory factory changes

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -91,3 +91,11 @@ jobs:
         # explicitly ignore docstring errors (start with D)
         git diff "refs/remotes/${BASE_REPO_OWNER}/${BASE_REF}" -- | flake8 . --count --statistics --diff --extend-ignore D
     ####################################################################
+
+    ####################################################################
+    # Ensure all tests pass
+    ####################################################################
+    - name: PyTest tests
+      run: |
+        pytest
+    ####################################################################

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   flake8:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -12,7 +12,7 @@ on:
     branches: [ develop ]
 
 jobs:
-  flake8:
+  code-checks:
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/push-checks.yml
+++ b/.github/workflows/push-checks.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/journal_lock.py
+++ b/journal_lock.py
@@ -182,7 +182,9 @@ class JournalLock:
         if hasattr(self, 'journal_dir_lockfile'):
             self.journal_dir_lockfile.close()
 
-        self.journal_dir_lockfile_name = None
+        # Doing this makes it impossible for tests to ensure the file
+        # is removed as a part of cleanup.  So don't.
+        # self.journal_dir_lockfile_name = None
         # Avoids type hint issues, see 'declaration' in JournalLock.__init__()
         # self.journal_dir_lockfile = None
 

--- a/tests/journal_lock.py/test_journal_lock.py
+++ b/tests/journal_lock.py/test_journal_lock.py
@@ -277,7 +277,7 @@ class TestJournalLock:
         continue_q: mp.Queue = mp.Queue()
         exit_q: mp.Queue = mp.Queue()
         locker = mp.Process(target=other_process_lock,
-                            args=(continue_q, exit_q, mock_journaldir)
+                            args=(continue_q, exit_q, mock_journaldir.getbasetemp())
                             )
         print('Starting sub-process other_process_lock()...')
         locker.start()

--- a/tests/journal_lock.py/test_journal_lock.py
+++ b/tests/journal_lock.py/test_journal_lock.py
@@ -353,7 +353,7 @@ class TestJournalLock:
         """
         # First actually obtain the lock, and check it worked
         jlock = JournalLock()
-        jlock.obtain_lock()
+        assert jlock.obtain_lock() == JournalLockResult.LOCKED
         assert jlock.locked
 
         # Now store the 'current' journaldir for reference and attempt

--- a/tests/journal_lock.py/test_journal_lock.py
+++ b/tests/journal_lock.py/test_journal_lock.py
@@ -108,25 +108,28 @@ class TestJournalLock:
     """JournalLock test class."""
 
     @pytest.fixture
-    def mock_journaldir(self, monkeypatch: _pytest_monkeypatch, tmpdir: _pytest_tmpdir) -> py_path_local_LocalPath:
+    def mock_journaldir(
+        self, monkeypatch: _pytest_monkeypatch,
+        tmpdir_factory: _pytest_tmpdir.TempPathFactory
+    ) -> py_path_local_LocalPath:
         """Fixture for mocking config.get_str('journaldir')."""
         def get_str(key: str, *, default: str = None) -> str:
             """Mock config.*Config get_str to provide fake journaldir."""
             if key == 'journaldir':
-                return tmpdir
+                return tmpdir_factory
 
             print('Other key, calling up ...')
             return config.get_str(key)  # Call the non-mocked
 
         with monkeypatch.context() as m:
             m.setattr(config, "get_str", get_str)
-            yield tmpdir
+            yield tmpdir_factory
 
     @pytest.fixture
     def mock_journaldir_changing(
             self,
             monkeypatch: _pytest_monkeypatch,
-            tmpdir_factory: _pytest_tmpdir.TempdirFactory
+            tmpdir_factory: _pytest_tmpdir.TempPathFactory
     ) -> py_path_local_LocalPath:
         """Fixture for mocking config.get_str('journaldir')."""
         def get_str(key: str, *, default: str = None) -> str:

--- a/tests/journal_lock.py/test_journal_lock.py
+++ b/tests/journal_lock.py/test_journal_lock.py
@@ -200,9 +200,9 @@ class TestJournalLock:
         locked = jlock.obtain_lock()
         assert locked == JournalLockResult.LOCKED
         assert jlock.locked
-        assert jlock.release_lock()
 
         # Cleanup, to avoid side-effect on other tests
+        assert jlock.release_lock()
         os.unlink(str(jlock.journal_dir_lockfile_name))
 
     def test_obtain_lock_with_tmpdir_ro(self, mock_journaldir: py_path_local_LocalPath):
@@ -314,6 +314,9 @@ class TestJournalLock:
         with open(mock_journaldir / 'edmc-journal-lock.txt', mode='w+') as lf:
             assert _obtain_lock('release-lock', lf)
 
+        # Cleanup, to avoid side-effect on other tests
+        os.unlink(str(jlock.journal_dir_lockfile_name))
+
     def test_release_lock_not_locked(self, mock_journaldir: py_path_local_LocalPath):
         """Test JournalLock.release_lock() when not locked."""
         jlock = JournalLock()
@@ -350,7 +353,9 @@ class TestJournalLock:
         assert jlock.journal_dir != old_journaldir
         assert jlock.locked
 
+        # Cleanup, to avoid side-effect on other tests
         assert jlock.release_lock()
+        os.unlink(str(jlock.journal_dir_lockfile_name))
 
     def test_update_lock_same(self, mock_journaldir: py_path_local_LocalPath):
         """
@@ -370,3 +375,7 @@ class TestJournalLock:
         jlock.update_lock(None)  # type: ignore
         assert jlock.journal_dir == old_journaldir
         assert jlock.locked
+
+        # Cleanup, to avoid side-effect on other tests
+        assert jlock.release_lock()
+        os.unlink(str(jlock.journal_dir_lockfile_name))

--- a/tests/journal_lock.py/test_journal_lock.py
+++ b/tests/journal_lock.py/test_journal_lock.py
@@ -116,7 +116,7 @@ class TestJournalLock:
         def get_str(key: str, *, default: str = None) -> str:
             """Mock config.*Config get_str to provide fake journaldir."""
             if key == 'journaldir':
-                return str(tmp_path_factory)
+                return str(tmp_path_factory.getbasetemp())
 
             print('Other key, calling up ...')
             return config.get_str(key)  # Call the non-mocked
@@ -148,7 +148,8 @@ class TestJournalLock:
     # Tests against JournalLock.__init__()
     def test_journal_lock_init(self, mock_journaldir: py_path_local_LocalPath):
         """Test JournalLock instantiation."""
-        tmpdir = str(mock_journaldir)
+        print(f'{type(mock_journaldir)=}')
+        tmpdir = str(mock_journaldir.getbasetemp())
 
         jlock = JournalLock()
         # Check members are properly initialised.
@@ -343,6 +344,8 @@ class TestJournalLock:
         jlock.update_lock(None)  # type: ignore
         assert jlock.journal_dir != old_journaldir
         assert jlock.locked
+
+        assert jlock.release_lock()
 
     def test_update_lock_same(self, mock_journaldir: py_path_local_LocalPath):
         """

--- a/tests/journal_lock.py/test_journal_lock.py
+++ b/tests/journal_lock.py/test_journal_lock.py
@@ -69,6 +69,9 @@ def other_process_lock(continue_q: mp.Queue, exit_q: mp.Queue, lockfile: pathlib
         print('sub-process: Waiting for exit signal...')
         exit_q.get(block=True, timeout=None)
 
+        # And clean up
+        os.unlink(lockfile / 'edmc-journal-lock.txt')
+
 
 def _obtain_lock(prefix: str, filehandle) -> bool:
     """
@@ -311,7 +314,7 @@ class TestJournalLock:
         assert jlock.release_lock()
 
         # And finally check it actually IS unlocked.
-        with open(mock_journaldir / 'edmc-journal-lock.txt', mode='w+') as lf:
+        with open(mock_journaldir.getbasetemp() / 'edmc-journal-lock.txt', mode='w+') as lf:
             assert _obtain_lock('release-lock', lf)
 
         # Cleanup, to avoid side-effect on other tests

--- a/tests/journal_lock.py/test_journal_lock.py
+++ b/tests/journal_lock.py/test_journal_lock.py
@@ -352,6 +352,7 @@ class TestJournalLock:
         # Now store the 'current' journaldir for reference and attempt
         # to update to a new one.
         old_journaldir = jlock.journal_dir
+        old_journaldir_lockfile_name = jlock.journal_dir_lockfile_name
         jlock.update_lock(None)  # type: ignore
         assert jlock.journal_dir != old_journaldir
         assert jlock.locked
@@ -359,6 +360,8 @@ class TestJournalLock:
         # Cleanup, to avoid side-effect on other tests
         assert jlock.release_lock()
         os.unlink(str(jlock.journal_dir_lockfile_name))
+        # And the old_journaldir's lockfile too
+        os.unlink(str(old_journaldir_lockfile_name))
 
     def test_update_lock_same(self, mock_journaldir: py_path_local_LocalPath):
         """

--- a/tests/journal_lock.py/test_journal_lock.py
+++ b/tests/journal_lock.py/test_journal_lock.py
@@ -110,45 +110,45 @@ class TestJournalLock:
     @pytest.fixture
     def mock_journaldir(
         self, monkeypatch: _pytest_monkeypatch,
-        tmpdir_factory: _pytest_tmpdir.TempPathFactory
+        tmp_path_factory: _pytest_tmpdir.TempPathFactory
     ) -> py_path_local_LocalPath:
         """Fixture for mocking config.get_str('journaldir')."""
         def get_str(key: str, *, default: str = None) -> str:
             """Mock config.*Config get_str to provide fake journaldir."""
             if key == 'journaldir':
-                return tmpdir_factory
+                return str(tmp_path_factory)
 
             print('Other key, calling up ...')
             return config.get_str(key)  # Call the non-mocked
 
         with monkeypatch.context() as m:
             m.setattr(config, "get_str", get_str)
-            yield tmpdir_factory
+            yield tmp_path_factory
 
     @pytest.fixture
     def mock_journaldir_changing(
             self,
             monkeypatch: _pytest_monkeypatch,
-            tmpdir_factory: _pytest_tmpdir.TempPathFactory
+            tmp_path_factory: _pytest_tmpdir.TempPathFactory
     ) -> py_path_local_LocalPath:
         """Fixture for mocking config.get_str('journaldir')."""
         def get_str(key: str, *, default: str = None) -> str:
             """Mock config.*Config get_str to provide fake journaldir."""
             if key == 'journaldir':
-                return tmpdir_factory.mktemp("changing")
+                return tmp_path_factory.mktemp("changing")
 
             print('Other key, calling up ...')
             return config.get_str(key)  # Call the non-mocked
 
         with monkeypatch.context() as m:
             m.setattr(config, "get_str", get_str)
-            yield tmpdir_factory
+            yield tmp_path_factory
 
     ###########################################################################
     # Tests against JournalLock.__init__()
     def test_journal_lock_init(self, mock_journaldir: py_path_local_LocalPath):
         """Test JournalLock instantiation."""
-        tmpdir = mock_journaldir
+        tmpdir = str(mock_journaldir)
 
         jlock = JournalLock()
         # Check members are properly initialised.


### PR DESCRIPTION
I happened to run `pytest` and found the journal_lock tests utterly broken.

In essence they changed the name of the "temporary directory factory", and by the looks of it also what references to it return. So, this adds some `.getbasetemp()` calls, and some wrapper `str(...)` where necessary to actually be comparing the correct things.

Also, a prior test could have left a lock file in existence when subsequent tests needed it to not be there in order to work properly, i.e. the "read only directory" test.  So I've added `release_lock()` and `os.unlink(...)` cleanups all over.

I've also now added an attempt to run `pytest` in the GitHub pr-checks, and bumped all reference to Ubuntu 18.04 to 22.04, as the former is deprecated.