### PR TITLE
monitor/NavRoute: Load NavRoute after catching_up ends.

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -397,6 +397,12 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 except Exception as ex:
                     logger.debug(f'Invalid journal entry:\n{line!r}\n', exc_info=ex)
 
+            # One-shot attempt to read in latest NavRoute, if present
+            navroute_data = self._parse_navroute_file()
+            if navroute_data is not None:
+                # If it's NavRouteClear contents, just keep those anyway.
+                self.state['NavRoute'] = navroute_data
+
             self.catching_up = False
             log_pos = loghandle.tell()
 


### PR DESCRIPTION
This is to allow restart of EDMarketConnector whilst the game is running to have `state['NavRoute']` hold data when the synthetic `StartUp` event is passed to plugins.

Closes #1739 