### PR TITLE
Change EDDN 'replay' to using an sqlite3 DB & otherwise improve

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -922,7 +922,7 @@ class AppWindow(object):
                     return False
 
             # Ignore possibly missing shipyard info
-            elif (config.get_int('output') & config.OUT_MKT_EDDN) \
+            elif (config.get_int('output') & config.OUT_EDDN_SEND_STATION_DATA) \
                     and not (data['lastStarport'].get('commodities') or data['lastStarport'].get('modules')):
                 if not self.status['text']:
                     # LANG: Status - Either no market or no modules data for station from Frontier CAPI

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -617,6 +617,7 @@ Content of `state` (updated to the current journal entry):
 | `Modules`            |           `dict`            | Currently fitted modules                                                                                        |
 | `NavRoute`           |           `dict`            | Last plotted multi-hop route                                                                                    |
 | `ModuleInfo`         |           `dict`            | Last loaded ModulesInfo.json data                                                                               |
+| `IsDocked`           |           `bool`            | Whether the Cmdr is currently docked *in their own ship*.                                                       |
 | `OnFoot`             |           `bool`            | Whether the Cmdr is on foot                                                                                     |
 | `Component`          |           `dict`            | 'Component' MicroResources in Odyssey, `int` count each.                                                        |
 | `Item`               |           `dict`            | 'Item' MicroResources in Odyssey, `int` count each.                                                             |
@@ -709,6 +710,17 @@ access to the prior plotted route.
 NB: It *is* possible, if a player is quick enough, to plot and clear a route
 before we load it, in which case we'd be retaining the *previous* plotted
 route.
+
+New in version 5.6.0:
+
+`IsDocked` boolean added to `state`.  This is set True for a `Location` event
+having `"Docked":true"`, or the `Docked` event.  It is set back to False (its
+default value) for an `Undocked` event.  Being on-foot in a station at login
+time does *not* count as docked for this.
+
+In general on-foot, including being in a taxi, might not set this 100%
+correctly.  Its main use in core code is to detect being docked so as to send
+any stored EDDN messages due to "Delay sending until docked" option.
 
 ___
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -52,7 +52,7 @@ appcmdname = 'EDMC'
 # <https://semver.org/#semantic-versioning-specification-semver>
 # Major.Minor.Patch(-prerelease)(+buildmetadata)
 # NB: Do *not* import this, use the functions appversion() and appversion_nobuild()
-_static_appversion = '5.5.1-alpha0'
+_static_appversion = '5.6.0-alpha0'
 _cached_version: Optional[semantic_version.Version] = None
 copyright = '© 2015-2019 Jonathan Harris, 2020-2022 EDCD'
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -175,7 +175,7 @@ class AbstractConfig(abc.ABC):
     # OUT_SYS_EDSM = 256  # Now a plugin
     # OUT_SYS_AUTO = 512  # Now always automatic
     OUT_MKT_MANUAL = 1024
-    OUT_SYS_EDDN = 2048
+    OUT_EDDN_SEND_NON_STATION = 2048
     OUT_EDDN_DO_NOT_DELAY = 4096
 
     app_dir_path: pathlib.Path

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -176,7 +176,7 @@ class AbstractConfig(abc.ABC):
     # OUT_SYS_AUTO = 512  # Now always automatic
     OUT_MKT_MANUAL = 1024
     OUT_SYS_EDDN = 2048
-    OUT_SYS_DELAY = 4096
+    OUT_EDDN_DO_NOT_DELAY = 4096
 
     app_dir_path: pathlib.Path
     plugin_dir_path: pathlib.Path

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -171,12 +171,12 @@ class AbstractConfig(abc.ABC):
     # OUT_SYS_FILE = 32	# No longer supported
     # OUT_STAT = 64	# No longer available
     # OUT_SHIP_CORIOLIS = 128	# Replaced by OUT_SHIP
-    OUT_STATION_ANY = OUT_EDDN_SEND_STATION_DATA | OUT_MKT_TD | OUT_MKT_CSV
     # OUT_SYS_EDSM = 256  # Now a plugin
     # OUT_SYS_AUTO = 512  # Now always automatic
     OUT_MKT_MANUAL = 1024
     OUT_EDDN_SEND_NON_STATION = 2048
     OUT_EDDN_DO_NOT_DELAY = 4096
+    OUT_STATION_ANY = OUT_EDDN_SEND_STATION_DATA | OUT_MKT_TD | OUT_MKT_CSV
 
     app_dir_path: pathlib.Path
     plugin_dir_path: pathlib.Path

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -175,7 +175,7 @@ class AbstractConfig(abc.ABC):
     # OUT_SYS_AUTO = 512  # Now always automatic
     OUT_MKT_MANUAL = 1024
     OUT_EDDN_SEND_NON_STATION = 2048
-    OUT_EDDN_DO_NOT_DELAY = 4096
+    OUT_EDDN_DELAY = 4096
     OUT_STATION_ANY = OUT_EDDN_SEND_STATION_DATA | OUT_MKT_TD | OUT_MKT_CSV
 
     app_dir_path: pathlib.Path

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -162,7 +162,7 @@ def appversion_nobuild() -> semantic_version.Version:
 class AbstractConfig(abc.ABC):
     """Abstract root class of all platform specific Config implementations."""
 
-    OUT_MKT_EDDN = 1
+    OUT_EDDN_SEND_STATION_DATA = 1
     # OUT_MKT_BPC = 2	# No longer supported
     OUT_MKT_TD = 4
     OUT_MKT_CSV = 8
@@ -171,7 +171,7 @@ class AbstractConfig(abc.ABC):
     # OUT_SYS_FILE = 32	# No longer supported
     # OUT_STAT = 64	# No longer available
     # OUT_SHIP_CORIOLIS = 128	# Replaced by OUT_SHIP
-    OUT_STATION_ANY = OUT_MKT_EDDN | OUT_MKT_TD | OUT_MKT_CSV
+    OUT_STATION_ANY = OUT_EDDN_SEND_STATION_DATA | OUT_MKT_TD | OUT_MKT_CSV
     # OUT_SYS_EDSM = 256  # Now a plugin
     # OUT_SYS_AUTO = 512  # Now always automatic
     OUT_MKT_MANUAL = 1024

--- a/monitor.py
+++ b/monitor.py
@@ -166,6 +166,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             'Modules':            None,
             'CargoJSON':          None,  # The raw data from the last time cargo.json was read
             'Route':              None,  # Last plotted route from Route.json file
+            'IsDocked':           False,  # Whether we think cmdr is docked
             'OnFoot':             False,  # Whether we think you're on-foot
             'Component':          defaultdict(int),      # Odyssey Components in Ship Locker
             'Item':               defaultdict(int),      # Odyssey Items in Ship Locker
@@ -306,6 +307,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         self.systemaddress = None
         self.is_beta = False
         self.state['OnFoot'] = False
+        self.state['IsDocked'] = False
         self.state['Body'] = None
         self.state['BodyType'] = None
 
@@ -725,6 +727,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.station_marketid = None
                 self.stationtype = None
                 self.stationservices = None
+                self.state['IsDocked'] = False
 
             elif event_type == 'embark':
                 # This event is logged when a player (on foot) gets into a ship or SRV
@@ -791,6 +794,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.state['Dropship'] = False
 
             elif event_type == 'docked':
+                self.state['IsDocked'] = True
                 self.station = entry.get('StationName')  # May be None
                 self.station_marketid = entry.get('MarketID')  # May be None
                 self.stationtype = entry.get('StationType')  # May be None
@@ -813,6 +817,8 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
                     if event_type == 'location':
                         logger.trace_if('journal.locations', '"Location" event')
+                        if entry.get('Docked'):
+                            self.state['IsDocked'] = True
 
                 elif event_type == 'fsdjump':
                     self.planet = None

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -201,6 +201,14 @@ class EDDNSender:
 
         return db_conn
 
+    def close(self) -> None:
+        """Clean up any resources."""
+        if self.db:
+            self.db.close()
+
+        if self.db_conn:
+            self.db_conn.close()
+
     def add_message(self, cmdr, msg) -> int:
         """
         Add an EDDN message to the database.
@@ -318,11 +326,10 @@ class EDDN:
 
     def close(self):
         """Close down the EDDN class instance."""
-        logger.debug('Closing replayfile...')
-        if self.replayfile:
-            self.replayfile.close()
+        logger.debug('Closing Sender...')
+        if self.sender:
+            self.sender.close()
 
-        self.replayfile = None
         logger.debug('Done.')
 
         logger.debug('Closing EDDN requests.Session.')

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -678,7 +678,7 @@ class EDDN:
             self.send_message(data['commander']['name'], {
                 '$schemaRef': f'https://eddn.edcd.io/schemas/commodity/3{"/test" if is_beta else ""}',
                 'message':    message,
-                'header':     self.standard_header(game_version='CAPI-market', game_build='CAPI-market'),
+                'header':     self.standard_header(game_version='CAPI-market', game_build=''),
             })
 
         this.commodities = commodities
@@ -772,7 +772,7 @@ class EDDN:
                     ('modules',     outfitting),
                     ('odyssey',     this.odyssey),
                 ]),
-                'header':     self.standard_header(game_version='CAPI-shipyard', game_build='CAPI-shipyard'),
+                'header':     self.standard_header(game_version='CAPI-shipyard', game_build=''),
             })
 
         this.outfitting = (horizons, outfitting)
@@ -817,7 +817,7 @@ class EDDN:
                     ('ships',       shipyard),
                     ('odyssey',     this.odyssey),
                 ]),
-                'header':     self.standard_header(game_version='CAPI-shipyard', game_build='CAPI-shipyard'),
+                'header':     self.standard_header(game_version='CAPI-shipyard', game_build=''),
             })
 
         this.shipyard = (horizons, shipyard)
@@ -1506,7 +1506,7 @@ class EDDN:
         msg = {
             '$schemaRef': f'https://eddn.edcd.io/schemas/fcmaterials_capi/1{"/test" if is_beta else ""}',
             'message': entry,
-            'header': self.standard_header(game_version='CAPI-market', game_build='CAPI-market'),
+            'header': self.standard_header(game_version='CAPI-market', game_build=''),
         }
 
         this.eddn.send_message(data['commander']['name'], msg)

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -254,6 +254,20 @@ class EDDNSender:
 
         return self.db.lastrowid
 
+    def delete_message(self, row_id: int) -> None:
+        """
+        Delete a queued message by row id.
+
+        :param row_id:
+        """
+        self.db.execute(
+            """
+            DELETE FROM messages WHERE id = :row_id
+            """,
+            {'row_id': row_id}
+        )
+        self.db_conn.commit()
+
     def convert_legacy_file(self):
         """Convert a legacy file's contents into the sqlite3 db."""
         try:

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -175,7 +175,7 @@ class EDDNSender:
 
         self.queue_processing = Lock()
         # Initiate retry/send-now timer
-        self.eddn.parent.after(self.eddn.REPLAY_PERIOD, self.queue_check_and_send, True)
+        self.eddn.parent.after(self.eddn.REPLAY_STARTUP_DELAY, self.queue_check_and_send, True)
 
     def sqlite_queue_v1(self) -> sqlite3.Connection:
         """
@@ -552,6 +552,7 @@ class EDDN:
         DEFAULT_URL = f'http://{edmc_data.DEBUG_WEBSERVER_HOST}:{edmc_data.DEBUG_WEBSERVER_PORT}/eddn'
 
     # FIXME: Change back to `300_000`
+    REPLAY_STARTUP_DELAY = 10_000  # Delay during startup before checking queue [milliseconds]
     REPLAY_PERIOD = 300_000  # How often to try (re-)sending the queue, [milliseconds]
     REPLAY_DELAY = 400  # Roughly two messages per second, accounting for send delays [milliseconds]
     REPLAYFLUSH = 20  # Update log on disk roughly every 10 seconds

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -316,19 +316,6 @@ class EDDN:
 
         self.fss_signals: List[Mapping[str, Any]] = []
 
-    def flush(self):
-        """Flush the replay file, clearing any data currently there that is not in the replaylog list."""
-        if self.replayfile is None:
-            logger.error('replayfile is None!')
-            return
-
-        self.replayfile.seek(0, SEEK_SET)
-        self.replayfile.truncate()
-        for line in self.replaylog:
-            self.replayfile.write(f'{line}\n')
-
-        self.replayfile.flush()
-
     def close(self):
         """Close down the EDDN class instance."""
         logger.debug('Closing replayfile...')

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -340,7 +340,7 @@ class EDDNSender:
 
         return False
 
-    def send_message(self, msg: str) -> bool:  # noqa: CCR001
+    def send_message(self, msg: str) -> bool:
         """
         Transmit a fully-formed EDDN message to the Gateway.
 
@@ -2191,7 +2191,7 @@ def journal_entry(  # noqa: C901, CCR001
     return None
 
 
-def cmdr_data(data: CAPIData, is_beta: bool) -> Optional[str]:  # noqa: CCR001
+def cmdr_data(data: CAPIData, is_beta: bool) -> Optional[str]:
     """
     Process new CAPI data.
 

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -349,6 +349,9 @@ class EDDNSender:
         :param msg: Fully formed, string, message.
         :return: `True` for "now remove this message from the queue"
         """
+
+        # TODO: Check if user options require us to send at this time.
+
         should_return, new_data = killswitch.check_killswitch('plugins.eddn.send', json.loads(msg))
         if should_return:
             logger.warning('eddn.send has been disabled via killswitch. Returning.')
@@ -500,6 +503,9 @@ class EDDN:
         :param cmdr: the CMDR to use as the uploader ID.
         :param msg: the payload to send.
         """
+
+        # TODO: Check if the global 'Send to EDDN' option is off
+
         to_send: OrderedDictT[str, OrderedDict[str, Any]] = OrderedDict([
             ('$schemaRef', msg['$schemaRef']),
             ('header', OrderedDict([
@@ -1854,7 +1860,7 @@ def plugin_prefs(parent, cmdr: str, is_beta: bool) -> Frame:
     )
 
     this.eddn_system_button.grid(padx=BUTTONX, pady=(5, 0), sticky=tk.W)
-    this.eddn_delay = tk.IntVar(value=(output & config.OUT_SYS_DELAY) and 1)
+    this.eddn_delay = tk.IntVar(value=(output & config.OUT_EDDN_DO_NOT_DELAY) and 1)
     # Output setting under 'Send system and scan data to the Elite Dangerous Data Network' new in E:D 2.2
     this.eddn_delay_button = nb.Checkbutton(
         eddnframe,
@@ -1891,7 +1897,7 @@ def prefs_changed(cmdr: str, is_beta: bool) -> None:
          & (config.OUT_MKT_TD | config.OUT_MKT_CSV | config.OUT_SHIP | config.OUT_MKT_MANUAL)) +
         (this.eddn_station.get() and config.OUT_MKT_EDDN) +
         (this.eddn_system.get() and config.OUT_SYS_EDDN) +
-        (this.eddn_delay.get() and config.OUT_SYS_DELAY)
+        (this.eddn_delay.get() and config.OUT_EDDN_DO_NOT_DELAY)
     )
 
 

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -30,7 +30,6 @@ import pathlib
 import re
 import sqlite3
 import sys
-import time
 import tkinter as tk
 from collections import OrderedDict
 from platform import system
@@ -929,14 +928,18 @@ class EDDN:
             # 'Station data'
             if config.get_int('output') & config.OUT_EDDN_SEND_STATION_DATA:
                 # And user has 'station data' configured to be sent
-                msg['header'] = self.standard_header()
+                if 'header' not in msg:
+                    msg['header'] = self.standard_header()
+
                 msg_id = self.sender.add_message(cmdr, msg)
                 # 'Station data' is never delayed on construction of message
                 self.sender.send_message_by_id(msg_id)
 
         elif config.get_int('output') & config.OUT_EDDN_SEND_NON_STATION:
             # Any data that isn't 'station' is configured to be sent
-            msg['header'] = self.standard_header()
+            if 'header' not in msg:
+                msg['header'] = self.standard_header()
+
             msg_id = self.sender.add_message(cmdr, msg)
             if not (config.get_int('output') & config.OUT_EDDN_DELAY):
                 # No delay in sending configured, so attempt immediately

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -635,7 +635,7 @@ class EDDN:
             self.send_message(data['commander']['name'], {
                 '$schemaRef': f'https://eddn.edcd.io/schemas/commodity/3{"/test" if is_beta else ""}',
                 'message':    message,
-                'header':     self.standard_header(game_version='CAPI-market', game_build='CAPI-market')
+                'header':     self.standard_header(game_version='CAPI-market', game_build='CAPI-market'),
             })
 
         this.commodities = commodities
@@ -729,6 +729,7 @@ class EDDN:
                     ('modules',     outfitting),
                     ('odyssey',     this.odyssey),
                 ]),
+                'header':     self.standard_header(game_version='CAPI-shipyard', game_build='CAPI-shipyard'),
             })
 
         this.outfitting = (horizons, outfitting)
@@ -773,6 +774,7 @@ class EDDN:
                     ('ships',       shipyard),
                     ('odyssey',     this.odyssey),
                 ]),
+                'header':     self.standard_header(game_version='CAPI-shipyard', game_build='CAPI-shipyard'),
             })
 
         this.shipyard = (horizons, shipyard)

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -191,13 +191,31 @@ class EDDN:
                 """
                 CREATE TABLE messages
                 (
-                    id INT PRIMARY KEY NOT NULL,
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
                     created TEXT NOT NULL,
                     cmdr TEXT NOT NULL,
                     edmc_version TEXT,
                     game_version TEXT,
                     game_build TEXT,
                     message TEXT NOT NULL
+                )
+                """
+            )
+
+            replaydb.execute(
+                """
+                CREATE INDEX messages_created ON messages
+                (
+                    created
+                )
+                """
+            )
+
+            replaydb.execute(
+                """
+                CREATE INDEX messages_cmdr ON messages
+                (
+                    cmdr
                 )
                 """
             )

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -1350,8 +1350,7 @@ class EDDN:
         #         }
         #     ]
         # }
-
-        # TODO: Check we're configured to send station data
+        # Abort if we're not configured to send 'station' data.
         if not config.get_int('output') & config.OUT_EDDN_SEND_STATION_DATA:
             return None
 

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -1797,10 +1797,7 @@ def plugin_app(parent: tk.Tk) -> Optional[tk.Frame]:
     Set up any plugin-specific UI.
 
     In this case we need the tkinter parent in order to later call
-    `update_idletasks()` on it.
-
-    TODO: Re-work the whole replaylog and general sending to EDDN so this isn't
-          necessary.
+    `update_idletasks()` on it, or schedule things with `after()`.
 
     :param parent: tkinter parent frame.
     :return: Optional tk.Frame, if the tracking UI is active.

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -30,7 +30,6 @@ import sqlite3
 import sys
 import tkinter as tk
 from collections import OrderedDict
-from os import SEEK_SET
 from platform import system
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Mapping, MutableMapping, Optional
@@ -130,13 +129,17 @@ class EDDNSender:
 
     SQLITE_DB_FILENAME_V1 = 'eddn_queue-v1.db'
 
-    def __init__(self, eddn_endpoint) -> None:
+    def __init__(self, eddn_endpoint: str) -> None:
         """
         Prepare the system for processing messages.
 
         - Ensure the sqlite3 database for EDDN replays exists and has schema.
         - Convert any legacy file into the database.
+
+        :param eddn_endpoint: Where messages should be sent.
         """
+        self.eddn_endpoint = eddn_endpoint
+
         self.db_conn = self.sqlite_queue_v1()
         self.db = self.db_conn.cursor()
 
@@ -146,7 +149,7 @@ class EDDNSender:
         self.convert_legacy_file()
         #######################################################################
 
-    def sqlite_queue_v1(self):
+    def sqlite_queue_v1(self) -> sqlite3.Connection:
         """
         Initialise a v1 EDDN queue database.
 
@@ -209,7 +212,7 @@ class EDDNSender:
         if self.db_conn:
             self.db_conn.close()
 
-    def add_message(self, cmdr, msg) -> int:
+    def add_message(self, cmdr: str, msg: dict) -> int:
         """
         Add an EDDN message to the database.
 
@@ -266,7 +269,7 @@ class EDDNSender:
         """
         Delete a queued message by row id.
 
-        :param row_id:
+        :param row_id: id of message to be deleted.
         """
         self.db.execute(
             """

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -260,10 +260,8 @@ class EDDNSender:
             filename = config.app_dir_path / 'replay.jsonl'
             with open(filename, 'r+', buffering=1) as replay_file:
                 for line in replay_file:
-                    j = json.loads(line)
-                    cmdr, msg = j
+                    cmdr, msg = json.loads(line)
                     self.add_message(cmdr, msg)
-                    break
 
         except FileNotFoundError:
             pass

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -941,7 +941,7 @@ class EDDN:
                 msg['header'] = self.standard_header()
 
             msg_id = self.sender.add_message(cmdr, msg)
-            if not (config.get_int('output') & config.OUT_EDDN_DELAY):
+            if this.docked or not (config.get_int('output') & config.OUT_EDDN_DELAY):
                 # No delay in sending configured, so attempt immediately
                 self.sender.send_message_by_id(msg_id)
 

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -635,6 +635,7 @@ class EDDN:
             self.send_message(data['commander']['name'], {
                 '$schemaRef': f'https://eddn.edcd.io/schemas/commodity/3{"/test" if is_beta else ""}',
                 'message':    message,
+                'header':     self.standard_header(game_version='CAPI-market', game_build='CAPI-market')
             })
 
         this.commodities = commodities
@@ -1453,7 +1454,7 @@ class EDDN:
         msg = {
             '$schemaRef': f'https://eddn.edcd.io/schemas/fcmaterials_capi/1{"/test" if is_beta else ""}',
             'message': entry,
-            'header': self.standard_header(game_version='CAPI-commodity', game_build='CAPI-commodity'),
+            'header': self.standard_header(game_version='CAPI-market', game_build='CAPI-market'),
         }
 
         this.eddn.send_message(data['commander']['name'], msg)

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -125,10 +125,10 @@ HORIZONS_SKU = 'ELITE_HORIZONS_V_PLANETARY_LANDINGS'
 # one.
 
 
-class EDDNReplay:
+class EDDNSender:
     """Store and retry sending of EDDN messages."""
 
-    SQLITE_DB_FILENAME = 'eddn_replay.db'
+    SQLITE_DB_FILENAME = 'eddn_queue-v1.db'
 
     def __init__(self) -> None:
         """
@@ -187,6 +187,8 @@ class EDDNReplay:
         `msg` absolutely needs to be the **FULL** EDDN message, including all
         of `header`, `$schemaRef` and `message`.  Code handling this not being
         the case is only for loading the legacy `replay.json` file messages.
+
+        TODO: Return the unique row id of the added message.
 
         :param cmdr: Name of the Commander that created this message.
         :param msg: The full, transmission-ready, EDDN message.
@@ -267,11 +269,7 @@ class EDDN:
         self.session = requests.Session()
         self.session.headers['User-Agent'] = user_agent
 
-        #######################################################################
-        # EDDN delayed sending/retry
-        #######################################################################
-        self.replay = EDDNReplay()
-        #######################################################################
+        self.sender = EDDNSender()
 
         self.fss_signals: List[Mapping[str, Any]] = []
 

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -201,7 +201,7 @@ class EDDNSender:
 
         return db_conn
 
-    def add_message(self, cmdr, msg):
+    def add_message(self, cmdr, msg) -> int:
         """
         Add an EDDN message to the database.
 
@@ -209,10 +209,12 @@ class EDDNSender:
         of `header`, `$schemaRef` and `message`.  Code handling this not being
         the case is only for loading the legacy `replay.json` file messages.
 
-        TODO: Return the unique row id of the added message.
+        NB: Although `cmdr` *should* be the same as `msg->header->uploaderID`
+            we choose not to assume that.
 
         :param cmdr: Name of the Commander that created this message.
         :param msg: The full, transmission-ready, EDDN message.
+        :return: ID of the successfully inserted row.
         """
         # Cater for legacy replay.json messages
         if 'header' not in msg:
@@ -249,6 +251,8 @@ class EDDNSender:
 
         except Exception:
             logger.exception('EDDNReplay INSERT error')
+
+        return self.db.lastrowid
 
     def convert_legacy_file(self):
         """Convert a legacy file's contents into the sqlite3 db."""

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -1824,7 +1824,7 @@ def plugin_prefs(parent, cmdr: str, is_beta: bool) -> Frame:
     BUTTONX = 12  # noqa: N806 # indent Checkbuttons and Radiobuttons
 
     if prefsVersion.shouldSetDefaults('0.0.0.0', not bool(config.get_int('output'))):
-        output: int = (config.OUT_MKT_EDDN | config.OUT_SYS_EDDN)  # default settings
+        output: int = (config.OUT_MKT_EDDN | config.OUT_EDDN_SEND_NON_STATION)  # default settings
 
     else:
         output = config.get_int('output')
@@ -1849,7 +1849,7 @@ def plugin_prefs(parent, cmdr: str, is_beta: bool) -> Frame:
     )  # Output setting
 
     this.eddn_station_button.grid(padx=BUTTONX, pady=(5, 0), sticky=tk.W)
-    this.eddn_system = tk.IntVar(value=(output & config.OUT_SYS_EDDN) and 1)
+    this.eddn_system = tk.IntVar(value=(output & config.OUT_EDDN_SEND_NON_STATION) and 1)
     # Output setting new in E:D 2.2
     this.eddn_system_button = nb.Checkbutton(
         eddnframe,
@@ -1896,7 +1896,7 @@ def prefs_changed(cmdr: str, is_beta: bool) -> None:
         (config.get_int('output')
          & (config.OUT_MKT_TD | config.OUT_MKT_CSV | config.OUT_SHIP | config.OUT_MKT_MANUAL)) +
         (this.eddn_station.get() and config.OUT_MKT_EDDN) +
-        (this.eddn_system.get() and config.OUT_SYS_EDDN) +
+        (this.eddn_system.get() and config.OUT_EDDN_SEND_NON_STATION) +
         (this.eddn_delay.get() and config.OUT_EDDN_DO_NOT_DELAY)
     )
 
@@ -2066,7 +2066,7 @@ def journal_entry(  # noqa: C901, CCR001
             this.status_body_name = None
 
     # Events with their own EDDN schema
-    if config.get_int('output') & config.OUT_SYS_EDDN and not state['Captain']:
+    if config.get_int('output') & config.OUT_EDDN_SEND_NON_STATION and not state['Captain']:
 
         if event_name == 'fssdiscoveryscan':
             return this.eddn.export_journal_fssdiscoveryscan(cmdr, system, state['StarPos'], is_beta, entry)
@@ -2123,7 +2123,7 @@ def journal_entry(  # noqa: C901, CCR001
             )
 
     # Send journal schema events to EDDN, but not when on a crew
-    if (config.get_int('output') & config.OUT_SYS_EDDN and not state['Captain'] and
+    if (config.get_int('output') & config.OUT_EDDN_SEND_NON_STATION and not state['Captain'] and
         (event_name in ('location', 'fsdjump', 'docked', 'scan', 'saasignalsfound', 'carrierjump')) and
             ('StarPos' in entry or this.coordinates)):
 

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -342,6 +342,10 @@ class EDDNSender:
         """
         Transmit a fully-formed EDDN message to the Gateway.
 
+        If this is called then the attempt *will* be made.  This is not where
+        options to not send to EDDN, or to delay the sending until docked,
+        are checked.
+
         Should catch and handle all failure conditions.  A `True` return might
         mean that the message was successfully sent, *or* that this message
         should not be retried after a failure, i.e. too large.
@@ -349,9 +353,6 @@ class EDDNSender:
         :param msg: Fully formed, string, message.
         :return: `True` for "now remove this message from the queue"
         """
-
-        # TODO: Check if user options require us to send at this time.
-
         should_return, new_data = killswitch.check_killswitch('plugins.eddn.send', json.loads(msg))
         if should_return:
             logger.warning('eddn.send has been disabled via killswitch. Returning.')

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -24,6 +24,7 @@
 # ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $#
 import itertools
 import json
+import os
 import pathlib
 import re
 import sqlite3
@@ -281,8 +282,8 @@ class EDDNSender:
 
     def convert_legacy_file(self):
         """Convert a legacy file's contents into the sqlite3 db."""
+        filename = config.app_dir_path / 'replay.jsonl'
         try:
-            filename = config.app_dir_path / 'replay.jsonl'
             with open(filename, 'r+', buffering=1) as replay_file:
                 for line in replay_file:
                     cmdr, msg = json.loads(line)
@@ -290,6 +291,13 @@ class EDDNSender:
 
         except FileNotFoundError:
             pass
+
+        finally:
+            # Best effort at removing the file/contents
+            # NB: The legacy code assumed it could write to the file.
+            replay_file = open(filename, 'w')  # Will truncate
+            replay_file.close()
+            os.unlink(filename)
 
 
 # TODO: a good few of these methods are static or could be classmethods. they should be created as such.

--- a/prefs.py
+++ b/prefs.py
@@ -1221,7 +1221,7 @@ class PreferencesDialog(tk.Toplevel):
             (self.out_csv.get() and config.OUT_MKT_CSV) +
             (config.OUT_MKT_MANUAL if not self.out_auto.get() else 0) +
             (self.out_ship.get() and config.OUT_SHIP) +
-            (config.get_int('output') & (config.OUT_MKT_EDDN | config.OUT_SYS_EDDN | config.OUT_SYS_DELAY))
+            (config.get_int('output') & (config.OUT_MKT_EDDN | config.OUT_SYS_EDDN | config.OUT_EDDN_DO_NOT_DELAY))
         )
 
         config.set(

--- a/prefs.py
+++ b/prefs.py
@@ -1221,7 +1221,7 @@ class PreferencesDialog(tk.Toplevel):
             (self.out_csv.get() and config.OUT_MKT_CSV) +
             (config.OUT_MKT_MANUAL if not self.out_auto.get() else 0) +
             (self.out_ship.get() and config.OUT_SHIP) +
-            (config.get_int('output') & (config.OUT_MKT_EDDN | config.OUT_EDDN_SEND_NON_STATION | config.OUT_EDDN_DO_NOT_DELAY))
+            (config.get_int('output') & (config.OUT_EDDN_SEND_STATION_DATA | config.OUT_EDDN_SEND_NON_STATION | config.OUT_EDDN_DO_NOT_DELAY))
         )
 
         config.set(

--- a/prefs.py
+++ b/prefs.py
@@ -1221,7 +1221,9 @@ class PreferencesDialog(tk.Toplevel):
             (self.out_csv.get() and config.OUT_MKT_CSV) +
             (config.OUT_MKT_MANUAL if not self.out_auto.get() else 0) +
             (self.out_ship.get() and config.OUT_SHIP) +
-            (config.get_int('output') & (config.OUT_EDDN_SEND_STATION_DATA | config.OUT_EDDN_SEND_NON_STATION | config.OUT_EDDN_DO_NOT_DELAY))
+            (config.get_int('output') & (
+                config.OUT_EDDN_SEND_STATION_DATA | config.OUT_EDDN_SEND_NON_STATION | config.OUT_EDDN_DO_NOT_DELAY
+            ))
         )
 
         config.set(

--- a/prefs.py
+++ b/prefs.py
@@ -1221,7 +1221,7 @@ class PreferencesDialog(tk.Toplevel):
             (self.out_csv.get() and config.OUT_MKT_CSV) +
             (config.OUT_MKT_MANUAL if not self.out_auto.get() else 0) +
             (self.out_ship.get() and config.OUT_SHIP) +
-            (config.get_int('output') & (config.OUT_MKT_EDDN | config.OUT_SYS_EDDN | config.OUT_EDDN_DO_NOT_DELAY))
+            (config.get_int('output') & (config.OUT_MKT_EDDN | config.OUT_EDDN_SEND_NON_STATION | config.OUT_EDDN_DO_NOT_DELAY))
         )
 
         config.set(

--- a/prefs.py
+++ b/prefs.py
@@ -1222,7 +1222,7 @@ class PreferencesDialog(tk.Toplevel):
             (config.OUT_MKT_MANUAL if not self.out_auto.get() else 0) +
             (self.out_ship.get() and config.OUT_SHIP) +
             (config.get_int('output') & (
-                config.OUT_EDDN_SEND_STATION_DATA | config.OUT_EDDN_SEND_NON_STATION | config.OUT_EDDN_DO_NOT_DELAY
+                config.OUT_EDDN_SEND_STATION_DATA | config.OUT_EDDN_SEND_NON_STATION | config.OUT_EDDN_DELAY
             ))
         )
 


### PR DESCRIPTION
1. The current `replay.json` has to be entirely rewritten if any message is added or removed.  That's just crap.  Either it churns to disk or risks losing data until a `flush()`.
2. The current code explicitly never queues station data messages.  The premise was "this is ephemeral data and another Cmdr will be along soon enough", but that's misguided.
3. 'Replay' was only ever triggered by being docked.  This is fine for a strict replay scenario, but not where initial sending of a message failed and it should be retried.  Cmdrs out in the black, without 'delay sending until docked' would have long delays in anything else being sent.

So, a partial rewrite.  At this time most of the functionality is working:

1. There's a new class `EDDNSender` to hold the queue and actual transmission code.
1. `EDDNSender.add_message()` will add the given message to the queue (sqlite3 DB).
2. If configuration says so then `EDDNSender.send_message_by_id(...)` will immediately be called to attempt sending.
3. If send is successful the message is removed from the queue.
4. All the code that constructs messages is on a path that checks if the message should be sent, skipping all processing if not.  There's an extra paranoia check in `EDDN.send_message()` which everything now goes through.
5. The one thing left to write is a queue worker to attempt to flush the queue by sending each message.