### PR TITLE
UI: Properly name main widgets & put each plugin in its own Frame

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -578,8 +578,9 @@ class AppWindow(object):
                 plugin_sep.grid(columnspan=2, sticky=tk.EW)
                 ui_row = frame.grid_size()[1]
                 plugin_frame.grid(
-                    row=ui_row, columnspan=2, sticky=tk.EW
+                    row=ui_row, columnspan=2, sticky=tk.NSEW
                 )
+                # plugin_frame.columnconfigure(1, weight=1)
                 if isinstance(appitem, tuple) and len(appitem) == 2:
                     ui_row = frame.grid_size()[1]
                     appitem[0].grid(row=ui_row, column=0, sticky=tk.W)

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -580,7 +580,7 @@ class AppWindow(object):
                 plugin_frame.grid(
                     row=ui_row, columnspan=2, sticky=tk.NSEW
                 )
-                # plugin_frame.columnconfigure(1, weight=1)
+                plugin_frame.columnconfigure(1, weight=1)
                 if isinstance(appitem, tuple) and len(appitem) == 2:
                     ui_row = frame.grid_size()[1]
                     appitem[0].grid(row=ui_row, column=0, sticky=tk.W)

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -718,11 +718,15 @@ class AppWindow(object):
             theme.register(self.help_menu)
 
             # Alternate title bar and menu for dark theme
-            self.theme_menubar = tk.Frame(frame)
+            self.theme_menubar = tk.Frame(frame, name="alternate_menubar")
             self.theme_menubar.columnconfigure(2, weight=1)
-            theme_titlebar = tk.Label(self.theme_menubar, text=applongname,
-                                      image=self.theme_icon, cursor='fleur',
-                                      anchor=tk.W, compound=tk.LEFT)
+            theme_titlebar = tk.Label(
+                self.theme_menubar,
+                name="alternate_titlebar",
+                text=applongname,
+                image=self.theme_icon, cursor='fleur',
+                anchor=tk.W, compound=tk.LEFT
+            )
             theme_titlebar.grid(columnspan=3, padx=2, sticky=tk.NSEW)
             self.drag_offset: Tuple[Optional[int], Optional[int]] = (None, None)
             theme_titlebar.bind('<Button-1>', self.drag_start)
@@ -755,7 +759,7 @@ class AppWindow(object):
             tk.Frame(self.theme_menubar, highlightthickness=1).grid(columnspan=5, padx=self.PADX, sticky=tk.EW)
             theme.register(self.theme_minimize)  # images aren't automatically registered
             theme.register(self.theme_close)
-            self.blank_menubar = tk.Frame(frame)
+            self.blank_menubar = tk.Frame(frame, name="blank_menubar")
             tk.Label(self.blank_menubar).grid()
             tk.Label(self.blank_menubar).grid()
             tk.Frame(self.blank_menubar, height=2).grid()

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -523,15 +523,15 @@ class AppWindow(object):
         frame.grid(sticky=tk.NSEW)
         frame.columnconfigure(1, weight=1)
 
-        self.cmdr_label = tk.Label(frame)
+        self.cmdr_label = tk.Label(frame, name='cmdr_label')
         self.cmdr = tk.Label(frame, compound=tk.RIGHT, anchor=tk.W, name='cmdr')
-        self.ship_label = tk.Label(frame)
+        self.ship_label = tk.Label(frame, name='ship_label')
         self.ship = HyperlinkLabel(frame, compound=tk.RIGHT, url=self.shipyard_url, name='ship')
-        self.suit_label = tk.Label(frame)
+        self.suit_label = tk.Label(frame, name='suit_label')
         self.suit = tk.Label(frame, compound=tk.RIGHT, anchor=tk.W, name='suit')
-        self.system_label = tk.Label(frame)
+        self.system_label = tk.Label(frame, name='system_label')
         self.system = HyperlinkLabel(frame, compound=tk.RIGHT, url=self.system_url, popup_copy=True, name='system')
-        self.station_label = tk.Label(frame)
+        self.station_label = tk.Label(frame, name='station_label')
         self.station = HyperlinkLabel(frame, compound=tk.RIGHT, url=self.station_url, name='station')
         # system and station text is set/updated by the 'provider' plugins
         # eddb, edsm and inara.  Look for:
@@ -560,10 +560,14 @@ class AppWindow(object):
         self.station.grid(row=ui_row, column=1, sticky=tk.EW)
         ui_row += 1
 
+        plugin_no = 0
         for plugin in plug.PLUGINS:
             appitem = plugin.get_app(frame)
             if appitem:
-                tk.Frame(frame, highlightthickness=1).grid(columnspan=2, sticky=tk.EW)  # separator
+                plugin_no += 1
+                tk.Frame(
+                    frame, highlightthickness=1, name=f"plugin_hr_{plugin_no}"
+                ).grid(columnspan=2, sticky=tk.EW)  # separator
                 if isinstance(appitem, tuple) and len(appitem) == 2:
                     ui_row = frame.grid_size()[1]
                     appitem[0].grid(row=ui_row, column=0, sticky=tk.W)
@@ -573,8 +577,20 @@ class AppWindow(object):
                     appitem.grid(columnspan=2, sticky=tk.EW)
 
         # LANG: Update button in main window
-        self.button = ttk.Button(frame, text=_('Update'), width=28, default=tk.ACTIVE, state=tk.DISABLED)
-        self.theme_button = tk.Label(frame, width=32 if sys.platform == 'darwin' else 28, state=tk.DISABLED)
+        self.button = ttk.Button(
+            frame,
+            name='update_button',
+            text=_('Update'),
+            width=28,
+            default=tk.ACTIVE,
+            state=tk.DISABLED
+        )
+        self.theme_button = tk.Label(
+            frame,
+            name='themed_update_button',
+            width=32 if sys.platform == 'darwin' else 28,
+            state=tk.DISABLED
+        )
 
         ui_row = frame.grid_size()[1]
         self.button.grid(row=ui_row, columnspan=2, sticky=tk.NSEW)

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -536,7 +536,8 @@ class AppWindow(object):
         # system and station text is set/updated by the 'provider' plugins
         # eddb, edsm and inara.  Look for:
         #
-        # parent.children['system'] / parent.children['station']
+        # parent.nametowidget(f".{appname.lower()}.system")
+        # parent.nametowidget(f".{appname.lower()}.station")
 
         ui_row = 1
 
@@ -562,7 +563,11 @@ class AppWindow(object):
 
         plugin_no = 0
         for plugin in plug.PLUGINS:
-            # Per plugin frame
+            # Per plugin separator
+            plugin_sep = tk.Frame(
+                frame, highlightthickness=1, name=f"plugin_hr_{plugin_no + 1}"
+            )
+            # Per plugin frame, for it to use as its parent for own widgets
             plugin_frame = tk.Frame(
                 frame,
                 name=f"plugin_{plugin_no + 1}"
@@ -570,9 +575,11 @@ class AppWindow(object):
             appitem = plugin.get_app(plugin_frame)
             if appitem:
                 plugin_no += 1
-                tk.Frame(
-                    frame, highlightthickness=1, name=f"plugin_hr_{plugin_no}"
-                ).grid(columnspan=2, sticky=tk.EW)  # separator
+                plugin_sep.grid(columnspan=2, sticky=tk.EW)
+                ui_row = frame.grid_size()[1]
+                plugin_frame.grid(
+                    row=ui_row, columnspan=2, sticky=tk.EW
+                )
                 if isinstance(appitem, tuple) and len(appitem) == 2:
                     ui_row = frame.grid_size()[1]
                     appitem[0].grid(row=ui_row, column=0, sticky=tk.W)
@@ -582,7 +589,9 @@ class AppWindow(object):
                     appitem.grid(columnspan=2, sticky=tk.EW)
 
             else:
+                # This plugin didn't provide any UI, so drop the frames
                 plugin_frame.destroy()
+                plugin_sep.destroy()
 
         # LANG: Update button in main window
         self.button = ttk.Button(

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -562,7 +562,12 @@ class AppWindow(object):
 
         plugin_no = 0
         for plugin in plug.PLUGINS:
-            appitem = plugin.get_app(frame)
+            # Per plugin frame
+            plugin_frame = tk.Frame(
+                frame,
+                name=f"plugin_{plugin_no + 1}"
+            )
+            appitem = plugin.get_app(plugin_frame)
             if appitem:
                 plugin_no += 1
                 tk.Frame(
@@ -575,6 +580,9 @@ class AppWindow(object):
 
                 else:
                     appitem.grid(columnspan=2, sticky=tk.EW)
+
+            else:
+                plugin_frame.destroy()
 
         # LANG: Update button in main window
         self.button = ttk.Button(

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -1138,7 +1138,7 @@ _ = functools.partial(l10n.Translations.translate, context=__file__)
 Wrap each string that needs translating with the `_()` function, e.g.:
 
 ```python
-    status["text"] = _('Happy!')  # Main window status
+    somewidget["text"] = _("Happy!")
 ```
 
 If you display localized strings in EDMarketConnector's main window you should

--- a/plugins/eddb.py
+++ b/plugins/eddb.py
@@ -50,7 +50,7 @@ import EDMCLogging
 import killswitch
 import plug
 from companion import CAPIData
-from config import config
+from config import appname, config
 
 if TYPE_CHECKING:
     from tkinter import Tk
@@ -131,12 +131,14 @@ def plugin_app(parent: 'Tk'):
     :param parent: The tk parent to place our widgets into.
     :return: See PLUGINS.md#display
     """
-    this.system_link = parent.children['system']  # system label in main window
+    # system label in main window
+    this.system_link = parent.nametowidget(f".{appname.lower()}.system")
     this.system = None
     this.system_address = None
     this.station = None
     this.station_marketid = None  # Frontier MarketID
-    this.station_link = parent.children['station']  # station label in main window
+    # station label in main window
+    this.station_link = parent.nametowidget(f".{appname.lower()}.station")
     this.station_link['popup_copy'] = lambda x: x != this.STATION_UNDOCKED
 
 

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -46,7 +46,7 @@ import killswitch
 import myNotebook as nb  # noqa: N813
 import plug
 from companion import CAPIData, category_map
-from config import applongname, appversion_nobuild, config, debug_senders, user_agent
+from config import applongname, appname, appversion_nobuild, config, debug_senders, user_agent
 from EDMCLogging import get_main_logger
 from monitor import monitor
 from myNotebook import Frame
@@ -382,7 +382,7 @@ class EDDNSender:
             logger.info(text)
             return
 
-        self.eddn.parent.children['status']['text'] = text
+        self.eddn.parent.nametowidget(f".{appname.lower()}.status")['text'] = text
 
     def send_message(self, msg: str) -> bool:
         """
@@ -2501,7 +2501,7 @@ def cmdr_data(data: CAPIData, is_beta: bool) -> Optional[str]:  # noqa: CCR001
                 this.commodities = this.outfitting = this.shipyard = None
                 this.marketId = data['lastStarport']['id']
 
-            status = this.parent.children['status']
+            status = this.parent.nametowidget(f".{appname.lower()}.status")
             old_status = status['text']
             if not old_status:
                 status['text'] = _('Sending data to EDDN...')  # LANG: Status text shown while attempting to send data

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -49,7 +49,7 @@ import myNotebook
 import myNotebook as nb  # noqa: N813
 import plug
 from companion import CAPIData
-from config import applongname, appversion, config, debug_senders, user_agent
+from config import applongname, appname, appversion, config, debug_senders, user_agent
 from edmc_data import DEBUG_WEBSERVER_HOST, DEBUG_WEBSERVER_PORT
 from EDMCLogging import get_main_logger
 from ttkHyperlinkLabel import HyperlinkLabel
@@ -250,9 +250,15 @@ def plugin_app(parent: tk.Tk) -> None:
     :param parent: The tk parent to place our widgets into.
     :return: See PLUGINS.md#display
     """
-    this.system_link = parent.children['system']  # system label in main window
+    # system label in main window
+    this.system_link = parent.nametowidget(f".{appname.lower()}.system")
+    if this.system_link is None:
+        logger.error("Couldn't look up system widget!!!")
+        return
+
     this.system_link.bind_all('<<EDSMStatus>>', update_status)
-    this.station_link = parent.children['station']  # station label in main window
+    # station label in main window
+    this.station_link = parent.nametowidget(f".{appname.lower()}.station")
 
 
 def plugin_stop() -> None:

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -628,7 +628,6 @@ entry: {entry!r}'''
             ):
                 # LANG: The Inara API only accepts Live galaxy data, not Legacy galaxy data
                 logger.info("EDSM only accepts Live galaxy data")
-                # this.parent.children['status']['text'] =
                 this.legacy_galaxy_last_notified = datetime.now(timezone.utc)
                 return _("EDSM only accepts Live galaxy data")
 

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -382,7 +382,6 @@ def journal_entry(  # noqa: C901, CCR001
         ):
             # LANG: The Inara API only accepts Live galaxy data, not Legacy galaxy data
             logger.info(_("Inara only accepts Live galaxy data"))
-            # this.parent.children['status']['text'] =
             this.legacy_galaxy_last_notified = datetime.now(timezone.utc)
             return _("Inara only accepts Live galaxy data")
 

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -43,7 +43,7 @@ import myNotebook as nb  # noqa: N813
 import plug
 import timeout_session
 from companion import CAPIData
-from config import applongname, appversion, config, debug_senders
+from config import applongname, appname, appversion, config, debug_senders
 from EDMCLogging import get_main_logger
 from monitor import monitor
 from ttkHyperlinkLabel import HyperlinkLabel
@@ -218,8 +218,10 @@ def plugin_start3(plugin_dir: str) -> str:
 def plugin_app(parent: tk.Tk) -> None:
     """Plugin UI setup Hook."""
     this.parent = parent
-    this.system_link = parent.children['system']  # system label in main window
-    this.station_link = parent.children['station']  # station label in main window
+    # system label in main window
+    this.system_link = parent.nametowidget(f".{appname.lower()}.system")
+    # station label in main window
+    this.station_link = parent.nametowidget(f".{appname.lower()}.station")
     this.system_link.bind_all('<<InaraLocation>>', update_location)
     this.system_link.bind_all('<<InaraShip>>', update_ship)
 


### PR DESCRIPTION
Given talk about adding the ability to change the UI ordering of third-party plugins I started looking at the totality of plugins in the main UI.  Most of them had no `name=...` in their creation so ended up with non-useful tkinter names.  This PR ensures each one has a pertinent name.

Then I experimented with creating a per-plugin frame for all its UI to be in, rather than it being directly in the main UI Frame.  This appears to have no ill effects on the three plugins with UI I have running (aussi's BGS-Tally, Hourly Income and FCMS).  The one piece of fallout was to switch to `nametowidget()` in some of the core plugin code where it needs to access system/station widgets or set status text.

There is no sanctioned reason for a third-party plugin to be trying to poke at/get information about the main UI widgets, so this change causing them to be one step down in the family tree *shouldn't* be a breaking one for them.

Specifically:
```python
	some_widget = self.parent.children['somewidgetname']
```
would have to change to:
```python
	some_widget = self.parent.parent.children['somewidgetname']
```
But, actually the correct way to do this is:
```python
from config import appname

def some_function():
	some_widget = this.parent.nametowidget(f".{appname.lower()}.somewidgetname")
```
i.e. look up the widget by its full tk name.  This method doesn't require knowing how many generations down you are.