### PR TITLE
Improve CAPI code for Legacy/Live split

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -944,7 +944,7 @@ class AppWindow(object):
 
         return True
 
-    def capi_request_data(self, event=None) -> None:
+    def capi_request_data(self, event=None) -> None:  # noqa: CCR001
         """
         Perform CAPI data retrieval and associated actions.
 
@@ -967,6 +967,17 @@ class AppWindow(object):
             logger.trace_if('capi.worker', 'Aborting Query: Game Mode unknown')
             # LANG: CAPI queries aborted because game mode unknown
             self.status['text'] = _('CAPI query aborted: Game mode unknown')
+            return
+
+        if monitor.state['GameVersion'] is None:
+            logger.trace_if('capi.worker', 'Aborting Query: GameVersion unknown')
+            # LANG: CAPI queries aborted because GameVersion unknown
+            self.status['text'] = _('CAPI query aborted: GameVersion unknown')
+            return
+
+        if not monitor.is_live_galaxy():
+            logger.warning("Dropping CAPI request because this is the Legacy galaxy, which is not yet supported")
+            self.status['text'] = 'CAPI for Legacy not yet supported'
             return
 
         if not monitor.system:

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -1172,6 +1172,7 @@ class AppWindow(object):
                     monitor.state['Loan'] = capi_response.capi_data['commander'].get('debt', 0)
 
                 # stuff we can do when not docked
+                # TODO: Use plug.notify_capi_legacy if Legacy host
                 err = plug.notify_newdata(capi_response.capi_data, monitor.is_beta)
                 self.status['text'] = err and err or ''
                 if err:

--- a/L10n/en.template
+++ b/L10n/en.template
@@ -214,6 +214,9 @@
 /* EDMarketConnector.py: CAPI queries aborted because game mode unknown; In files: EDMarketConnector.py:967; */
 "CAPI query aborted: Game mode unknown" = "CAPI query aborted: Game mode unknown";
 
+/* EDMarketConnector.py: CAPI queries aborted because GameVersion unknown; In files: EDMarketConnector.py:974; */
+"CAPI query aborted: GameVersion unknown" = "CAPI query aborted: GameVersion unknown";
+
 /* EDMarketConnector.py: CAPI queries aborted because current star system name unknown; In files: EDMarketConnector.py:973; */
 "CAPI query aborted: Current system unknown" = "CAPI query aborted: Current system unknown";
 

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -896,6 +896,9 @@ data from Frontier's servers.
 | :-------- | :--------------: | :------------------------------------------------------------------------------------------------------- |
 | `data`    | `Dict[str, Any]` | `/profile` API response, with `/market` and `/shipyard` added under the keys `marketdata` and `shipdata` |
 | `is_beta` |      `bool`      | If the game is currently in beta                                                                         |
+NB: Actually `data` is a custom type, based on `UserDict`, called `CAPIData`,
+and has some extra properties.  However, these are for **internal use only**
+at this time, especially as there are some caveats about at least one of them.
 
 ---
 

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -676,19 +676,15 @@ class EDDN:
             if 'prohibited' in data['lastStarport']:
                 message['prohibited'] = sorted(x for x in (data['lastStarport']['prohibited'] or {}).values())
 
-            if data.source_host == companion.SERVER_LIVE:
-                gv = 'CAPI-Live-market'
-
-            elif data.source_host == companion.SERVER_LEGACY:
-                gv = 'CAPI-Legacy-market'
-
-            else:
-                gv = 'CAPI-market'
-
             self.send_message(data['commander']['name'], {
                 '$schemaRef': f'https://eddn.edcd.io/schemas/commodity/3{"/test" if is_beta else ""}',
                 'message':    message,
-                'header':     self.standard_header(game_version=gv, game_build=''),
+                'header':     self.standard_header(
+                    game_version=self.capi_gameversion_from_host_endpoint(
+                        data.source_host, companion.Session.FRONTIER_CAPI_PATH_MARKET
+                    ),
+                    game_build=''
+                ),
             })
 
         this.commodities = commodities
@@ -771,15 +767,6 @@ class EDDN:
 
         # Don't send empty modules list - schema won't allow it
         if outfitting and this.outfitting != (horizons, outfitting):
-            if data.source_host == companion.SERVER_LIVE:
-                gv = 'CAPI-Live-shipyard'
-
-            elif data.source_host == companion.SERVER_LEGACY:
-                gv = 'CAPI-Legacy-shipyard'
-
-            else:
-                gv = 'CAPI-shipyard'
-
             self.send_message(data['commander']['name'], {
                 '$schemaRef': f'https://eddn.edcd.io/schemas/outfitting/2{"/test" if is_beta else ""}',
                 'message': OrderedDict([
@@ -791,7 +778,12 @@ class EDDN:
                     ('modules',     outfitting),
                     ('odyssey',     this.odyssey),
                 ]),
-                'header':     self.standard_header(game_version=gv, game_build=''),
+                'header':     self.standard_header(
+                    game_version=self.capi_gameversion_from_host_endpoint(
+                        data.source_host, companion.Session.FRONTIER_CAPI_PATH_SHIPYARD
+                    ),
+                    game_build=''
+                ),
             })
 
         this.outfitting = (horizons, outfitting)
@@ -825,15 +817,6 @@ class EDDN:
         )
         # Don't send empty ships list - shipyard data is only guaranteed present if user has visited the shipyard.
         if shipyard and this.shipyard != (horizons, shipyard):
-            if data.source_host == companion.SERVER_LIVE:
-                gv = 'CAPI-Live-shipyard'
-
-            elif data.source_host == companion.SERVER_LEGACY:
-                gv = 'CAPI-Legacy-shipyard'
-
-            else:
-                gv = 'CAPI-shipyard'
-
             self.send_message(data['commander']['name'], {
                 '$schemaRef': f'https://eddn.edcd.io/schemas/shipyard/2{"/test" if is_beta else ""}',
                 'message': OrderedDict([
@@ -845,7 +828,12 @@ class EDDN:
                     ('ships',       shipyard),
                     ('odyssey',     this.odyssey),
                 ]),
-                'header':     self.standard_header(game_version=gv, game_build=''),
+                'header': self.standard_header(
+                    game_version=self.capi_gameversion_from_host_endpoint(
+                        data.source_host, companion.Session.FRONTIER_CAPI_PATH_SHIPYARD
+                    ),
+                    game_build=''
+                ),
             })
 
         this.shipyard = (horizons, shipyard)
@@ -1495,7 +1483,7 @@ class EDDN:
         return None
 
     def export_capi_fcmaterials(
-        self, data: Mapping[str, Any], is_beta: bool, horizons: bool
+        self, data: CAPIData, is_beta: bool, horizons: bool
     ) -> Optional[str]:
         """
         Send CAPI-sourced 'onfootmicroresources' data on `fcmaterials/1` schema.
@@ -1547,7 +1535,11 @@ class EDDN:
         msg = {
             '$schemaRef': f'https://eddn.edcd.io/schemas/fcmaterials_capi/1{"/test" if is_beta else ""}',
             'message': entry,
-            'header': self.standard_header(game_version='CAPI-market', game_build=''),
+            'header': self.standard_header(
+                game_version=self.capi_gameversion_from_host_endpoint(
+                    data.source_host, companion.Session.FRONTIER_CAPI_PATH_MARKET
+                ), game_build=''
+            ),
         }
 
         this.eddn.send_message(data['commander']['name'], msg)
@@ -1853,9 +1845,47 @@ class EDDN:
         match = self.CANONICALISE_RE.match(item)
         return match and match.group(1) or item
 
+    def capi_gameversion_from_host_endpoint(self, capi_host: str, capi_endpoint: str) -> str:
+        """
+        Return the correct CAPI gameversion string for the given host/endpoint.
+
+        :param capi_host: CAPI host used.
+        :param capi_endpoint: CAPI endpoint queried.
+        :return: CAPI gameversion string.
+        """
+        gv = ''
+        #######################################################################
+        # Base string
+        if capi_host == companion.SERVER_LIVE or capi_host == companion.SERVER_BETA:
+            gv = 'CAPI-Live-'
+
+        elif capi_host == companion.SERVER_LEGACY:
+            gv = 'CAPI-Legacy-'
+
+        else:
+            # Technically incorrect, but it will inform Listeners
+            logger.error(f"{capi_host=} lead to bad gameversion")
+            gv = 'CAPI-UNKNOWN-'
+        #######################################################################
+
+        #######################################################################
+        # endpoint
+        if capi_endpoint == companion.Session.FRONTIER_CAPI_PATH_MARKET:
+            gv += 'market'
+
+        elif capi_endpoint == companion.Session.FRONTIER_CAPI_PATH_SHIPYARD:
+            gv += 'shipyard'
+
+        else:
+            # Technically incorrect, but it will inform Listeners
+            logger.error(f"{capi_endpoint=} lead to bad gameversion")
+            gv += 'UNKNOWN'
+        #######################################################################
+
+        return gv
+
 
 # Plugin callbacks
-
 def plugin_start3(plugin_dir: str) -> str:
     """
     Start this plugin.


### PR DESCRIPTION
- #1733 - Disable CAPI functionality for Legacy players.  There's logging *and* a new status UI string, but the latter isn't intended for translation as this should be a short-lived measure.
- #1734 - Set improved `game_version` for CAPI-sourced data on EDDN messages.