### PR TITLE
Implement a `ttk.Sizegrip` for any-theme window resizing

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -551,9 +551,11 @@ class AppWindow(object):
         self.status.grid(row=0, column=0, sticky=tk.W)
 
         # Make the window resizable
-        master.resizable(True, False)
+        # Yes, we need to allow vertical resizing, else theme changing can
+        # cause the botttom of the UI to be irretrievably hidden.
+        master.resizable(True, True)
         ttk_grip = ttk.Sizegrip(self.status_row, name='size_grip')
-        ttk_grip.grid(row=0, column=1, sticky=tk.SE)
+        ttk_grip.grid(row=0, column=1, sticky=tk.E)
         #######################################################################
 
         for child in frame.winfo_children():

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -526,19 +526,35 @@ class AppWindow(object):
                 else:
                     appitem.grid(columnspan=2, sticky=tk.EW)
 
+        #######################################################################
         # LANG: Update button in main window
         self.button = ttk.Button(frame, text=_('Update'), width=28, default=tk.ACTIVE, state=tk.DISABLED)
         self.theme_button = tk.Label(frame, width=32 if sys.platform == 'darwin' else 28, state=tk.DISABLED)
-        self.status = tk.Label(frame, name='status', anchor=tk.W)
 
         ui_row = frame.grid_size()[1]
         self.button.grid(row=ui_row, columnspan=2, sticky=tk.NSEW)
         self.theme_button.grid(row=ui_row, columnspan=2, sticky=tk.NSEW)
         theme.register_alternate((self.button, self.theme_button, self.theme_button),
                                  {'row': ui_row, 'columnspan': 2, 'sticky': tk.NSEW})
-        self.status.grid(columnspan=2, sticky=tk.EW)
         self.button.bind('<Button-1>', self.capi_request_data)
         theme.button_bind(self.theme_button, self.capi_request_data)
+        #######################################################################
+
+        #######################################################################
+        # Status line
+        self.status_row = tk.Frame(frame, name='status_row')
+        self.status_row.grid(columnspan=2, sticky=tk.NSEW)
+        self.status_row.columnconfigure(0, weight=99)
+        self.status_row.columnconfigure(1, weight=1)
+
+        self.status = tk.Label(self.status_row, name='status', anchor=tk.W)
+        self.status.grid(row=0, column=0, sticky=tk.W)
+
+        # Make the window resizable
+        master.resizable(True, False)
+        ttk_grip = ttk.Sizegrip(self.status_row, name='size_grip')
+        ttk_grip.grid(row=0, column=1, sticky=tk.SE)
+        #######################################################################
 
         for child in frame.winfo_children():
             child.grid_configure(padx=self.PADX, pady=(

--- a/theme.py
+++ b/theme.py
@@ -298,17 +298,17 @@ class _Theme(object):
 
             elif 'cursor' in widget.keys() and str(widget['cursor']) not in ['', 'arrow']:
                 # Hack - highlight widgets like HyperlinkLabel with a non-default cursor
-                if 'fg' not in attribs:
+                if 'fg' not in attribs and 'foreground' in widget.keys():
                     widget.configure(foreground=self.current['highlight']),
                     if 'insertbackground' in widget.keys():  # tk.Entry
                         widget.configure(insertbackground=self.current['foreground']),
 
-                if 'bg' not in attribs:
+                if 'bg' not in attribs and 'background' in widget.keys():
                     widget.configure(background=self.current['background'])
                     if 'highlightbackground' in widget.keys():  # tk.Entry
                         widget.configure(highlightbackground=self.current['background'])
 
-                if 'font' not in attribs:
+                if 'font' not in attribs and 'font' in widget.keys():
                     widget.configure(font=self.current['font'])
 
             elif 'activeforeground' in widget.keys():

--- a/theme.py
+++ b/theme.py
@@ -115,6 +115,7 @@ elif sys.platform == 'linux':
 class _Theme(object):
 
     def __init__(self):
+        self.ttk_style = None
         self.active = None  # Starts out with no theme
         self.minwidth = None
         self.widgets = {}
@@ -183,6 +184,10 @@ class _Theme(object):
         if isinstance(widget, tk.Frame) or isinstance(widget, ttk.Frame):
             for child in widget.winfo_children():
                 self.register(child)
+
+        # This class is an import-time singleton, so can't do this in __init__
+        # as tkinter won't have been at all set up by then.
+        self.ttk_style = ttk.Style()
 
     def register_alternate(self, pair, gridopts):
         self.widgets_pair.append((pair, gridopts))
@@ -430,6 +435,16 @@ class _Theme(object):
         if not self.minwidth:
             self.minwidth = root.winfo_width()  # Minimum width = width on first creation
             root.minsize(self.minwidth, -1)
+
+        #######################################################################
+        # Update our ttk.Style
+        #
+        # Ref: <https://stackoverflow.com/a/54476816>
+        # Ref: <https://tkdocs.com/shipman/ttk-style-layer.html>
+        ######################################################################
+        self.ttk_style.configure('TSizegrip', background=self.current['background'])
+        self.ttk_style.configure('TSizegrip', foreground=self.current['foreground'])
+        #######################################################################
 
 
 # singleton


### PR DESCRIPTION
Due to how some of the UI is set up this *still* only allows *horizontal* resizing, but that's no change.

Now there's a handle in the bottom-right corner, same row as the status text, which allows for resizing.

This entailed implementing a `ttk.Style` instance to ensure correct colouring in all themes.

**This will need testing on Linux**.

Closes #478 