### PR TITLE
EDMC.py quietening and fixes

### DIFF
--- a/EDMC.py
+++ b/EDMC.py
@@ -433,9 +433,9 @@ sys.path: {sys.path}'''
             try:
                 eddn_sender = eddn.EDDN(None)
                 logger.debug('Sending Market, Outfitting and Shipyard data to EDDN...')
-                eddn_sender.export_commodities(data, monitor.is_beta, monitor.state['Odyssey'])
-                eddn_sender.export_outfitting(data, monitor.is_beta, monitor.state['Odyssey'])
-                eddn_sender.export_shipyard(data, monitor.is_beta, monitor.state['Odyssey'])
+                eddn_sender.export_commodities(data, monitor.is_beta)
+                eddn_sender.export_outfitting(data, monitor.is_beta)
+                eddn_sender.export_shipyard(data, monitor.is_beta)
 
             except Exception:
                 logger.exception('Failed to send data to EDDN')

--- a/monitor.py
+++ b/monitor.py
@@ -1710,7 +1710,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 pass
 
             else:
-                logger.info(f"Parsed {self.state['GameVersion']=} into {self.version_semantic=}")
+                logger.debug(f"Parsed {self.state['GameVersion']=} into {self.version_semantic=}")
 
             self.is_beta = any(v in self.version.lower() for v in ('alpha', 'beta'))  # type: ignore
         except KeyError:


### PR DESCRIPTION
* Changes the `GameVersion` we found logging from INFO to DEBUG.  Thus not polluting normal EDMC.py output.
* Fixes `EDMC.py -n` to work again - mostly avoiding trying to set tkinter Label text when there's no GUI.