### PR TITLE
Finally(?) ensure all the tests work, no contamination or races

### DIFF
--- a/tests/journal_lock.py/test_journal_lock.py
+++ b/tests/journal_lock.py/test_journal_lock.py
@@ -70,6 +70,7 @@ def other_process_lock(continue_q: mp.Queue, exit_q: mp.Queue, lockfile: pathlib
         exit_q.get(block=True, timeout=None)
 
         # And clean up
+        _release_lock('sub-process', lf)
         os.unlink(lockfile / 'edmc-journal-lock.txt')
 
 
@@ -329,6 +330,8 @@ class TestJournalLock:
         # Fails on Linux, because flock(2) is per process, so we'd need to
         # use multiprocessing to test this.
         assert second_attempt == JournalLockResult.ALREADY_LOCKED
+        # And need to release any handles on the lockfile
+        jlock.journal_dir_lockfile.close()
         print('Telling sub-process to quit...')
         exit_q.put('quit')
         print('Waiting for sub-process...')

--- a/tests/journal_lock.py/test_journal_lock.py
+++ b/tests/journal_lock.py/test_journal_lock.py
@@ -1,33 +1,4 @@
-"""
-Tests for journal_lock.py code.
-
-Tests:
- - Is file actually locked after obtain_lock().  Problem: We opened the
-    file in a manner which means nothing else can open it.  Also I assume
-    that the same process will either be allowed to lock it 'again' or
-    overwrite the lock.
-
-    Expected failures if:
-
-     1. Lock already held (elsewhere).
-     2. Can't open lock file 'w+'.
-     3. Path to lock file doesn't exist.
-     4. journaldir is None (default on Linux).
-
- - Does release_lock() work?  Easier to test, if it's worked....
-     1. return True if not locked.
-     2. return True if locked, but successful unlock.
-     3. return False otherwise.
-
- - JournalLock.set_path_from_journaldir
-     1. When journaldir is None.
-     2. Succeeds otherwise?
-
- - Can any string to pathlib.Path result in an invalid path for other
-   operations?
-
- - Not sure about testing JournalAlreadyLocked class.
-"""
+"""Tests for journal_lock.py code."""
 import multiprocessing as mp
 import os
 import pathlib
@@ -327,11 +298,13 @@ class TestJournalLock:
         # Now attempt to lock with to-test code
         jlock = JournalLock()
         second_attempt = jlock.obtain_lock()
-        # Fails on Linux, because flock(2) is per process, so we'd need to
-        # use multiprocessing to test this.
         assert second_attempt == JournalLockResult.ALREADY_LOCKED
-        # And need to release any handles on the lockfile
+
+        # Need to release any handles on the lockfile else the sub-process
+        # might not be able to clean up properly, and that will impact
+        # on later tests.
         jlock.journal_dir_lockfile.close()
+
         print('Telling sub-process to quit...')
         exit_q.put('quit')
         print('Waiting for sub-process...')


### PR DESCRIPTION
Mostly the test for 'already locked', which utilises a `multiprocessing` separate process to have the lock already held, was causing issues for later tests due to failure to properly remove the lockfile during its run.

I also checked that the tests *do* run properly on Linux, so have removed the comment about that test 'not working' on Linux, as we did implement the whole separate process thing.

It was also high time for removal of most of the top-level docstring text, which was initial thoughts on what tests would be needed.

I'm willing to be convinced that, actually, we should make each test use its own sub-directory so as to avoid any cross-test issues.  Those issues having been:
1. Another test left the lockfile in existence, which interfered with the "this user doesn't have permissions to create the lockfile" test.   So they all need to `os.unlink(...)` it when they're done, which in turn means they need to have closed their filehandle(s) on it as well.
2. The 'already locked' test highlighted possible race conditions if the separate process didn't clean up after itself properly.