### PR TITLE
Make runnable under 64-bit Python

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           Invoke-Webrequest -UseBasicParsing https://github.com/vslavik/winsparkle/releases/download/v0.7.0/WinSparkle-0.7.0.zip -OutFile out.zip
           Expand-Archive out.zip
-          Move-Item 'out\WinSparkle-0.7.0\Release\*' '.\'
+          Move-Item 'out\WinSparkle-0.7.0\x64\Release\*' '.\'
 
       - name: Build EDMC
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,7 +82,7 @@ repos:
     - id: LANG_comments
       name: 'LANG comments'
       language: system
-      entry: python scripts/find_localised_strings.py --compare-lang L10n/en.template --directory . --ignore coriolis-data --ignore dist.win32
+      entry: python scripts/find_localised_strings.py --compare-lang L10n/en.template --directory . --ignore coriolis-data --ignore dist.win32 --ignore venv-3.11_64
       pass_filenames: false
       always_run: true
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,7 +82,7 @@ repos:
     - id: LANG_comments
       name: 'LANG comments'
       language: system
-      entry: python scripts/find_localised_strings.py --compare-lang L10n/en.template --directory . --ignore coriolis-data --ignore dist.win32 --ignore venv-3.11_64
+      entry: python scripts/find_localised_strings.py --compare-lang L10n/en.template --directory . --ignore coriolis-data --ignore dist.win32
       pass_filenames: false
       always_run: true
 

--- a/Build-exe-and-msi.py
+++ b/Build-exe-and-msi.py
@@ -22,7 +22,7 @@ if sys.version_info[0:2] != (3, 11):
     raise AssertionError(f'Unexpected python version {sys.version}')
 
 if sys.platform == 'win32':
-    assert platform.architecture()[0] == '32bit', 'A Python 32bit build is required'
+    assert platform.architecture()[0] == '64bit', 'A Python 64bit build is required'
     import py2exe  # noqa: F401 # Yes, this *is* used
     dist_dir = 'dist.win32'
 

--- a/Build-exe-and-msi.py
+++ b/Build-exe-and-msi.py
@@ -2,7 +2,6 @@
 """Build to executables and MSI installer using py2exe and other tools."""
 import os
 import pathlib
-import platform
 import re
 import shutil
 import sys
@@ -22,7 +21,6 @@ if sys.version_info[0:2] != (3, 11):
     raise AssertionError(f'Unexpected python version {sys.version}')
 
 if sys.platform == 'win32':
-    assert platform.architecture()[0] == '64bit', 'A Python 64bit build is required'
     import py2exe  # noqa: F401 # Yes, this *is* used
     dist_dir = 'dist.win32'
 

--- a/prefs.py
+++ b/prefs.py
@@ -1078,48 +1078,13 @@ class PreferencesDialog(tk.Toplevel):
         :param title: Title of the window
         :param pathvar: the path to start the dialog on
         """
-        import locale
-
-        # If encoding isn't UTF-8 we can't use the tkinter dialog
-        current_locale = locale.getlocale(locale.LC_CTYPE)
-        directory = None
-        if sys.platform == 'win32' and current_locale[1] not in ('utf8', 'UTF8', 'utf-8', 'UTF-8'):
-            def browsecallback(hwnd, uMsg, lParam, lpData):  # noqa: N803 # Windows API convention
-                # set initial folder
-                if uMsg == BFFM_INITIALIZED and lpData:
-                    ctypes.windll.user32.SendMessageW(hwnd, BFFM_SETSELECTION, 1, lpData)
-                return 0
-
-            browseInfo = BROWSEINFOW()  # noqa: N806 # Windows convention
-            # browseInfo.pidlRoot = None
-            browseInfo.pszDisplayName = ctypes.c_wchar_p("x" * MAX_PATH)
-            browseInfo.lpszTitle = title
-            browseInfo.ulFlags = BIF_RETURNONLYFSDIRS | BIF_USENEWUI
-            browseInfo.lpfn = BrowseCallbackProc(browsecallback)
-            # browseInfo.lParam = pathvar.get().startswith('~') and join(config.home_path,
-            #                                                            pathvar.get()[2:]) or pathvar.get()
-            ctypes.windll.ole32.CoInitialize(None)
-            pidl = ctypes.windll.shell32.SHBrowseForFolderW(ctypes.byref(browseInfo))
-            # ctypes.ArgumentError: argument 1: <class 'TypeError'>: expected LP__ITEMIDLIST instance instead of int
-            # pidl = SHBrowseForFolderW(ctypes.byref(browseInfo))
-            # OSError: exception: access violation writing 0x00007FFB582DC9BF
-            if pidl:
-                pidl = ctypes.cast(pidl, PIDLIST_ABSOLUTE)
-                path = ctypes.create_unicode_buffer(MAX_PATH)
-                path = SHGetPathFromIDListW(pidl)
-                ctypes.windll.ole32.CoTaskMemFree(pidl)
-                directory = path.value
-            else:
-                directory = None
-
-        else:
-            import tkinter.filedialog
-            directory = tkinter.filedialog.askdirectory(
-                parent=self,
-                initialdir=expanduser(pathvar.get()),
-                title=title,
-                mustexist=tk.TRUE
-            )
+        import tkinter.filedialog
+        directory = tkinter.filedialog.askdirectory(
+            parent=self,
+            initialdir=expanduser(pathvar.get()),
+            title=title,
+            mustexist=tk.TRUE
+        )
 
         if directory:
             pathvar.set(directory)

--- a/prefs.py
+++ b/prefs.py
@@ -189,7 +189,7 @@ elif sys.platform == 'win32':
         winreg.OpenKey(reg, WINE_REGISTRY_KEY)
         is_wine = True
 
-    except OSError:
+    except OSError:  # Assumed to be 'path not found', i.e. not-wine
         pass
 
     CalculatePopupWindowPosition = None

--- a/prefs.py
+++ b/prefs.py
@@ -181,7 +181,10 @@ if sys.platform == 'darwin':
 elif sys.platform == 'win32':
     import ctypes
     import winreg
-    from ctypes.wintypes import HINSTANCE, HWND, LPARAM, LPCWSTR, LPVOID, LPWSTR, MAX_PATH, POINT, RECT, SIZE, UINT
+    from ctypes import POINTER, WINFUNCTYPE, Structure
+    from ctypes.wintypes import (
+        BOOL, BYTE, HINSTANCE, HWND, LPARAM, LPCWSTR, LPWSTR, MAX_PATH, POINT, RECT, SIZE, UINT, USHORT
+    )
     is_wine = False
     try:
         WINE_REGISTRY_KEY = r'HKEY_LOCAL_MACHINE\Software\Wine'
@@ -192,18 +195,68 @@ elif sys.platform == 'win32':
     except OSError:
         pass
 
+    ###########################################################################
+    # From <https://github.com/hakril/PythonForWindows/blob/master/windows/generated_def/winstructs.py>
+    class _SHITEMID(ctypes.Structure):
+        _fields_ = [
+            ("cb", USHORT),
+            ("abID", BYTE * (1)),
+        ]
+
+    SHITEMID = _SHITEMID
+
+    class _ITEMIDLIST(Structure):
+        _fields_ = [
+            ("mkid", SHITEMID),
+        ]
+
+    ITEMIDLIST = _ITEMIDLIST
+    PCIDLIST_ABSOLUTE = ctypes.POINTER(_ITEMIDLIST)
+    PIDLIST_ABSOLUTE = ctypes.POINTER(_ITEMIDLIST)
+    ###########################################################################
+
+    ###########################################################################
+    # From: <https://stackoverflow.com/questions/32979525/creating-choose-folder-dialog-from-python-using-windows-api>
+    BrowseCallbackProc = WINFUNCTYPE(ctypes.c_int, HWND, ctypes.c_uint, LPARAM, LPARAM)
+
+    class BROWSEINFOW(ctypes.Structure):
+        """
+        Windows file browser fields.
+
+        Ref: <https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/ns-shlobj_core-browseinfow>
+        """
+
+        _fields_ = [
+            ("hwndOwner", HWND),
+            ("pidlRoot", PCIDLIST_ABSOLUTE),
+            ("pszDisplayName", LPWSTR),
+            ("lpszTitle", LPCWSTR),
+            ("ulFlags", UINT),
+            ("lpfn", BrowseCallbackProc),
+            ("lParam", LPARAM),
+            ("iImage", ctypes.c_int)
+        ]
+    LPBROWSEINFOW = POINTER(BROWSEINFOW)
+    ###########################################################################
+
     # https://msdn.microsoft.com/en-us/library/windows/desktop/bb762115
     BIF_RETURNONLYFSDIRS = 0x00000001
     BIF_USENEWUI = 0x00000050
     BFFM_INITIALIZED = 1
     BFFM_SETSELECTION = 0x00000467
-    BrowseCallbackProc = ctypes.WINFUNCTYPE(ctypes.c_int, HWND, ctypes.c_uint, LPARAM, LPARAM)
+    # SHGetPathFromIDListW
+    # Ref: <https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetpathfromidlistw>
+    # BOOL SHGetPathFromIDListW([in]  PCIDLIST_ABSOLUTE pidl,[out] LPWSTR pszPath);
+    prototype = WINFUNCTYPE(BOOL, PCIDLIST_ABSOLUTE, LPCWSTR)
+    paramflags = (1, "pidl"), (2, "pszPath", "")
+    SHGetPathFromIDListW = prototype(("SHGetPathFromIDListW", ctypes.windll.shell32), paramflags)
 
-    class BROWSEINFO(ctypes.Structure):
-        """Windows file browser fields."""
-
-        _fields_ = [("hwndOwner", HWND), ("pidlRoot", LPVOID), ("pszDisplayName", LPWSTR), ("lpszTitle", LPCWSTR),
-                    ("ulFlags", UINT), ("lpfn", BrowseCallbackProc), ("lParam", LPCWSTR), ("iImage", ctypes.c_int)]
+    # SHBrowseForFolderW
+    # Ref: <https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shbrowseforfolderw>
+    # PIDLIST_ABSOLUTE SHBrowseForFolderW([in] LPBROWSEINFOWW lpbi);
+    prototype = WINFUNCTYPE(PIDLIST_ABSOLUTE, LPBROWSEINFOW)
+    paramflags2 = (1, "lpbi"),
+    SHBrowseForFolderW = prototype(("SHGetPathFromIDListW", ctypes.windll.shell32), paramflags2)
 
     CalculatePopupWindowPosition = None
     if not is_wine:
@@ -1037,17 +1090,23 @@ class PreferencesDialog(tk.Toplevel):
                     ctypes.windll.user32.SendMessageW(hwnd, BFFM_SETSELECTION, 1, lpData)
                 return 0
 
-            browseInfo = BROWSEINFO()  # noqa: N806 # Windows convention
+            browseInfo = BROWSEINFOW()  # noqa: N806 # Windows convention
+            # browseInfo.pidlRoot = None
+            browseInfo.pszDisplayName = ctypes.c_wchar_p("x" * MAX_PATH)
             browseInfo.lpszTitle = title
             browseInfo.ulFlags = BIF_RETURNONLYFSDIRS | BIF_USENEWUI
             browseInfo.lpfn = BrowseCallbackProc(browsecallback)
-            browseInfo.lParam = pathvar.get().startswith('~') and join(config.home_path,
-                                                                       pathvar.get()[2:]) or pathvar.get()
+            # browseInfo.lParam = pathvar.get().startswith('~') and join(config.home_path,
+            #                                                            pathvar.get()[2:]) or pathvar.get()
             ctypes.windll.ole32.CoInitialize(None)
             pidl = ctypes.windll.shell32.SHBrowseForFolderW(ctypes.byref(browseInfo))
+            # ctypes.ArgumentError: argument 1: <class 'TypeError'>: expected LP__ITEMIDLIST instance instead of int
+            # pidl = SHBrowseForFolderW(ctypes.byref(browseInfo))
+            # OSError: exception: access violation writing 0x00007FFB582DC9BF
             if pidl:
+                pidl = ctypes.cast(pidl, PIDLIST_ABSOLUTE)
                 path = ctypes.create_unicode_buffer(MAX_PATH)
-                ctypes.windll.shell32.SHGetPathFromIDListW(pidl, path)
+                path = SHGetPathFromIDListW(pidl)
                 ctypes.windll.ole32.CoTaskMemFree(pidl)
                 directory = path.value
             else:

--- a/prefs.py
+++ b/prefs.py
@@ -181,10 +181,7 @@ if sys.platform == 'darwin':
 elif sys.platform == 'win32':
     import ctypes
     import winreg
-    from ctypes import POINTER, WINFUNCTYPE, Structure
-    from ctypes.wintypes import (
-        BOOL, BYTE, HINSTANCE, HWND, LPARAM, LPCWSTR, LPWSTR, MAX_PATH, POINT, RECT, SIZE, UINT, USHORT
-    )
+    from ctypes.wintypes import HINSTANCE, HWND, LPCWSTR, LPWSTR, MAX_PATH, POINT, RECT, SIZE, UINT
     is_wine = False
     try:
         WINE_REGISTRY_KEY = r'HKEY_LOCAL_MACHINE\Software\Wine'
@@ -194,69 +191,6 @@ elif sys.platform == 'win32':
 
     except OSError:
         pass
-
-    ###########################################################################
-    # From <https://github.com/hakril/PythonForWindows/blob/master/windows/generated_def/winstructs.py>
-    class _SHITEMID(ctypes.Structure):
-        _fields_ = [
-            ("cb", USHORT),
-            ("abID", BYTE * (1)),
-        ]
-
-    SHITEMID = _SHITEMID
-
-    class _ITEMIDLIST(Structure):
-        _fields_ = [
-            ("mkid", SHITEMID),
-        ]
-
-    ITEMIDLIST = _ITEMIDLIST
-    PCIDLIST_ABSOLUTE = ctypes.POINTER(_ITEMIDLIST)
-    PIDLIST_ABSOLUTE = ctypes.POINTER(_ITEMIDLIST)
-    ###########################################################################
-
-    ###########################################################################
-    # From: <https://stackoverflow.com/questions/32979525/creating-choose-folder-dialog-from-python-using-windows-api>
-    BrowseCallbackProc = WINFUNCTYPE(ctypes.c_int, HWND, ctypes.c_uint, LPARAM, LPARAM)
-
-    class BROWSEINFOW(ctypes.Structure):
-        """
-        Windows file browser fields.
-
-        Ref: <https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/ns-shlobj_core-browseinfow>
-        """
-
-        _fields_ = [
-            ("hwndOwner", HWND),
-            ("pidlRoot", PCIDLIST_ABSOLUTE),
-            ("pszDisplayName", LPWSTR),
-            ("lpszTitle", LPCWSTR),
-            ("ulFlags", UINT),
-            ("lpfn", BrowseCallbackProc),
-            ("lParam", LPARAM),
-            ("iImage", ctypes.c_int)
-        ]
-    LPBROWSEINFOW = POINTER(BROWSEINFOW)
-    ###########################################################################
-
-    # https://msdn.microsoft.com/en-us/library/windows/desktop/bb762115
-    BIF_RETURNONLYFSDIRS = 0x00000001
-    BIF_USENEWUI = 0x00000050
-    BFFM_INITIALIZED = 1
-    BFFM_SETSELECTION = 0x00000467
-    # SHGetPathFromIDListW
-    # Ref: <https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetpathfromidlistw>
-    # BOOL SHGetPathFromIDListW([in]  PCIDLIST_ABSOLUTE pidl,[out] LPWSTR pszPath);
-    prototype = WINFUNCTYPE(BOOL, PCIDLIST_ABSOLUTE, LPCWSTR)
-    paramflags = (1, "pidl"), (2, "pszPath", "")
-    SHGetPathFromIDListW = prototype(("SHGetPathFromIDListW", ctypes.windll.shell32), paramflags)
-
-    # SHBrowseForFolderW
-    # Ref: <https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shbrowseforfolderw>
-    # PIDLIST_ABSOLUTE SHBrowseForFolderW([in] LPBROWSEINFOWW lpbi);
-    prototype = WINFUNCTYPE(PIDLIST_ABSOLUTE, LPBROWSEINFOW)
-    paramflags2 = (1, "lpbi"),
-    SHBrowseForFolderW = prototype(("SHGetPathFromIDListW", ctypes.windll.shell32), paramflags2)
 
     CalculatePopupWindowPosition = None
     if not is_wine:

--- a/protocol.py
+++ b/protocol.py
@@ -125,8 +125,8 @@ elif (config.auth_force_edmc_protocol
     from ctypes import windll  # type: ignore
     from ctypes import POINTER, WINFUNCTYPE, Structure, byref, c_long, c_void_p, create_unicode_buffer, wstring_at
     from ctypes.wintypes import (
-        ATOM, BOOL, DWORD, HBRUSH, HGLOBAL, HICON, HINSTANCE, HMENU, HWND, INT, LPARAM, LPCWSTR, LPVOID, LPWSTR, MSG,
-        UINT, WPARAM
+        ATOM, BOOL, DWORD, HBRUSH, HGLOBAL, HICON, HINSTANCE, HMENU, HWND, INT, LPARAM, LPCWSTR, LPMSG, LPVOID, LPWSTR,
+        MSG, UINT, WPARAM
     )
 
     class WNDCLASS(Structure):
@@ -161,13 +161,21 @@ elif (config.auth_force_edmc_protocol
     # Ref: <https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-defwindowprocw>
     # LRESULT DefWindowProcW([in] HWND   hWnd,[in] UINT   Msg,[in] WPARAM wParam,[in] LPARAM lParam);
     # As per example at <https://docs.python.org/3/library/ctypes.html#ctypes.WINFUNCTYPE>
+
     prototype = WINFUNCTYPE(c_long, HWND, UINT, WPARAM, LPARAM)
     paramflags = (1, "hWnd"), (1, "Msg"), (1, "wParam"), (1, "lParam")
     DefWindowProcW = prototype(("DefWindowProcW", windll.user32), paramflags)
+
     GetParent = windll.user32.GetParent
     SetForegroundWindow = windll.user32.SetForegroundWindow
 
-    GetMessageW = windll.user32.GetMessageW
+    # <https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getmessagew>
+    # NB: Despite 'BOOL' return type, it *can* be >0, 0 or -1, so is actually
+    #     c_long
+    prototype = WINFUNCTYPE(c_long, LPMSG, HWND, UINT, UINT)
+    paramflags = (1, "lpMsg"), (1, "hWnd"), (1, "wMsgFilterMin"), (1, "wMsgFilterMax")
+    GetMessageW = prototype(("GetMessageW", windll.user32), paramflags)
+
     TranslateMessage = windll.user32.TranslateMessage
     DispatchMessageW = windll.user32.DispatchMessageW
     PostThreadMessageW = windll.user32.PostThreadMessageW
@@ -309,6 +317,17 @@ elif (config.auth_force_edmc_protocol
 
             msg = MSG()
             # Calls GetMessageW: https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getmessagew
+            # Something is off with the return from this, meaning you'll see:
+            # Exception ignored on converting result of ctypes callback function: <function WndProc
+            #    at 0x000001F5B8738FE0>
+            # Traceback (most recent call last):
+            #   File "C:\Users\Athan\Documents\Devel\EDMarketConnector\protocol.py", line 323, in worker
+            #     while int(GetMessageW(byref(msg), None, 0, 0)) != 0:
+            #               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+            # TypeError: 'c_long' object cannot be interpreted as an integer
+            #
+            # But it does actually work.  Either getting a non-0 value and
+            # entering the loop, or getting 0 and exiting it.
             while GetMessageW(byref(msg), None, 0, 0) != 0:
                 logger.trace_if('frontier-auth.windows', f'DDE message of type: {msg.message}')
                 if msg.message == WM_DDE_EXECUTE:

--- a/protocol.py
+++ b/protocol.py
@@ -106,12 +106,12 @@ if sys.platform == 'darwin' and getattr(sys, 'frozen', False):  # noqa: C901 # i
 
         def handleEvent_withReplyEvent_(self, event, replyEvent) -> None:  # noqa: N802 N803 # Required to override
             """Actual event handling from NSAppleEventManager."""
-            protocolhandler.lasturl = urllib.parse.unquote(  # noqa: F821: type: ignore # Its going to be a DPH in
+            protocolhandler.lasturl = urllib.parse.unquote(  # noqa: F821: type: ignore # It's going to be a DPH in
                 # this code
                 event.paramDescriptorForKeyword_(keyDirectObject).stringValue()
             ).strip()
 
-            protocolhandler.master.after(DarwinProtocolHandler.POLL, protocolhandler.poll)  # noqa: F821: type: ignore
+            protocolhandler.master.after(DarwinProtocolHandler.POLL, protocolhandler.poll)  # noqa: F821 # type: ignore
 
 
 elif (config.auth_force_edmc_protocol
@@ -157,7 +157,13 @@ elif (config.auth_force_edmc_protocol
     CreateWindowExW.restype = HWND
     RegisterClassW = windll.user32.RegisterClassW
     RegisterClassW.argtypes = [POINTER(WNDCLASS)]
-    DefWindowProcW = windll.user32.DefWindowProcW
+    # DefWindowProcW
+    # Ref: <https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-defwindowprocw>
+    # LRESULT DefWindowProcW([in] HWND   hWnd,[in] UINT   Msg,[in] WPARAM wParam,[in] LPARAM lParam);
+    # As per example at <https://docs.python.org/3/library/ctypes.html#ctypes.WINFUNCTYPE>
+    prototype = WINFUNCTYPE(c_long, HWND, UINT, WPARAM, LPARAM)
+    paramflags = (1, "hWnd"), (1, "Msg"), (1, "wParam"), (1, "lParam")
+    DefWindowProcW = prototype(("DefWindowProcW", windll.user32), paramflags)
     GetParent = windll.user32.GetParent
     SetForegroundWindow = windll.user32.SetForegroundWindow
 

--- a/stats.py
+++ b/stats.py
@@ -335,8 +335,6 @@ class StatsDialog():
         elif (
             not capi_data.get('lastSystem')
             or not capi_data['lastSystem'].get('name', '').strip()
-            or not capi_data.get('lastStarport')
-            or not capi_data['lastStarport'].get('name', '').strip()
         ):
             # Shouldn't happen
             # LANG: Unknown location


### PR DESCRIPTION
Given the `py2exe` deprecation of 32-bit packages I decided it was time to take another stab at getting our .exe files to run under 64-bit Python.

After some fiddling around with ctypes, and re-testing showing we **can** just use `tkinter.filedialog` now (last tested under Python 3.7.x in Oct 2020), the code now all works under 64-bit Python 3.10.8 (and also 3.11.0).

* `Build-exe-and-msi.py` has been adjusted to check for, and require, 64-bit, not 32-bit, Python.
* You need the `x64` version of the `WinSparkle.dll` (~~still need to adjust the github workflow for that~~ done).
* All the files that had `ctypes` in them have had all their code tested as working on 64-bit.
* For that "Where should the Output file location be?" code in `prefs.py`... I really did try to get the old ctypes code working under 64-bit python, but ultimately failed.  Upon re-checking `tkinter.filedialog` **without setting locale to UTF-8** it Just Worked anyway.  Indeed I couldn't reproduce the original error with Python 3.7.9 64-bit either.  It's possible that Windows 10 builds older than mine (21H2 / 19044.2311) might still have an issue with this.  It needs testing.