### PR TITLE
Fix URL for EDDN GitHub Link

### DIFF
--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -1697,7 +1697,7 @@ def plugin_prefs(parent, cmdr: str, is_beta: bool) -> Frame:
         eddnframe,
         text='Elite Dangerous Data Network',
         background=nb.Label().cget('background'),
-        url='https://github.com/EDSM-NET/EDDN/wiki',
+        url='https://github.com/EDCD/EDDN#eddn---elite-dangerous-data-network',
         underline=True
     ).grid(padx=PADX, sticky=tk.W)  # Don't translate
 


### PR DESCRIPTION
Currently `https://github.com/EDSM-NET/EDDN/wiki` is being forwarded to `https://github.com/EDCD/EDDN/wiki` already and that page says one should read the readme instead of the wiki, so we should adjust the URL in EDMC. I'm open for the exact URL though (link to README.md directly, use anchor or not..).