### PR TITLE
Get everything passing flake8 checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -85,11 +85,15 @@ jobs:
         # F63 - 'tests' checking
         # F7 - syntax errors
         # F82 - undefined checking
-        git diff "refs/remotes/${BASE_REPO_OWNER}/${BASE_REF}" -- | flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --diff
+        echo git diff --name-only --diff-filter=d -z "refs/remotes/${BASE_REPO_OWNER}/${BASE_REF}" -- | \
+          grep -E -z -Z '\.py$' | \
+          xargs -0 flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # Can optionally add `--exit-zero` to the flake8 arguments so that
         # this doesn't fail the build.
         # explicitly ignore docstring errors (start with D)
-        git diff "refs/remotes/${BASE_REPO_OWNER}/${BASE_REF}" -- | flake8 . --count --statistics --diff --extend-ignore D
+        git diff --name-only --diff-filter=d -z "refs/remotes/${BASE_REPO_OWNER}/${BASE_REF}" -- | \
+          grep -E -z -Z '\.py$' | \
+          xargs -0 flake8 . --count --statistics --extend-ignore D
     ####################################################################
 
     ####################################################################

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -87,13 +87,13 @@ jobs:
         # F82 - undefined checking
         git diff --name-only --diff-filter=d -z "refs/remotes/${BASE_REPO_OWNER}/${BASE_REF}" -- | \
           grep -E -z -Z '\.py$' | \
-          xargs -0 flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          xargs -0 flake8 --count --select=E9,F63,F7,F82 --show-source --statistics
         # Can optionally add `--exit-zero` to the flake8 arguments so that
         # this doesn't fail the build.
         # explicitly ignore docstring errors (start with D)
         git diff --name-only --diff-filter=d -z "refs/remotes/${BASE_REPO_OWNER}/${BASE_REF}" -- | \
           grep -E -z -Z '\.py$' | \
-          xargs -0 flake8 . --count --statistics --extend-ignore D
+          xargs -0 flake8 --count --statistics --extend-ignore D
     ####################################################################
 
     ####################################################################

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -85,7 +85,7 @@ jobs:
         # F63 - 'tests' checking
         # F7 - syntax errors
         # F82 - undefined checking
-        echo git diff --name-only --diff-filter=d -z "refs/remotes/${BASE_REPO_OWNER}/${BASE_REF}" -- | \
+        git diff --name-only --diff-filter=d -z "refs/remotes/${BASE_REPO_OWNER}/${BASE_REF}" -- | \
           grep -E -z -Z '\.py$' | \
           xargs -0 flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # Can optionally add `--exit-zero` to the flake8 arguments so that

--- a/.github/workflows/push-checks.yml
+++ b/.github/workflows/push-checks.yml
@@ -51,9 +51,11 @@ jobs:
         #######################################################################
           
         #######################################################################
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        # 'Full' run, but ignoring docstring errors
         #######################################################################
+        # explicitly ignore docstring errors (start with D)
+        # Can optionally add `--exit-zero` to the flake8 arguments so that
         git diff --name-only --diff-filter=d -z "$DATA" | \
           grep -E -z -Z '\.py$' | \
-          xargs -0 flake8 . --count --statistics
+          xargs -0 flake8 --count --statistics --extend-ignore D
         #######################################################################

--- a/.github/workflows/push-checks.yml
+++ b/.github/workflows/push-checks.yml
@@ -40,7 +40,20 @@ jobs:
         DATA=$(jq --raw-output .before $GITHUB_EVENT_PATH)
 
         echo "DATA: ${DATA}"
+        #######################################################################
         # stop the build if there are Python syntax errors or undefined names, ignore existing 
-        git diff "$DATA" | flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --diff
+        #######################################################################
+        # We need to get just the *filenames* of only *python* files changed.
+        # Using various -z/-Z/-0 to utilise NUL-terminated strings.
+        git diff --name-only --diff-filter=d -z "$DATA" | \
+          grep -E -z -Z '\.py$' | \
+          xargs -0 flake8 --count --select=E9,F63,F7,F82 --show-source --statistics
+        #######################################################################
+          
+        #######################################################################
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        git diff "$DATA" | flake8 . --count --statistics --diff
+        #######################################################################
+        git diff --name-only --diff-filter=d -z "$DATA" | \
+          grep -E -z -Z '\.py$' | \
+          xargs -0 flake8 . --count --statistics
+        #######################################################################

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -529,16 +529,18 @@ class AppWindow(object):
         # LANG: Update button in main window
         self.button = ttk.Button(frame, text=_('Update'), width=28, default=tk.ACTIVE, state=tk.DISABLED)
         self.theme_button = tk.Label(frame, width=32 if sys.platform == 'darwin' else 28, state=tk.DISABLED)
-        self.status = tk.Label(frame, name='status', anchor=tk.W)
 
         ui_row = frame.grid_size()[1]
         self.button.grid(row=ui_row, columnspan=2, sticky=tk.NSEW)
         self.theme_button.grid(row=ui_row, columnspan=2, sticky=tk.NSEW)
         theme.register_alternate((self.button, self.theme_button, self.theme_button),
                                  {'row': ui_row, 'columnspan': 2, 'sticky': tk.NSEW})
-        self.status.grid(columnspan=2, sticky=tk.EW)
         self.button.bind('<Button-1>', self.capi_request_data)
         theme.button_bind(self.theme_button, self.capi_request_data)
+
+        # Bottom 'status' line.
+        self.status = tk.Label(frame, name='status', anchor=tk.W)
+        self.status.grid(columnspan=2, sticky=tk.EW)
 
         for child in frame.winfo_children():
             child.grid_configure(padx=self.PADX, pady=(

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -558,7 +558,7 @@ class AppWindow(object):
             # https://www.tcl.tk/man/tcl/TkCmd/menu.htm
             self.system_menu = tk.Menu(self.menubar, name='apple')
             self.system_menu.add_command(command=lambda: self.w.call('tk::mac::standardAboutPanel'))
-            self.system_menu.add_command(command=lambda: self.updater.checkForUpdates())
+            self.system_menu.add_command(command=lambda: self.updater.check_for_updates())
             self.menubar.add_cascade(menu=self.system_menu)
             self.file_menu = tk.Menu(self.menubar, name='file')
             self.file_menu.add_command(command=self.save_raw)
@@ -601,7 +601,7 @@ class AppWindow(object):
             self.help_menu.add_command(command=self.help_general)
             self.help_menu.add_command(command=self.help_privacy)
             self.help_menu.add_command(command=self.help_releases)
-            self.help_menu.add_command(command=lambda: self.updater.checkForUpdates())
+            self.help_menu.add_command(command=lambda: self.updater.check_for_updates())
             self.help_menu.add_command(command=lambda: not self.HelpAbout.showing and self.HelpAbout(self.w))
 
             self.menubar.add_cascade(menu=self.help_menu)
@@ -724,7 +724,7 @@ class AppWindow(object):
             self.updater = update.Updater(tkroot=self.w, provider='external')
         else:
             self.updater = update.Updater(tkroot=self.w, provider='internal')
-            self.updater.checkForUpdates()  # Sparkle / WinSparkle does this automatically for packaged apps
+            self.updater.check_for_updates()  # Sparkle / WinSparkle does this automatically for packaged apps
 
         # Migration from <= 3.30
         for username in config.get_list('fdev_usernames', default=[]):
@@ -733,7 +733,6 @@ class AppWindow(object):
         config.delete('username', suppress=True)
         config.delete('password', suppress=True)
         config.delete('logdir', suppress=True)
-
         self.postprefs(False)  # Companion login happens in callback from monitor
         self.toggle_suit_row(visible=False)
 
@@ -1382,7 +1381,7 @@ class AppWindow(object):
 
                 # Disable WinSparkle automatic update checks, IFF configured to do so when in-game
                 if config.get_int('disable_autoappupdatecheckingame') and 1:
-                    self.updater.setAutomaticUpdatesCheck(False)
+                    self.updater.set_automatic_updates_check(False)
                     logger.info('Monitor: Disable WinSparkle automatic update checks')
 
                 # Can't start dashboard monitoring
@@ -1433,7 +1432,7 @@ class AppWindow(object):
             if entry['event'] == 'ShutDown':
                 # Enable WinSparkle automatic update checks
                 # NB: Do this blindly, in case option got changed whilst in-game
-                self.updater.setAutomaticUpdatesCheck(True)
+                self.updater.set_automatic_updates_check(True)
                 logger.info('Monitor: Enable WinSparkle automatic update checks')
 
     def auth(self, event=None) -> None:

--- a/config/linux.py
+++ b/config/linux.py
@@ -3,7 +3,7 @@ import os
 import pathlib
 import sys
 from configparser import ConfigParser
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import List, Optional, Union
 
 from config import AbstractConfig, appname, logger
 

--- a/journal_lock.py
+++ b/journal_lock.py
@@ -133,7 +133,7 @@ class JournalLock:
 
         return JournalLockResult.LOCKED
 
-    def release_lock(self) -> bool:  # noqa: CCR001
+    def release_lock(self) -> bool:
         """
         Release lock on journal directory.
 

--- a/loadout.py
+++ b/loadout.py
@@ -49,19 +49,11 @@ def export(data: companion.CAPIData, requested_filename: Optional[str] = None) -
     query_time = config.get_int('querytime', default=int(time.time()))
 
     # Write
-    #
-    #  When this is refactored into multi-line CHECK IT WORKS, avoiding the
-    #  brainfart we had with dangling commas in commodity.py:export() !!!
-    #
-    output_path = pathlib.Path(config.get_str('outdir'))
-    output_filename = pathlib.Path(
-        ship + '.' + time.strftime('%Y-%m-%dT%H.%M.%S', time.localtime(query_time)) + '.txt'
-    )
-    # Can't re-use `filename`, different type
-    file_name = output_path / output_filename
-    #
-    #  When this is refactored into multi-line CHECK IT WORKS, avoiding the
-    #  brainfart we had with dangling commas in commodity.py:export() !!!
-    #
-    with open(file_name, 'wt') as h:
+
+    with open(
+        pathlib.Path(config.get_str('outdir')) / pathlib.Path(
+            ship + '.' + time.strftime('%Y-%m-%dT%H.%M.%S', time.localtime(query_time)) + '.txt'
+        ),
+        'wt'
+    ) as h:
         h.write(string)

--- a/loadout.py
+++ b/loadout.py
@@ -1,48 +1,67 @@
-# Export ship loadout in Companion API json format
+"""Export ship loadout in Companion API json format."""
 
 import json
 import os
-from os.path import join
+import pathlib
 import re
 import time
+from os.path import join
+from typing import Optional
 
-from config import config
 import companion
 import util_ships
+from config import config
+from EDMCLogging import get_main_logger
+
+logger = get_main_logger()
 
 
-def export(data, filename=None):
+def export(data: companion.CAPIData, requested_filename: Optional[str] = None) -> None:
+    """
+    Write Ship Loadout in Companion API JSON format.
 
+    :param data: CAPI data containing ship loadout.
+    :param requested_filename: Name of file to write to.
+    """
     string = json.dumps(
         companion.ship(data), cls=companion.CAPIDataEncoder,
         ensure_ascii=False, indent=2, sort_keys=True, separators=(',', ': ')
     )  # pretty print
 
-    if filename:
-        with open(filename, 'wt') as h:
+    if requested_filename is not None and requested_filename:
+        with open(requested_filename, 'wt') as h:
             h.write(string)
+        return
+
+    elif not requested_filename:
+        logger.error(f"{requested_filename=} is not valid")
         return
 
     # Look for last ship of this type
     ship = util_ships.ship_file_name(data['ship'].get('shipName'), data['ship']['name'])
-    regexp = re.compile(re.escape(ship) + '\.\d\d\d\d\-\d\d\-\d\dT\d\d\.\d\d\.\d\d\.txt')
+    regexp = re.compile(re.escape(ship) + r'\.\d\d\d\d\-\d\d\-\d\dT\d\d\.\d\d\.\d\d\.txt')
     oldfiles = sorted([x for x in os.listdir(config.get_str('outdir')) if regexp.match(x)])
     if oldfiles:
         with open(join(config.get_str('outdir'), oldfiles[-1]), 'rU') as h:
             if h.read() == string:
-                return	# same as last time - don't write
+                return  # same as last time - don't write
 
-    querytime = config.get_int('querytime', default=int(time.time()))
+    query_time = config.get_int('querytime', default=int(time.time()))
 
     # Write
     #
     #  When this is refactored into multi-line CHECK IT WORKS, avoiding the
     #  brainfart we had with dangling commas in commodity.py:export() !!!
     #
-    filename = join(config.get_str('outdir'), '%s.%s.txt' % (ship, time.strftime('%Y-%m-%dT%H.%M.%S', time.localtime(querytime))))
+    output_path = pathlib.Path(config.get_str('outdir'))
+    output_filename = pathlib.Path(
+        ship + '.' + time.strftime('%Y-%m-%dT%H.%M.%S', time.localtime(query_time)) + '.txt'
+    )
+    # Can't re-use `filename`, different type
+    file_name = output_path / output_filename
     #
     #  When this is refactored into multi-line CHECK IT WORKS, avoiding the
     #  brainfart we had with dangling commas in commodity.py:export() !!!
     #
-    with open(filename, 'wt') as h:
+    with open(file_name, 'wt') as h:
         h.write(string)

--- a/myNotebook.py
+++ b/myNotebook.py
@@ -13,6 +13,7 @@ Entire file may be imported by plugins.
 import sys
 import tkinter as tk
 from tkinter import ttk
+from typing import Optional
 
 # Can't do this with styles on OSX - http://www.tkdocs.com/tutorial/styles.html#whydifficult
 if sys.platform == 'darwin':
@@ -28,7 +29,7 @@ elif sys.platform == 'win32':
 class Notebook(ttk.Notebook):
     """Custom ttk.Notebook class to fix some display issues."""
 
-    def __init__(self, master=None, **kw):
+    def __init__(self, master: Optional[ttk.Frame] = None, **kw):
 
         ttk.Notebook.__init__(self, master, **kw)
         style = ttk.Style()
@@ -51,10 +52,13 @@ class Notebook(ttk.Notebook):
             self.grid(padx=10, pady=10, sticky=tk.NSEW)
 
 
-class Frame(sys.platform == 'darwin' and tk.Frame or ttk.Frame):
+# FIXME: The real fix for this 'dynamic type' would be to split this whole
+#  thing into being a module with per-platform files, as we've done with config
+#  That would also make the code cleaner.
+class Frame(sys.platform == 'darwin' and tk.Frame or ttk.Frame):  # type: ignore
     """Custom t(t)k.Frame class to fix some display issues."""
 
-    def __init__(self, master=None, **kw):
+    def __init__(self, master: Optional[ttk.Frame] = None, **kw):
         if sys.platform == 'darwin':
             kw['background'] = kw.pop('background', PAGEBG)
             tk.Frame.__init__(self, master, **kw)
@@ -71,7 +75,7 @@ class Frame(sys.platform == 'darwin' and tk.Frame or ttk.Frame):
 class Label(tk.Label):
     """Custom tk.Label class to fix some display issues."""
 
-    def __init__(self, master=None, **kw):
+    def __init__(self, master: Optional[ttk.Frame] = None, **kw):
         if sys.platform in ['darwin', 'win32']:
             kw['foreground'] = kw.pop('foreground', PAGEFG)
             kw['background'] = kw.pop('background', PAGEBG)
@@ -81,10 +85,10 @@ class Label(tk.Label):
         tk.Label.__init__(self, master, **kw)  # Just use tk.Label on all platforms
 
 
-class Entry(sys.platform == 'darwin' and tk.Entry or ttk.Entry):
+class Entry(sys.platform == 'darwin' and tk.Entry or ttk.Entry):  # type: ignore
     """Custom t(t)k.Entry class to fix some display issues."""
 
-    def __init__(self, master=None, **kw):
+    def __init__(self, master: Optional[ttk.Frame] = None, **kw):
         if sys.platform == 'darwin':
             kw['highlightbackground'] = kw.pop('highlightbackground', PAGEBG)
             tk.Entry.__init__(self, master, **kw)
@@ -92,10 +96,10 @@ class Entry(sys.platform == 'darwin' and tk.Entry or ttk.Entry):
             ttk.Entry.__init__(self, master, **kw)
 
 
-class Button(sys.platform == 'darwin' and tk.Button or ttk.Button):
+class Button(sys.platform == 'darwin' and tk.Button or ttk.Button):  # type: ignore
     """Custom t(t)k.Button class to fix some display issues."""
 
-    def __init__(self, master=None, **kw):
+    def __init__(self, master: Optional[ttk.Frame] = None, **kw):
         if sys.platform == 'darwin':
             kw['highlightbackground'] = kw.pop('highlightbackground', PAGEBG)
             tk.Button.__init__(self, master, **kw)
@@ -105,10 +109,10 @@ class Button(sys.platform == 'darwin' and tk.Button or ttk.Button):
             ttk.Button.__init__(self, master, **kw)
 
 
-class ColoredButton(sys.platform == 'darwin' and tk.Label or tk.Button):
+class ColoredButton(sys.platform == 'darwin' and tk.Label or tk.Button):  # type: ignore
     """Custom t(t)k.ColoredButton class to fix some display issues."""
 
-    def __init__(self, master=None, **kw):
+    def __init__(self, master: Optional[ttk.Frame] = None, **kw):
         if sys.platform == 'darwin':
             # Can't set Button background on OSX, so use a Label instead
             kw['relief'] = kw.pop('relief', tk.RAISED)
@@ -123,10 +127,10 @@ class ColoredButton(sys.platform == 'darwin' and tk.Label or tk.Button):
             self._command()
 
 
-class Checkbutton(sys.platform == 'darwin' and tk.Checkbutton or ttk.Checkbutton):
+class Checkbutton(sys.platform == 'darwin' and tk.Checkbutton or ttk.Checkbutton):  # type: ignore
     """Custom t(t)k.Checkbutton class to fix some display issues."""
 
-    def __init__(self, master=None, **kw):
+    def __init__(self, master: Optional[ttk.Frame] = None, **kw):
         if sys.platform == 'darwin':
             kw['foreground'] = kw.pop('foreground', PAGEFG)
             kw['background'] = kw.pop('background', PAGEBG)
@@ -137,10 +141,10 @@ class Checkbutton(sys.platform == 'darwin' and tk.Checkbutton or ttk.Checkbutton
             ttk.Checkbutton.__init__(self, master, **kw)
 
 
-class Radiobutton(sys.platform == 'darwin' and tk.Radiobutton or ttk.Radiobutton):
+class Radiobutton(sys.platform == 'darwin' and tk.Radiobutton or ttk.Radiobutton):  # type: ignore
     """Custom t(t)k.Radiobutton class to fix some display issues."""
 
-    def __init__(self, master=None, **kw):
+    def __init__(self, master: Optional[ttk.Frame] = None, **kw):
         if sys.platform == 'darwin':
             kw['foreground'] = kw.pop('foreground', PAGEFG)
             kw['background'] = kw.pop('background', PAGEBG)
@@ -151,7 +155,7 @@ class Radiobutton(sys.platform == 'darwin' and tk.Radiobutton or ttk.Radiobutton
             ttk.Radiobutton.__init__(self, master, **kw)
 
 
-class OptionMenu(sys.platform == 'darwin' and tk.OptionMenu or ttk.OptionMenu):
+class OptionMenu(sys.platform == 'darwin' and tk.OptionMenu or ttk.OptionMenu):  # type: ignore
     """Custom t(t)k.OptionMenu class to fix some display issues."""
 
     def __init__(self, master, variable, default=None, *values, **kw):

--- a/myNotebook.py
+++ b/myNotebook.py
@@ -1,14 +1,18 @@
-#
-# Hacks to fix various display issues with notebooks and their child widgets on OSX and Windows.
-# - Windows: page background should be White, not SystemButtonFace
-# - OSX:     page background should be a darker gray than systemWindowBody
-#            selected tab foreground should be White when the window is active
-#
+"""
+Custom `ttk.Notebook` to fix various display issues.
+
+Hacks to fix various display issues with notebooks and their child widgets on
+OSX and Windows.
+
+- Windows: page background should be White, not SystemButtonFace
+- OSX:     page background should be a darker gray than systemWindowBody
+           selected tab foreground should be White when the window is active
+
+Entire file may be imported by plugins.
+"""
 import sys
 import tkinter as tk
 from tkinter import ttk
-
-# Entire file may be imported by plugins
 
 # Can't do this with styles on OSX - http://www.tkdocs.com/tutorial/styles.html#whydifficult
 if sys.platform == 'darwin':
@@ -22,6 +26,7 @@ elif sys.platform == 'win32':
 
 
 class Notebook(ttk.Notebook):
+    """Custom ttk.Notebook class to fix some display issues."""
 
     def __init__(self, master=None, **kw):
 
@@ -47,6 +52,7 @@ class Notebook(ttk.Notebook):
 
 
 class Frame(sys.platform == 'darwin' and tk.Frame or ttk.Frame):
+    """Custom t(t)k.Frame class to fix some display issues."""
 
     def __init__(self, master=None, **kw):
         if sys.platform == 'darwin':
@@ -63,6 +69,7 @@ class Frame(sys.platform == 'darwin' and tk.Frame or ttk.Frame):
 
 
 class Label(tk.Label):
+    """Custom tk.Label class to fix some display issues."""
 
     def __init__(self, master=None, **kw):
         if sys.platform in ['darwin', 'win32']:
@@ -75,6 +82,7 @@ class Label(tk.Label):
 
 
 class Entry(sys.platform == 'darwin' and tk.Entry or ttk.Entry):
+    """Custom t(t)k.Entry class to fix some display issues."""
 
     def __init__(self, master=None, **kw):
         if sys.platform == 'darwin':
@@ -85,6 +93,7 @@ class Entry(sys.platform == 'darwin' and tk.Entry or ttk.Entry):
 
 
 class Button(sys.platform == 'darwin' and tk.Button or ttk.Button):
+    """Custom t(t)k.Button class to fix some display issues."""
 
     def __init__(self, master=None, **kw):
         if sys.platform == 'darwin':
@@ -97,6 +106,7 @@ class Button(sys.platform == 'darwin' and tk.Button or ttk.Button):
 
 
 class ColoredButton(sys.platform == 'darwin' and tk.Label or tk.Button):
+    """Custom t(t)k.ColoredButton class to fix some display issues."""
 
     def __init__(self, master=None, **kw):
         if sys.platform == 'darwin':
@@ -114,6 +124,7 @@ class ColoredButton(sys.platform == 'darwin' and tk.Label or tk.Button):
 
 
 class Checkbutton(sys.platform == 'darwin' and tk.Checkbutton or ttk.Checkbutton):
+    """Custom t(t)k.Checkbutton class to fix some display issues."""
 
     def __init__(self, master=None, **kw):
         if sys.platform == 'darwin':
@@ -127,6 +138,7 @@ class Checkbutton(sys.platform == 'darwin' and tk.Checkbutton or ttk.Checkbutton
 
 
 class Radiobutton(sys.platform == 'darwin' and tk.Radiobutton or ttk.Radiobutton):
+    """Custom t(t)k.Radiobutton class to fix some display issues."""
 
     def __init__(self, master=None, **kw):
         if sys.platform == 'darwin':
@@ -140,6 +152,7 @@ class Radiobutton(sys.platform == 'darwin' and tk.Radiobutton or ttk.Radiobutton
 
 
 class OptionMenu(sys.platform == 'darwin' and tk.OptionMenu or ttk.OptionMenu):
+    """Custom t(t)k.OptionMenu class to fix some display issues."""
 
     def __init__(self, master, variable, default=None, *values, **kw):
         if sys.platform == 'darwin':

--- a/plug.py
+++ b/plug.py
@@ -62,7 +62,7 @@ class Plugin(object):
                     PLUGINS_not_py3.append(self)
                 else:
                     logger.error(f'plugin {name} has no plugin_start3() function')
-            except Exception as e:
+            except Exception:
                 logger.exception(f': Failed for Plugin "{name}"')
                 raise
         else:
@@ -70,7 +70,8 @@ class Plugin(object):
 
     def _get_func(self, funcname):
         """
-        Get a function from a plugin
+        Get a function from a plugin.
+
         :param funcname:
         :returns: The function, or None if it isn't implemented.
         """
@@ -79,6 +80,7 @@ class Plugin(object):
     def get_app(self, parent):
         """
         If the plugin provides mainwindow content create and return it.
+
         :param parent: the parent frame for this entry.
         :returns: None, a tk Widget, or a pair of tk.Widgets
         """
@@ -88,14 +90,23 @@ class Plugin(object):
                 appitem = plugin_app(parent)
                 if appitem is None:
                     return None
+                
                 elif isinstance(appitem, tuple):
-                    if len(appitem) != 2 or not isinstance(appitem[0], tk.Widget) or not isinstance(appitem[1], tk.Widget):
+                    if (
+                        len(appitem) != 2
+                        or not isinstance(appitem[0], tk.Widget)
+                        or not isinstance(appitem[1], tk.Widget)
+                    ):
                         raise AssertionError
+
                 elif not isinstance(appitem, tk.Widget):
                     raise AssertionError
+
                 return appitem
+
             except Exception as e:
                 logger.exception(f'Failed for Plugin "{self.name}"')
+
         return None
 
     def get_prefs(self, parent, cmdr, is_beta):

--- a/plug.py
+++ b/plug.py
@@ -1,6 +1,4 @@
-"""
-Plugin hooks for EDMC - Ian Norton, Jonathan Harris
-"""
+"""Plugin API."""
 import copy
 import importlib
 import logging
@@ -29,15 +27,17 @@ last_error = {
 
 
 class Plugin(object):
+    """An EDMC plugin."""
 
     def __init__(self, name: str, loadfile: str, plugin_logger: Optional[logging.Logger]):
         """
-        Load a single plugin
-        :param name: module name
-        :param loadfile: the main .py file
+        Load a single plugin.
+
+        :param name: Base name of the file being loaded from.
+        :param loadfile: Full path/filename of the plugin.
+        :param plugin_logger: The logging instance for this plugin to use.
         :raises Exception: Typically ImportError or OSError
         """
-
         self.name = name  # Display name.
         self.folder = name  # basename of plugin folder. None for internal plugins.
         self.module = None  # None for disabled plugins.
@@ -46,9 +46,13 @@ class Plugin(object):
         if loadfile:
             logger.info(f'loading plugin "{name.replace(".", "_")}" from "{loadfile}"')
             try:
-                module = importlib.machinery.SourceFileLoader('plugin_{}'.format(
-                    name.encode(encoding='ascii', errors='replace').decode('utf-8').replace('.', '_')),
-                    loadfile).load_module()
+                filename = 'plugin_'
+                filename += name.encode(encoding='ascii', errors='replace').decode('utf-8').replace('.', '_')
+                module = importlib.machinery.SourceFileLoader(
+                    filename,
+                    loadfile
+                ).load_module()
+
                 if getattr(module, 'plugin_start3', None):
                     newname = module.plugin_start3(os.path.dirname(loadfile))
                     self.name = newname and str(newname) or name

--- a/plugins/eddb.py
+++ b/plugins/eddb.py
@@ -1,8 +1,4 @@
-# -*- coding: utf-8 -*-
-#
-# Station display and eddb.io lookup
-#
-
+"""Station display and eddb.io lookup."""
 # Tests:
 #
 # As there's a lot of state tracking in here, need to ensure (at least)
@@ -38,15 +34,15 @@
 # Thus you **MUST** check if any imports you add in this file are only
 # referenced in this file (or only in any other core plugin), and if so...
 #
-#     YOU MUST ENSURE THAT PERTINENT ADJUSTMENTS ARE MADE IN `setup.py`
-#     SO AS TO ENSURE THE FILES ARE ACTUALLY PRESENT IN AN END-USER
-#     INSTALLATION ON WINDOWS.
+#     YOU MUST ENSURE THAT PERTINENT ADJUSTMENTS ARE MADE IN
+#     `Build-exe-and-msi.py` SO AS TO ENSURE THE FILES ARE ACTUALLY PRESENT IN
+#     AN END-USER INSTALLATION ON WINDOWS.
 #
 #
 # ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $#
 # ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $#
 import sys
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Mapping, MutableMapping, Optional
 
 import requests
 
@@ -79,6 +75,13 @@ this.on_foot = False
 
 
 def system_url(system_name: str) -> str:
+    """
+    Construct an appropriate EDDB.IO URL for the provided system.
+
+    :param system_name: Will be overridden with `this.system_address` if that
+      is set.
+    :return: The URL, empty if no data was available to construct it.
+    """
     if this.system_address:
         return requests.utils.requote_uri(f'https://eddb.io/system/ed-address/{this.system_address}')
 
@@ -89,17 +92,38 @@ def system_url(system_name: str) -> str:
 
 
 def station_url(system_name: str, station_name: str) -> str:
+    """
+    Construct an appropriate EDDB.IO URL for a station.
+
+    Ignores `station_name` in favour of `this.station_marketid`.
+
+    :param system_name: Name of the system the station is in.
+    :param station_name: **NOT USED**
+    :return: The URL, empty if no data was available to construct it.
+    """
     if this.station_marketid:
         return requests.utils.requote_uri(f'https://eddb.io/station/market-id/{this.station_marketid}')
 
     return system_url(system_name)
 
 
-def plugin_start3(plugin_dir):
+def plugin_start3(plugin_dir: str) -> str:
+    """
+    Start the plugin.
+
+    :param plugin_dir: NAme of directory this was loaded from.
+    :return: Identifier string for this plugin.
+    """
     return 'eddb'
 
 
 def plugin_app(parent: 'Tk'):
+    """
+    Construct this plugin's main UI, if any.
+
+    :param parent: The tk parent to place our widgets into.
+    :return: See PLUGINS.md#display
+    """
     this.system_link = parent.children['system']  # system label in main window
     this.system = None
     this.system_address = None
@@ -109,13 +133,34 @@ def plugin_app(parent: 'Tk'):
     this.station_link.configure(popup_copy=lambda x: x != STATION_UNDOCKED)
 
 
-def prefs_changed(cmdr, is_beta):
+def prefs_changed(cmdr: str, is_beta: bool) -> None:
+    """
+    Update any saved configuration after Settings is closed.
+
+    :param cmdr: Name of Commander.
+    :param is_beta: If game beta was detected.
+    """
     # Do *NOT* set 'url' here, as it's set to a function that will call
     # through correctly.  We don't want a static string.
     pass
 
 
-def journal_entry(cmdr, is_beta, system, station, entry, state):
+def journal_entry(  # noqa: CCR001
+    cmdr: str, is_beta: bool, system: str, station: str,
+    entry: MutableMapping[str, Any],
+    state: Mapping[str, Any]
+):
+    """
+    Handle a new Journal event.
+
+    :param cmdr: Name of Commander.
+    :param is_beta: Whether game beta was detected.
+    :param system: Name of current tracked system.
+    :param station: Name of current tracked station location.
+    :param entry: The journal event.
+    :param state: `monitor.state`
+    :return: None if no error, else an error string.
+    """
     should_return, new_entry = killswitch.check_killswitch('plugins.eddb.journal', entry)
     if should_return:
         # LANG: Journal Processing disabled due to an active killswitch
@@ -179,7 +224,14 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
         this.station_link.update_idletasks()
 
 
-def cmdr_data(data: CAPIData, is_beta):
+def cmdr_data(data: CAPIData, is_beta: bool) -> Optional[str]:
+    """
+    Process new CAPI data.
+
+    :param data: The latest merged CAPI data.
+    :param is_beta: Whether game beta was detected.
+    :return: Optional error string.
+    """
     # Always store initially, even if we're not the *current* system provider.
     if not this.station_marketid and data['commander']['docked']:
         this.station_marketid = data['lastStarport']['id']

--- a/plugins/eddb.py
+++ b/plugins/eddb.py
@@ -41,7 +41,7 @@
 #
 # ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $#
 # ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $#
-import sys
+import tkinter
 from typing import TYPE_CHECKING, Any, Mapping, MutableMapping, Optional
 
 import requests
@@ -55,23 +55,30 @@ from config import config
 if TYPE_CHECKING:
     from tkinter import Tk
 
+    def _(x: str) -> str:
+        return x
 
 logger = EDMCLogging.get_main_logger()
 
 
-STATION_UNDOCKED: str = '×'  # "Station" name to display when not docked = U+00D7
+class This:
+    """Holds module globals."""
 
-this: Any = sys.modules[__name__]  # For holding module globals
+    STATION_UNDOCKED: str = '×'  # "Station" name to display when not docked = U+00D7
 
-# Main window clicks
-this.system_link: Optional[str] = None
-this.system: Optional[str] = None
-this.system_address: Optional[str] = None
-this.system_population: Optional[int] = None
-this.station_link: 'Optional[Tk]' = None
-this.station: Optional[str] = None
-this.station_marketid: Optional[int] = None
-this.on_foot = False
+    def __init__(self) -> None:
+        # Main window clicks
+        self.system_link: tkinter.Widget
+        self.system: Optional[str] = None
+        self.system_address: Optional[str] = None
+        self.system_population: Optional[int] = None
+        self.station_link: tkinter.Widget
+        self.station: Optional[str] = None
+        self.station_marketid: Optional[int] = None
+        self.on_foot = False
+
+
+this = This()
 
 
 def system_url(system_name: str) -> str:
@@ -130,7 +137,7 @@ def plugin_app(parent: 'Tk'):
     this.station = None
     this.station_marketid = None  # Frontier MarketID
     this.station_link = parent.children['station']  # station label in main window
-    this.station_link.configure(popup_copy=lambda x: x != STATION_UNDOCKED)
+    this.station_link['popup_copy'] = lambda x: x != this.STATION_UNDOCKED
 
 
 def prefs_changed(cmdr: str, is_beta: bool) -> None:
@@ -213,7 +220,7 @@ def journal_entry(  # noqa: CCR001
         text = this.station
         if not text:
             if this.system_population is not None and this.system_population > 0:
-                text = STATION_UNDOCKED
+                text = this.STATION_UNDOCKED
 
             else:
                 text = ''
@@ -255,7 +262,7 @@ def cmdr_data(data: CAPIData, is_beta: bool) -> Optional[str]:
             this.station_link['text'] = this.station
 
         elif data['lastStarport']['name'] and data['lastStarport']['name'] != "":
-            this.station_link['text'] = STATION_UNDOCKED
+            this.station_link['text'] = this.STATION_UNDOCKED
 
         else:
             this.station_link['text'] = ''
@@ -263,3 +270,5 @@ def cmdr_data(data: CAPIData, is_beta: bool) -> Optional[str]:
         # Do *NOT* set 'url' here, as it's set to a function that will call
         # through correctly.  We don't want a static string.
         this.station_link.update_idletasks()
+
+    return ''

--- a/plugins/edsy.py
+++ b/plugins/edsy.py
@@ -1,4 +1,4 @@
-# EDShipyard ship export
+"""Export data for ED Shipyard."""
 
 # ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $#
 # ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $#
@@ -15,25 +15,41 @@
 # Thus you **MUST** check if any imports you add in this file are only
 # referenced in this file (or only in any other core plugin), and if so...
 #
-#     YOU MUST ENSURE THAT PERTINENT ADJUSTMENTS ARE MADE IN `setup.py`
-#     SO AS TO ENSURE THE FILES ARE ACTUALLY PRESENT IN AN END-USER
-#     INSTALLATION ON WINDOWS.
+#     YOU MUST ENSURE THAT PERTINENT ADJUSTMENTS ARE MADE IN
+#     `Build-exe-and-msi.py` SO AS TO ENSURE THE FILES ARE ACTUALLY PRESENT IN
+#     AN END-USER INSTALLATION ON WINDOWS.
 #
 #
 # ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $#
 # ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $#
 import base64
 import gzip
-import json
 import io
+import json
+from typing import Any, Mapping
 
 
-def plugin_start3(plugin_dir):
+def plugin_start3(plugin_dir: str) -> str:
+    """
+    Start the plugin.
+
+    :param plugin_dir: NAme of directory this was loaded from.
+    :return: Identifier string for this plugin.
+    """
     return 'EDSY'
 
+
 # Return a URL for the current ship
-def shipyard_url(loadout, is_beta):
-    string = json.dumps(loadout, ensure_ascii=False, sort_keys=True, separators=(',', ':')).encode('utf-8')	# most compact representation
+def shipyard_url(loadout: Mapping[str, Any], is_beta) -> bool | str:
+    """
+    Construct a URL for ship loadout.
+
+    :param loadout:
+    :param is_beta:
+    :return:
+    """
+    # most compact representation
+    string = json.dumps(loadout, ensure_ascii=False, sort_keys=True, separators=(',', ':')).encode('utf-8')
     if not string:
         return False
 
@@ -41,4 +57,6 @@ def shipyard_url(loadout, is_beta):
     with gzip.GzipFile(fileobj=out, mode='w') as f:
         f.write(string)
 
-    return (is_beta and 'http://edsy.org/beta/#/I=' or 'http://edsy.org/#/I=') + base64.urlsafe_b64encode(out.getvalue()).decode().replace('=', '%3D')
+    return (
+               is_beta and 'http://edsy.org/beta/#/I=' or 'http://edsy.org/#/I='
+           ) + base64.urlsafe_b64encode(out.getvalue()).decode().replace('=', '%3D')

--- a/protocol.py
+++ b/protocol.py
@@ -107,11 +107,12 @@ if sys.platform == 'darwin' and getattr(sys, 'frozen', False):  # noqa: C901 # i
 
         def handleEvent_withReplyEvent_(self, event, replyEvent) -> None:  # noqa: N802 N803 # Required to override
             """Actual event handling from NSAppleEventManager."""
-            protocolhandler.lasturl = urllib.parse.unquote(  # type: ignore # Its going to be a DPH in this code
+            protocolhandler.lasturl = urllib.parse.unquote(  # noqa: F821: type: ignore # Its going to be a DPH in
+                # this code
                 event.paramDescriptorForKeyword_(keyDirectObject).stringValue()
             ).strip()
 
-            protocolhandler.master.after(DarwinProtocolHandler.POLL, protocolhandler.poll)  # type: ignore
+            protocolhandler.master.after(DarwinProtocolHandler.POLL, protocolhandler.poll)  # noqa: F821: type: ignore
 
 
 elif (config.auth_force_edmc_protocol
@@ -389,7 +390,7 @@ else:  # Linux / Run from source
             url = urllib.parse.unquote(self.path)
             if url.startswith('/auth'):
                 logger.debug('Request starts with /auth, sending to protocolhandler.event()')
-                protocolhandler.event(url)
+                protocolhandler.event(url)  # noqa: F821
                 self.send_response(200)
                 return True
             else:

--- a/protocol.py
+++ b/protocol.py
@@ -1,5 +1,4 @@
 """protocol handler for cAPI authorisation."""
-
 # spell-checker: words ntdll GURL alloc wfile instantiatable pyright
 import os
 import sys
@@ -35,7 +34,7 @@ class GenericProtocolHandler:
     def __init__(self) -> None:
         self.redirect = protocolhandler_redirect  # Base redirection URL
         self.master: 'tkinter.Tk' = None  # type: ignore
-        self.lastpayload = None
+        self.lastpayload: Optional[str] = None
 
     def start(self, master: 'tkinter.Tk') -> None:
         """Start Protocol Handler."""
@@ -45,7 +44,7 @@ class GenericProtocolHandler:
         """Stop / Close Protocol Handler."""
         pass
 
-    def event(self, url) -> None:
+    def event(self, url: str) -> None:
         """Generate an auth event."""
         self.lastpayload = url
 
@@ -197,7 +196,7 @@ elif (config.auth_force_edmc_protocol
     # Windows Message handler stuff (IPC)
     # https://docs.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)
     @WINFUNCTYPE(c_long, HWND, UINT, WPARAM, LPARAM)
-    def WndProc(hwnd: HWND, message: UINT, wParam, lParam):  # noqa: N803 N802
+    def WndProc(hwnd: HWND, message: UINT, wParam: WPARAM, lParam: LPARAM) -> c_long:  # noqa: N803 N802
         """
         Deal with DDE requests.
 
@@ -216,8 +215,10 @@ elif (config.auth_force_edmc_protocol
         topic = create_unicode_buffer(256)
         # Note that lParam is 32 bits, and broken into two 16 bit words. This will break on 64bit as the math is
         # wrong
-        lparam_low = lParam & 0xFFFF  # if nonzero, the target application for which a conversation is requested
-        lparam_high = lParam >> 16  # if nonzero, the topic of said conversation
+        # if nonzero, the target application for which a conversation is requested
+        lparam_low = lParam & 0xFFFF  # type: ignore
+        # if nonzero, the topic of said conversation
+        lparam_high = lParam >> 16  # type: ignore
 
         # if either of the words are nonzero, they contain
         # atoms https://docs.microsoft.com/en-us/windows/win32/dataxchg/about-atom-tables
@@ -237,7 +238,10 @@ elif (config.auth_force_edmc_protocol
                 wParam, WM_DDE_ACK, hwnd, PackDDElParam(WM_DDE_ACK, GlobalAddAtomW(appname), GlobalAddAtomW('System'))
             )
 
-            return 0
+            # It works as a constructor as per <https://docs.python.org/3/library/ctypes.html#fundamental-data-types>
+            return c_long(0)
+
+        return c_long(1)  # This is an utter guess -Ath
 
     class WindowsProtocolHandler(GenericProtocolHandler):
         """
@@ -350,7 +354,7 @@ else:  # Linux / Run from source
 
             self.thread: Optional[threading.Thread] = None
 
-        def start(self, master) -> None:
+        def start(self, master: 'tkinter.Tk') -> None:
             """Start the HTTP server thread."""
             GenericProtocolHandler.start(self, master)
             self.thread = threading.Thread(target=self.worker, name='OAuth worker')
@@ -412,7 +416,7 @@ else:  # Linux / Run from source
             else:
                 self.end_headers()
 
-        def log_request(self, code, size=None):
+        def log_request(self, code: int | str = '-', size: int | str = '-') -> None:
             """Override to prevent logging."""
             pass
 

--- a/scripts/killswitch_test.py
+++ b/scripts/killswitch_test.py
@@ -29,7 +29,7 @@ KNOWN_KILLSWITCH_NAMES: list[str] = [
     'plugins.eddb.journal.event.$event'
 ]
 
-SPLIT_KNOWN_NAMES = list(map(lambda x: x.split('.'), KNOWN_KILLSWITCH_NAMES))
+SPLIT_KNOWN_NAMES = [x.split('.') for x in KNOWN_KILLSWITCH_NAMES]
 
 
 def match_exists(match: str) -> tuple[bool, str]:

--- a/shipyard.py
+++ b/shipyard.py
@@ -1,24 +1,35 @@
-# Export list of ships as CSV
+"""Export list of ships as CSV."""
+import csv
 
-import time
-
-from config import config
+import companion
 from edmc_data import ship_name_map
 
 
-def export(data, filename):
+def export(data: companion.CAPIData, filename: str) -> None:
+    """
+    Write shipyard data in Companion API JSON format.
 
-    querytime = config.get_int('querytime', default=int(time.time()))
-
+    :param data: The CAPI data.
+    :param filename: Optional filename to write to.
+    :return:
+    """
     assert data['lastSystem'].get('name')
     assert data['lastStarport'].get('name')
     assert data['lastStarport'].get('ships')
 
-    header = 'System,Station,Ship,FDevID,Date\n'
-    rowheader = '%s,%s' % (data['lastSystem']['name'], data['lastStarport']['name'])
+    with open(filename, 'w', newline='') as f:
+        c = csv.writer(f)
+        c.writerow(('System', 'Station', 'Ship', 'FDevID', 'Date'))
 
-    h = open(filename, 'wt')
-    h.write(header)
-    for (name,fdevid) in [(ship_name_map.get(ship['name'].lower(), ship['name']), ship['id']) for ship in list((data['lastStarport']['ships'].get('shipyard_list') or {}).values()) + data['lastStarport']['ships'].get('unavailable_list')]:
-        h.write('%s,%s,%s,%s\n' % (rowheader, name, fdevid, data['timestamp']))
-    h.close()
+        for (name, fdevid) in [
+            (
+                ship_name_map.get(ship['name'].lower(), ship['name']),
+                ship['id']
+            ) for ship in list(
+                (data['lastStarport']['ships'].get('shipyard_list') or {}).values()
+            ) + data['lastStarport']['ships'].get('unavailable_list')
+        ]:
+            c.writerow((
+                data['lastSystem']['name'], data['lastStarport']['name'],
+                name, fdevid, data['timestamp']
+            ))

--- a/td.py
+++ b/td.py
@@ -5,7 +5,6 @@ import time
 from collections import defaultdict
 from operator import itemgetter
 from platform import system
-from sys import platform
 
 from companion import CAPIData
 from config import applongname, appversion, config
@@ -20,6 +19,7 @@ stockbracketmap = {0: '-',
                    2: 'M',
                    3: 'H', }
 
+
 def export(data: CAPIData) -> None:
     """Export market data in TD format."""
     data_path = pathlib.Path(config.get_str('outdir'))
@@ -31,31 +31,35 @@ def export(data: CAPIData) -> None:
     with open(data_path / data_filename, 'wb') as h:
         # Format described here: https://bitbucket.org/kfsone/tradedangerous/wiki/Price%20Data
         h.write('#! trade.py import -\n'.encode('utf-8'))
-        this_platform = 'darwin' and "Mac OS" or system_name()
+        this_platform = 'darwin' and "Mac OS" or system()
         cmdr_name = data['commander']['name'].strip()
-        h.write(f'# Created by {applongname} {appversion()} on {this_platform} for Cmdr {cmdr_name}.\n'.encode('utf-8'))
-        h.write('#\n#    <item name>             <sellCR> <buyCR>   <demand>   <stock>  <timestamp>\n\n'.encode('utf-8'))
+        h.write(
+            f'# Created by {applongname} {appversion()} on {this_platform} for Cmdr {cmdr_name}.\n'.encode('utf-8')
+        )
+        h.write(
+            '#\n#    <item name>             <sellCR> <buyCR>   <demand>   <stock>  <timestamp>\n\n'.encode('utf-8')
+        )
         system_name = data['lastSystem']['name'].strip()
         starport_name = data['lastStarport']['name'].strip()
         h.write(f'@ {system_name}/{starport_name}\n'.encode('utf-8'))
 
         # sort commodities by category
-        bycategory = defaultdict(list)
+        by_category = defaultdict(list)
         for commodity in data['lastStarport']['commodities']:
-            bycategory[commodity['categoryname']].append(commodity)
+            by_category[commodity['categoryname']].append(commodity)
 
         timestamp = time.strftime('%Y-%m-%d %H:%M:%S', time.strptime(data['timestamp'], '%Y-%m-%dT%H:%M:%SZ'))
-        for category in sorted(bycategory):
-            h.write('   + {}\n'.format(category).encode('utf-8'))
+        for category in sorted(by_category):
+            h.write(f'   + {format(category)}\n'.encode('utf-8'))
             # corrections to commodity names can change the sort order
-            for commodity in sorted(bycategory[category], key=itemgetter('name')):
-                h.write('      {:<23} {:7d} {:7d} {:9}{:1} {:8}{:1}  {}\n'.format(
-                    commodity['name'],
-                    int(commodity['sellPrice']),
-                    int(commodity['buyPrice']),
-                    int(commodity['demand']) if commodity['demandBracket'] else '',
-                    demandbracketmap[commodity['demandBracket']],
-                    int(commodity['stock']) if commodity['stockBracket'] else '',
-                    stockbracketmap[commodity['stockBracket']],
-                    timestamp).encode('utf-8'))
-
+            for commodity in sorted(by_category[category], key=itemgetter('name')):
+                h.write(
+                    f"      {commodity['name']:<23}"
+                    f" {int(commodity['sellPrice']):7d}"
+                    f" {int(commodity['buyPrice']):7d}"
+                    f" {int(commodity['demand']) if commodity['demandBracket'] else '':9}"
+                    f"{demandbracketmap[commodity['demandBracket']]:1}"
+                    f" {int(commodity['stock']) if commodity['stockBracket'] else '':8}"
+                    f"{stockbracketmap[commodity['stockBracket']]:1}"
+                    f"  {timestamp}\n".encode('utf-8')
+                )

--- a/td.py
+++ b/td.py
@@ -1,70 +1,61 @@
-# Export to Trade Dangerous
+"""Export data for Trade Dangerous."""
 
+import pathlib
 import time
 from collections import defaultdict
 from operator import itemgetter
-from os.path import join
 from platform import system
 from sys import platform
 
+from companion import CAPIData
 from config import applongname, appversion, config
 
 # These are specific to Trade Dangerous, so don't move to edmc_data.py
-demandbracketmap = { 0: '?',
-                     1: 'L',
-                     2: 'M',
-                     3: 'H', }
-stockbracketmap =  { 0: '-',
-                     1: 'L',
-                     2: 'M',
-                     3: 'H', }
+demandbracketmap = {0: '?',
+                    1: 'L',
+                    2: 'M',
+                    3: 'H', }
+stockbracketmap = {0: '-',
+                   1: 'L',
+                   2: 'M',
+                   3: 'H', }
 
-def export(data):
+def export(data: CAPIData) -> None:
+    """Export market data in TD format."""
+    data_path = pathlib.Path(config.get_str('outdir'))
+    timestamp = time.strftime('%Y-%m-%dT%H.%M.%S', time.strptime(data['timestamp'], '%Y-%m-%dT%H:%M:%SZ'))
+    data_filename = f"{data['lastSystem']['name'].strip()}.{data['lastStarport']['name'].strip()}.{timestamp}.prices"
 
-    querytime = config.get_int('querytime', default=int(time.time()))
+    # codecs can't automatically handle line endings, so encode manually where
+    # required
+    with open(data_path / data_filename, 'wb') as h:
+        # Format described here: https://bitbucket.org/kfsone/tradedangerous/wiki/Price%20Data
+        h.write('#! trade.py import -\n'.encode('utf-8'))
+        this_platform = 'darwin' and "Mac OS" or system_name()
+        cmdr_name = data['commander']['name'].strip()
+        h.write(f'# Created by {applongname} {appversion()} on {this_platform} for Cmdr {cmdr_name}.\n'.encode('utf-8'))
+        h.write('#\n#    <item name>             <sellCR> <buyCR>   <demand>   <stock>  <timestamp>\n\n'.encode('utf-8'))
+        system_name = data['lastSystem']['name'].strip()
+        starport_name = data['lastStarport']['name'].strip()
+        h.write(f'@ {system_name}/{starport_name}\n'.encode('utf-8'))
 
-    #
-    #  When this is refactored into multi-line CHECK IT WORKS, avoiding the
-    #  brainfart we had with dangling commas in commodity.py:export() !!!
-    #
-    filename = join(config.get_str('outdir'), '%s.%s.%s.prices' % (data['lastSystem']['name'].strip(), data['lastStarport']['name'].strip(), time.strftime('%Y-%m-%dT%H.%M.%S', time.localtime(querytime))))
-    #
-    #  When this is refactored into multi-line CHECK IT WORKS, avoiding the
-    #  brainfart we had with dangling commas in commodity.py:export() !!!
-    #
+        # sort commodities by category
+        bycategory = defaultdict(list)
+        for commodity in data['lastStarport']['commodities']:
+            bycategory[commodity['categoryname']].append(commodity)
 
-    timestamp = time.strftime('%Y-%m-%d %H:%M:%S', time.strptime(data['timestamp'], '%Y-%m-%dT%H:%M:%SZ'))
+        timestamp = time.strftime('%Y-%m-%d %H:%M:%S', time.strptime(data['timestamp'], '%Y-%m-%dT%H:%M:%SZ'))
+        for category in sorted(bycategory):
+            h.write('   + {}\n'.format(category).encode('utf-8'))
+            # corrections to commodity names can change the sort order
+            for commodity in sorted(bycategory[category], key=itemgetter('name')):
+                h.write('      {:<23} {:7d} {:7d} {:9}{:1} {:8}{:1}  {}\n'.format(
+                    commodity['name'],
+                    int(commodity['sellPrice']),
+                    int(commodity['buyPrice']),
+                    int(commodity['demand']) if commodity['demandBracket'] else '',
+                    demandbracketmap[commodity['demandBracket']],
+                    int(commodity['stock']) if commodity['stockBracket'] else '',
+                    stockbracketmap[commodity['stockBracket']],
+                    timestamp).encode('utf-8'))
 
-    # Format described here: https://bitbucket.org/kfsone/tradedangerous/wiki/Price%20Data
-    h = open(filename, 'wb')	# codecs can't automatically handle line endings, so encode manually where required
-    h.write('#! trade.py import -\n# Created by {appname} {appversion} on {platform} for Cmdr {cmdr}.\n'
-            '#\n#    <item name>             <sellCR> <buyCR>   <demand>   <stock>  <timestamp>\n\n'
-            '@ {system}/{starport}\n'.format(
-                appname=applongname,
-                appversion=appversion(),
-                platform=platform == 'darwin' and "Mac OS" or system(),
-                cmdr=data['commander']['name'].strip(),
-                system=data['lastSystem']['name'].strip(),
-                starport=data['lastStarport']['name'].strip()
-    ).encode('utf-8'))
-
-    # sort commodities by category
-    bycategory = defaultdict(list)
-    for commodity in data['lastStarport']['commodities']:
-        bycategory[commodity['categoryname']].append(commodity)
-
-    for category in sorted(bycategory):
-        h.write('   + {}\n'.format(category).encode('utf-8'))
-        # corrections to commodity names can change the sort order
-        for commodity in sorted(bycategory[category], key=itemgetter('name')):
-            h.write('      {:<23} {:7d} {:7d} {:9}{:1} {:8}{:1}  {}\n'.format(
-                commodity['name'],
-                int(commodity['sellPrice']),
-                int(commodity['buyPrice']),
-                int(commodity['demand']) if commodity['demandBracket'] else '',
-                demandbracketmap[commodity['demandBracket']],
-                int(commodity['stock']) if commodity['stockBracket'] else '',
-                stockbracketmap[commodity['stockBracket']],
-                timestamp).encode('utf-8'))
-
-    h.close()

--- a/theme.py
+++ b/theme.py
@@ -310,57 +310,58 @@ class _Theme(object):
             if isinstance(widget, tk.BitmapImage):
                 # not a widget
                 if 'fg' not in attribs:
-                    widget.configure(foreground=self.current['foreground']),  # type: ignore
+                    widget['foreground'] = self.current['foreground']
 
                 if 'bg' not in attribs:
-                    widget.configure(background=self.current['background'])  # type: ignore
+                    widget['background'] = self.current['background']
 
             elif 'cursor' in widget.keys() and str(widget['cursor']) not in ['', 'arrow']:
                 # Hack - highlight widgets like HyperlinkLabel with a non-default cursor
                 if 'fg' not in attribs:
-                    widget.configure(foreground=self.current['highlight']),  # type: ignore
+                    widget['foreground'] = self.current['highlight']
                     if 'insertbackground' in widget.keys():  # tk.Entry
-                        widget.configure(insertbackground=self.current['foreground']),  # type: ignore
+                        widget['insertbackground'] = self.current['foreground']
 
                 if 'bg' not in attribs:
-                    widget.configure(background=self.current['background'])  # type: ignore
+                    widget['background'] = self.current['background']
                     if 'highlightbackground' in widget.keys():  # tk.Entry
-                        widget.configure(highlightbackground=self.current['background'])  # type: ignore
+                        widget['highlightbackground'] = self.current['background']
 
                 if 'font' not in attribs:
-                    widget.configure(font=self.current['font'])  # type: ignore
+                    widget['font'] = self.current['font']
 
             elif 'activeforeground' in widget.keys():
                 # e.g. tk.Button, tk.Label, tk.Menu
                 if 'fg' not in attribs:
-                    widget.configure(foreground=self.current['foreground'],  # type: ignore
-                                     activeforeground=self.current['activeforeground'],
-                                     disabledforeground=self.current['disabledforeground'])
+                    widget['foreground'] = self.current['foreground']
+                    widget['activeforeground'] = self.current['activeforeground'],
+                    widget['disabledforeground'] = self.current['disabledforeground']
 
                 if 'bg' not in attribs:
-                    widget.configure(background=self.current['background'],  # type: ignore
-                                     activebackground=self.current['activebackground'])
+                    widget['background'] = self.current['background']
+                    widget['activebackground'] = self.current['activebackground']
                     if sys.platform == 'darwin' and isinstance(widget, tk.Button):
-                        widget.configure(highlightbackground=self.current['background'])  # type: ignore
+                        widget['highlightbackground'] = self.current['background']
 
                 if 'font' not in attribs:
-                    widget.configure(font=self.current['font'])  # type: ignore
+                    widget['font'] = self.current['font']
+
             elif 'foreground' in widget.keys():
                 # e.g. ttk.Label
                 if 'fg' not in attribs:
-                    widget.configure(foreground=self.current['foreground']),  # type: ignore
+                    widget['foreground'] = self.current['foreground']
 
                 if 'bg' not in attribs:
-                    widget.configure(background=self.current['background'])  # type: ignore
+                    widget['background'] = self.current['background']
 
                 if 'font' not in attribs:
-                    widget.configure(font=self.current['font'])  # type: ignore
+                    widget['font'] = self.current['font']
 
             elif 'background' in widget.keys() or isinstance(widget, tk.Canvas):
                 # e.g. Frame, Canvas
                 if 'bg' not in attribs:
-                    widget.configure(background=self.current['background'],  # type: ignore
-                                     highlightbackground=self.current['disabledforeground'])
+                    widget['background'] = self.current['background']
+                    widget['highlightbackground'] = self.current['disabledforeground']
 
         except Exception:
             logger.exception(f'Plugin widget issue ? {widget=}')

--- a/theme.py
+++ b/theme.py
@@ -123,6 +123,13 @@ elif sys.platform == 'linux':
 
 class _Theme(object):
 
+    # Enum ?  Remember these are, probably, based on 'value' of a tk
+    # RadioButton set.  Looking in prefs.py, they *appear* to be hard-coded
+    # there as well.
+    THEME_DEFAULT = 0
+    THEME_DARK = 1
+    THEME_TRANSPARENT = 2
+
     def __init__(self) -> None:
         self.active = None  # Starts out with no theme
         self.minwidth: Optional[int] = None

--- a/ttkHyperlinkLabel.py
+++ b/ttkHyperlinkLabel.py
@@ -33,8 +33,7 @@ if TYPE_CHECKING:
 class HyperlinkLabel(sys.platform == 'darwin' and tk.Label or ttk.Label, object):  # type: ignore
     """Clickable label for HTTP links."""
 
-    # NB: do **NOT** try `**kw: Dict`, it causes more trouble than it's worth.
-    def __init__(self, master: Optional[tk.Tk] = None, **kw) -> None:
+    def __init__(self, master: Optional[tk.Tk] = None, **kw: Any) -> None:
         self.url = 'url' in kw and kw.pop('url') or None
         self.popup_copy = kw.pop('popup_copy', False)
         self.underline = kw.pop('underline', None)  # override ttk.Label's underline
@@ -66,9 +65,8 @@ class HyperlinkLabel(sys.platform == 'darwin' and tk.Label or ttk.Label, object)
                        text=kw.get('text'),
                        font=kw.get('font', ttk.Style().lookup('TLabel', 'font')))
 
-    # NB: do **NOT** try `**kw: Dict`, it causes more trouble than it's worth.
     def configure(  # noqa: CCR001
-        self, cnf: dict[str, Any] | None = None, **kw
+        self, cnf: dict[str, Any] | None = None, **kw: Any
     ) -> dict[str, tuple[str, str, str, Any, Any]] | None:
         """Change cursor and appearance depending on state and text."""
         # This class' state
@@ -104,7 +102,7 @@ class HyperlinkLabel(sys.platform == 'darwin' and tk.Label or ttk.Label, object)
 
         return super(HyperlinkLabel, self).configure(cnf, **kw)
 
-    def __setitem__(self, key: str, value) -> None:
+    def __setitem__(self, key: str, value: Any) -> None:
         """
         Allow for dict member style setting of options.
 

--- a/update.py
+++ b/update.py
@@ -49,7 +49,7 @@ class Updater(object):
 
     def shutdown_request(self) -> None:
         """Receive (Win)Sparkle shutdown request and send it to parent."""
-        if not config.shutting_down:
+        if not config.shutting_down and self.root:
             self.root.event_generate('<<Quit>>', when="tail")
 
     def use_internal(self) -> bool:
@@ -63,14 +63,14 @@ class Updater(object):
 
         return False
 
-    def __init__(self, tkroot: 'tk.Tk' = None, provider: str = 'internal'):
+    def __init__(self, tkroot: Optional['tk.Tk'] = None, provider: str = 'internal'):
         """
         Initialise an Updater instance.
 
         :param tkroot: reference to the root window of the GUI
         :param provider: 'internal' or other string if not
         """
-        self.root: 'tk.Tk' = tkroot
+        self.root: Optional['tk.Tk'] = tkroot
         self.provider: str = provider
         self.thread: threading.Thread = None
 
@@ -215,7 +215,7 @@ class Updater(object):
         """Perform internal update checking & update GUI status if needs be."""
         newversion = self.check_appcast()
 
-        if newversion:
+        if newversion and self.root:
             status = self.root.nametowidget(f'.{appname.lower()}.status')
             status['text'] = newversion.title + ' is available'
             self.root.update_idletasks()

--- a/update.py
+++ b/update.py
@@ -178,8 +178,22 @@ class Updater(object):
 
             return None
 
+        if sys.platform == 'darwin':
+            sparkle_platform = 'macos'
+
+        else:
+            # For *these* purposes anything else is the same as 'windows', as
+            # non-win32 would be running from source.
+            sparkle_platform = 'windows'
+
         for item in feed.findall('channel/item'):
             ver = item.find('enclosure').attrib.get('{http://www.andymatuschak.org/xml-namespaces/sparkle}version')
+            ver_platform = item.find('enclosure').attrib.get(
+                '{http://www.andymatuschak.org/xml-namespaces/sparkle}os'
+            )
+            if ver_platform != sparkle_platform:
+                continue
+
             # This will change A.B.C.D to A.B.C+D
             sv = semantic_version.Version.coerce(ver)
 

--- a/update.py
+++ b/update.py
@@ -206,9 +206,9 @@ class Updater(object):
         # Look for any remaining version greater than appversion
         simple_spec = semantic_version.SimpleSpec(f'>{appversion_nobuild()}')
         newversion = simple_spec.select(items.keys())
-
         if newversion:
             return items[newversion]
+
         return None
 
     def worker(self) -> None:

--- a/update.py
+++ b/update.py
@@ -72,7 +72,7 @@ class Updater(object):
         """
         self.root: Optional['tk.Tk'] = tkroot
         self.provider: str = provider
-        self.thread: threading.Thread = None
+        self.thread: Optional[threading.Thread] = None
 
         if self.use_internal():
             return
@@ -81,7 +81,7 @@ class Updater(object):
             import ctypes
 
             try:
-                self.updater = ctypes.cdll.WinSparkle
+                self.updater: Optional[ctypes.CDLL] = ctypes.cdll.WinSparkle
 
                 # Set the appcast URL
                 self.updater.win_sparkle_set_appcast_url(update_feed.encode())
@@ -94,8 +94,6 @@ class Updater(object):
                 self.updater.win_sparkle_set_app_build_version(str(appversion_nobuild()))
 
                 # set up shutdown callback
-                global root
-                root = tkroot
                 self.callback_t = ctypes.CFUNCTYPE(None)  # keep reference
                 self.callback_fn = self.callback_t(self.shutdown_request)
                 self.updater.win_sparkle_set_shutdown_request_callback(self.callback_fn)

--- a/update.py
+++ b/update.py
@@ -13,7 +13,7 @@ import semantic_version
 if TYPE_CHECKING:
     import tkinter as tk
 
-from config import appversion_nobuild, config, update_feed
+from config import appname, appversion_nobuild, config, update_feed
 from EDMCLogging import get_main_logger
 
 logger = get_main_logger()
@@ -216,7 +216,8 @@ class Updater(object):
         newversion = self.check_appcast()
 
         if newversion:
-            self.root.children['status']['text'] = newversion.title + ' is available'
+            status = self.root.nametowidget(f'.{appname.lower()}.status')
+            status['text'] = newversion.title + ' is available'
             self.root.update_idletasks()
 
     def close(self) -> None:

--- a/update.py
+++ b/update.py
@@ -185,8 +185,11 @@ class Updater(object):
             sparkle_platform = 'windows'
 
         for item in feed.findall('channel/item'):
-            ver = item.find('enclosure').attrib.get('{http://www.andymatuschak.org/xml-namespaces/sparkle}version')
-            ver_platform = item.find('enclosure').attrib.get(
+            # xml is a pain with types, hence these ignores
+            ver = item.find('enclosure').attrib.get(  # type: ignore
+                '{http://www.andymatuschak.org/xml-namespaces/sparkle}version'
+            )
+            ver_platform = item.find('enclosure').attrib.get(  # type: ignore
                 '{http://www.andymatuschak.org/xml-namespaces/sparkle}os'
             )
             if ver_platform != sparkle_platform:
@@ -196,8 +199,8 @@ class Updater(object):
             sv = semantic_version.Version.coerce(ver)
 
             items[sv] = EDMCVersion(
-                version=ver,  # sv might have mangled version
-                title=item.find('title').text,
+                version=str(ver),  # sv might have mangled version
+                title=item.find('title').text,  # type: ignore
                 sv=sv
             )
 

--- a/util_ships.py
+++ b/util_ships.py
@@ -1,6 +1,7 @@
 """Utility functions relating to ships."""
 from edmc_data import ship_name_map
 
+
 def ship_file_name(ship_name: str, ship_type: str) -> str:
     """Return a ship name suitable for a filename."""
     name = str(ship_name or ship_name_map.get(ship_type.lower(), ship_type)).strip()


### PR DESCRIPTION
Because of the change in flake8 6.0.0 (`--diff` no longer exists, and it turns out it was always unreliable, hence it being removed), we need to move to just running it on whole files.

But some of the details about how to achieve that are ... awkward.   So, as per #1723 we need to get all of our code passing flake8 tests such that we can *then* adjust the github workflows, and pre-commit config, to always run on whole files.

**THEN** we can actuall upgrade to flake8 6.0.0+.

Now complete
---
I did endeavour to check code was still working as I went, file by file, so this *should* be good to merge.