### PR TITLE
Move core plugin 'location' tracking into monitor.py

### DIFF
--- a/EDMC.py
+++ b/EDMC.py
@@ -326,10 +326,12 @@ sys.path: {sys.path}'''
             raise companion.CmdrError()
 
         elif (
-            data['lastSystem']['name'] != monitor.state['SystemName'] or
-            ((data['commander']['docked'] and data['lastStarport']['name'] or None) != monitor.station) or
-            data['ship']['id'] != monitor.state['ShipID'] or
-            data['ship']['name'].lower() != monitor.state['ShipType']
+            data['lastSystem']['name'] != monitor.state['SystemName']
+            or (
+                (data['commander']['docked'] and data['lastStarport']['name'] or None) != monitor.state['StationName']
+            )
+            or data['ship']['id'] != monitor.state['ShipID']
+            or data['ship']['name'].lower() != monitor.state['ShipType']
         ):
             raise companion.ServerLagging()
 
@@ -434,7 +436,7 @@ sys.path: {sys.path}'''
             if (
                 new_data['commander'].get('docked')
                 and deep_get(new_data, 'lastSystem', 'name') == monitor.state['SystemName']
-                and deep_get(new_data, 'lastStarport', 'name') == monitor.station
+                and deep_get(new_data, 'lastStarport', 'name') == monitor.state['StationName']
             ):
                 data = new_data
 

--- a/EDMC.py
+++ b/EDMC.py
@@ -326,7 +326,7 @@ sys.path: {sys.path}'''
             raise companion.CmdrError()
 
         elif (
-            data['lastSystem']['name'] != monitor.system or
+            data['lastSystem']['name'] != monitor.state['SystemName'] or
             ((data['commander']['docked'] and data['lastStarport']['name'] or None) != monitor.station) or
             data['ship']['id'] != monitor.state['ShipID'] or
             data['ship']['name'].lower() != monitor.state['ShipType']
@@ -431,10 +431,11 @@ sys.path: {sys.path}'''
 
             new_data = capi_response.capi_data
             # might have undocked while we were waiting for retry in which case station data is unreliable
-            if new_data['commander'].get('docked') and \
-                    deep_get(new_data, 'lastSystem', 'name') == monitor.system and \
-                    deep_get(new_data, 'lastStarport', 'name') == monitor.station:
-
+            if (
+                new_data['commander'].get('docked')
+                and deep_get(new_data, 'lastSystem', 'name') == monitor.state['SystemName']
+                and deep_get(new_data, 'lastStarport', 'name') == monitor.station
+            ):
                 data = new_data
 
         if args.s:

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -1295,9 +1295,9 @@ class AppWindow(object):
 
                 self.capi_query_holdoff_time = capi_response.query_time + companion.capi_query_cooldown
 
-            elif capi_response.capi_data['lastStarport']['id'] != monitor.station_marketid:
+            elif capi_response.capi_data['lastStarport']['id'] != monitor.state['MarketID']:
                 logger.warning(f"MarketID mis-match: {capi_response.capi_data['lastStarport']['id']!r} !="
-                               f" {monitor.station_marketid!r}")
+                               f" {monitor.state['MarketID']!r}")
                 raise companion.ServerLagging()
 
             elif not monitor.state['OnFoot'] and capi_response.capi_data['ship']['id'] != monitor.state['ShipID']:

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -662,6 +662,7 @@ Content of `state` (updated to the current journal entry):
 | `BodyType`[3][4]      |       `Optional[str]`       | The type of body that `Body` refers to                                                                          |
 | `StationName`[3]      |       `Optional[str]`       | Name of the station we're docked at, if applicable                                                              |
 | `MarketID`[3]         |       `Optional[str]`       | MarketID of the station we're docked at, if applicable                                                          |
+| `StationType`[3]      |       `Optional[str]`       | Type of the station we're docked at, if applicable                                                              |
 
 [1] - Contents of `NavRoute` not changed if a `NavRouteClear` event is seen,
 but plugins will see the `NavRouteClear` event.
@@ -808,7 +809,7 @@ now track in the same manner as prior core EDDN plugin code.  Check the
 documentation above for some caveats.  Do not just blindly use this data, or
 the 'Body' name value.
 
-`StationName` and `MarketID` added to the `state` dictionary.
+`StationName`, `MarketID`, and `StationType` added to the `state` dictionary.
 
 ___
 

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -771,7 +771,7 @@ ___
 
 A special "StartUp" entry is sent if EDMarketConnector is started while the
 game is already running. In this case you won't receive initial events such as
-"LoadGame", "Rank", "Location", etc. However the `state` dictionary will
+"LoadGame", "Rank", "Location", etc. However, the `state` dictionary will
 reflect the cumulative effect of these missed events.
 
 **NB: Any of the values in this might be `None` if the Cmdr has loaded into

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -607,11 +607,11 @@ This gets called when EDMarketConnector sees a new entry in the game's journal.
 Content of `state` (updated to the current journal entry):
 
 | Field                |            Type             | Description                                                                                                     |
-| :------------------- | :-------------------------: |:----------------------------------------------------------------------------------------------------------------|
+|:---------------------|:---------------------------:|:----------------------------------------------------------------------------------------------------------------|
 | `GameLanguage`       |       `Optional[str]`       | `language` value from `Fileheader` event.                                                                       |
 | `GameVersion`        |       `Optional[str]`       | `version` value from `Fileheader` event.                                                                        |
 | `GameBuild`          |       `Optional[str]`       | `build` value from `Fileheader` event.                                                                          |
-| `Captain`            |       `Optional[str]`       | Name of the commander who's crew you're on, if any                                                              |
+| `Captain`[3]         |       `Optional[str]`       | Name of the commander who's crew you're on, if any                                                              |
 | `Cargo`              |           `dict`            | Current cargo. Note that this will be totals, and any mission specific duplicates will be counted together      |
 | `CargoJSON`          |           `dict`            | content of cargo.json as of last read.                                                                          |
 | `Credits`            |            `int`            | Current credits balance                                                                                         |
@@ -639,7 +639,7 @@ Content of `state` (updated to the current journal entry):
 | `NavRoute`           |           `dict`            | Last plotted multi-hop route[1]                                                                                 |
 | `ModuleInfo`         |           `dict`            | Last loaded ModulesInfo.json data                                                                               |
 | `IsDocked`           |           `bool`            | Whether the Cmdr is currently docked *in their own ship*.                                                       |
-| `OnFoot`             |           `bool`            | Whether the Cmdr is on foot                                                                                     |
+| `OnFoot`[3]          |           `bool`            | Whether the Cmdr is on foot                                                                                     |
 | `Component`          |           `dict`            | 'Component' MicroResources in Odyssey, `int` count each.                                                        |
 | `Item`               |           `dict`            | 'Item' MicroResources in Odyssey, `int` count each.                                                             |
 | `Consumable`         |           `dict`            | 'Consumable' MicroResources in Odyssey, `int` count each.                                                       |
@@ -653,9 +653,13 @@ Content of `state` (updated to the current journal entry):
 | `SuitLoadouts`       |          `dict`[2]          | CAPI-returned data of all Suit Loadouts.  NB: May be `None` if no data.                                         |
 | `Taxi`               |      `Optional[bool]`       | Whether or not we're currently in a taxi. NB: This is best effort with what the journals provide.               |
 | `Dropship`           |      `Optional[bool]`       | Whether or not the above taxi is a Dropship                                                                     |
-| `Body`[3]            |       `Optional[str]`       | Name of the body we're currently on / in the SOI of                                                                     |
-| `BodyID`[3]            |       `Optional[int]`     | ID of the body we're currently on / in the SOI of                                                                     |
-| `BodyType`[3]        |       `Optional[str]`       | The type of body that `Body` refers to                                                                          |
+| `SystemAddress`[3]   |       `Optional[int]`       | Unique [ID64](http://disc.thargoid.space/ID64) of the star system we're currently in                            |
+| `SystemName`[3]      |       `Optional[str]`       | Name of the star system we're currently in                                                                      |
+| `SystemPopulation`[3]|       `Optional[int]`       | Population of the star system we're currently in                                                                |
+| `StarPos`[3]         |  `Optional[tuple[float]]`   | Galaxy co-ordinates of the system we're currently in                                                            |
+| `Body`[3][4]         |       `Optional[str]`       | Name of the body we're currently on / in the SOI of                                                             |
+| `BodyID`[3][4]       |       `Optional[int]`       | ID of the body we're currently on / in the SOI of                                                               |
+| `BodyType`[3][4]     |       `Optional[str]`       | The type of body that `Body` refers to                                                                          |
 
 [1] - Contents of `NavRoute` not changed if a `NavRouteClear` event is seen,
 but plugins will see the `NavRouteClear` event.
@@ -677,7 +681,10 @@ least one member is missing, so the indices are not contiguous).  We choose to
 always convert to the integer-keyed `dict` form so that code utilising the data
 is simpler.
 
-[3] - There are some caveats with the Body data.  Firstly the name and ID
+[3] - Forced to `None` if the player joins another player's ship in remote
+multi-crew.
+
+[4] - There are some caveats with the Body data.  Firstly the name and ID
 can be for the orbital station or fleet carrier the player is docked at.
 Check 'BodyType' before using the values.
 
@@ -789,6 +796,11 @@ with the synthetic `StartUp` event.  NB: Might just be a `NavRouteClear` event
 if that's what was in the file.
 
 New in version 5.8.0:
+
+`StarPos`, `SystemAddress`, `SystemName` and `SystemPopulation` have been 
+added to the `state` dictionary.  Best efforts data pertaining to the star
+system the player is in.
+
 `BodyID` and `BodyType` have been added to the `state` dictionary.  These
 now track in the same manner as prior core EDDN plugin code.  Check the
 documentation above for some caveats.  Do not just blindly use this data, or

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -660,6 +660,7 @@ Content of `state` (updated to the current journal entry):
 | `Body`[3][4]         |       `Optional[str]`       | Name of the body we're currently on / in the SOI of                                                             |
 | `BodyID`[3][4]       |       `Optional[int]`       | ID of the body we're currently on / in the SOI of                                                               |
 | `BodyType`[3][4]     |       `Optional[str]`       | The type of body that `Body` refers to                                                                          |
+| `StationName`        |       `Optional[str]`       | Name of the station we're docked at, if applicable                                                              |
 
 [1] - Contents of `NavRoute` not changed if a `NavRouteClear` event is seen,
 but plugins will see the `NavRouteClear` event.
@@ -805,6 +806,8 @@ system the player is in.
 now track in the same manner as prior core EDDN plugin code.  Check the
 documentation above for some caveats.  Do not just blindly use this data, or
 the 'Body' name value.
+
+`StationName` added to the `state` dictionary.
 
 ___
 

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -606,61 +606,62 @@ This gets called when EDMarketConnector sees a new entry in the game's journal.
 
 Content of `state` (updated to the current journal entry):
 
-| Field                |            Type             | Description                                                                                                     |
-|:---------------------|:---------------------------:|:----------------------------------------------------------------------------------------------------------------|
-| `GameLanguage`       |       `Optional[str]`       | `language` value from `Fileheader` event.                                                                       |
-| `GameVersion`        |       `Optional[str]`       | `version` value from `Fileheader` event.                                                                        |
-| `GameBuild`          |       `Optional[str]`       | `build` value from `Fileheader` event.                                                                          |
-| `Captain`[3]         |       `Optional[str]`       | Name of the commander who's crew you're on, if any                                                              |
-| `Cargo`              |           `dict`            | Current cargo. Note that this will be totals, and any mission specific duplicates will be counted together      |
-| `CargoJSON`          |           `dict`            | content of cargo.json as of last read.                                                                          |
-| `Credits`            |            `int`            | Current credits balance                                                                                         |
-| `FID`                |            `str`            | Frontier commander ID                                                                                           |
-| `Horizons`           |           `bool`            | From `LoadGame` event.                                                                                          |
-| `Odyssey`            |           `bool`            | From `LoadGame` event.  `False` if not present, else the event value.                                           |
-| `Loan`               |       `Optional[int]`       | Current loan amount, if any                                                                                     |
-| `Raw`                |           `dict`            | Current raw engineering materials                                                                               |
-| `Manufactured`       |           `dict`            | Current manufactured engineering materials                                                                      |
-| `Encoded`            |           `dict`            | Current encoded engineering materials                                                                           |
-| `Component`          |           `dict`            | Current component materials                                                                                     |
-| `Engineers`          |           `dict`            | Current Raw engineering materials                                                                               |
-| `Rank`               | `Dict[str, Tuple[int, int]` | Current ranks, each entry is a tuple of the current rank, and age                                               |
-| `Statistics`         |           `dict`            | Contents of a Journal Statistics event, ie, data shown in the stats panel. See the Journal manual for more info |
-| `Role`               |       `Optional[str]`       | Current role if in multi-crew, one of `Idle`, `FireCon`, `FighterCon`                                           |
-| `Friends`            |            `set`            | Currently online friend                                                                                         |
-| `ShipID`             |            `int`            | Frontier ID of current ship                                                                                     |
-| `ShipIdent`          |            `str`            | Current user-set ship ID                                                                                        |
-| `ShipName`           |            `str`            | Current user-set ship name                                                                                      |
-| `ShipType`           |            `str`            | Internal name for the current ship type                                                                         |
-| `HullValue`          |            `int`            | Current ship value, excluding modules                                                                           |
-| `ModulesValue`       |            `int`            | Value of the current ship's modules                                                                             |
-| `Rebuy`              |            `int`            | Current ship's rebuy cost                                                                                       |
-| `Modules`            |           `dict`            | Currently fitted modules                                                                                        |
-| `NavRoute`           |           `dict`            | Last plotted multi-hop route[1]                                                                                 |
-| `ModuleInfo`         |           `dict`            | Last loaded ModulesInfo.json data                                                                               |
-| `IsDocked`           |           `bool`            | Whether the Cmdr is currently docked *in their own ship*.                                                       |
-| `OnFoot`[3]          |           `bool`            | Whether the Cmdr is on foot                                                                                     |
-| `Component`          |           `dict`            | 'Component' MicroResources in Odyssey, `int` count each.                                                        |
-| `Item`               |           `dict`            | 'Item' MicroResources in Odyssey, `int` count each.                                                             |
-| `Consumable`         |           `dict`            | 'Consumable' MicroResources in Odyssey, `int` count each.                                                       |
-| `Data`               |           `dict`            | 'Data' MicroResources in Odyssey, `int` count each.                                                             |
-| `BackPack`           |           `dict`            | `dict` of Odyssey MicroResources in backpack.                                                                   |
-| `BackpackJSON`       |           `dict`            | Content of Backpack.json as of last read.                                                                       |
-| `ShipLockerJSON`     |           `dict`            | Content of ShipLocker.json as of last read.                                                                     |
-| `SuitCurrent`        |           `dict`            | CAPI-returned data of currently worn suit.  NB: May be `None` if no data.                                       |
-| `Suits`              |          `dict`[2]          | CAPI-returned data of owned suits.  NB: May be `None` if no data.                                               |
-| `SuitLoadoutCurrent` |           `dict`            | CAPI-returned data of current Suit Loadout.  NB: May be `None` if no data.                                      |
-| `SuitLoadouts`       |          `dict`[2]          | CAPI-returned data of all Suit Loadouts.  NB: May be `None` if no data.                                         |
-| `Taxi`               |      `Optional[bool]`       | Whether or not we're currently in a taxi. NB: This is best effort with what the journals provide.               |
-| `Dropship`           |      `Optional[bool]`       | Whether or not the above taxi is a Dropship                                                                     |
-| `SystemAddress`[3]   |       `Optional[int]`       | Unique [ID64](http://disc.thargoid.space/ID64) of the star system we're currently in                            |
-| `SystemName`[3]      |       `Optional[str]`       | Name of the star system we're currently in                                                                      |
-| `SystemPopulation`[3]|       `Optional[int]`       | Population of the star system we're currently in                                                                |
-| `StarPos`[3]         |  `Optional[tuple[float]]`   | Galaxy co-ordinates of the system we're currently in                                                            |
-| `Body`[3][4]         |       `Optional[str]`       | Name of the body we're currently on / in the SOI of                                                             |
-| `BodyID`[3][4]       |       `Optional[int]`       | ID of the body we're currently on / in the SOI of                                                               |
-| `BodyType`[3][4]     |       `Optional[str]`       | The type of body that `Body` refers to                                                                          |
-| `StationName`        |       `Optional[str]`       | Name of the station we're docked at, if applicable                                                              |
+| Field                 |            Type             | Description                                                                                                     |
+|:----------------------|:---------------------------:|:----------------------------------------------------------------------------------------------------------------|
+| `GameLanguage`        |       `Optional[str]`       | `language` value from `Fileheader` event.                                                                       |
+| `GameVersion`         |       `Optional[str]`       | `version` value from `Fileheader` event.                                                                        |
+| `GameBuild`           |       `Optional[str]`       | `build` value from `Fileheader` event.                                                                          |
+| `Captain`[3]          |       `Optional[str]`       | Name of the commander who's crew you're on, if any                                                              |
+| `Cargo`               |           `dict`            | Current cargo. Note that this will be totals, and any mission specific duplicates will be counted together      |
+| `CargoJSON`           |           `dict`            | content of cargo.json as of last read.                                                                          |
+| `Credits`             |            `int`            | Current credits balance                                                                                         |
+| `FID`                 |            `str`            | Frontier commander ID                                                                                           |
+| `Horizons`            |           `bool`            | From `LoadGame` event.                                                                                          |
+| `Odyssey`             |           `bool`            | From `LoadGame` event.  `False` if not present, else the event value.                                           |
+| `Loan`                |       `Optional[int]`       | Current loan amount, if any                                                                                     |
+| `Raw`                 |           `dict`            | Current raw engineering materials                                                                               |
+| `Manufactured`        |           `dict`            | Current manufactured engineering materials                                                                      |
+| `Encoded`             |           `dict`            | Current encoded engineering materials                                                                           |
+| `Component`           |           `dict`            | Current component materials                                                                                     |
+| `Engineers`           |           `dict`            | Current Raw engineering materials                                                                               |
+| `Rank`                | `Dict[str, Tuple[int, int]` | Current ranks, each entry is a tuple of the current rank, and age                                               |
+| `Statistics`          |           `dict`            | Contents of a Journal Statistics event, ie, data shown in the stats panel. See the Journal manual for more info |
+| `Role`                |       `Optional[str]`       | Current role if in multi-crew, one of `Idle`, `FireCon`, `FighterCon`                                           |
+| `Friends`             |            `set`            | Currently online friend                                                                                         |
+| `ShipID`              |            `int`            | Frontier ID of current ship                                                                                     |
+| `ShipIdent`           |            `str`            | Current user-set ship ID                                                                                        |
+| `ShipName`            |            `str`            | Current user-set ship name                                                                                      |
+| `ShipType`            |            `str`            | Internal name for the current ship type                                                                         |
+| `HullValue`           |            `int`            | Current ship value, excluding modules                                                                           |
+| `ModulesValue`        |            `int`            | Value of the current ship's modules                                                                             |
+| `Rebuy`               |            `int`            | Current ship's rebuy cost                                                                                       |
+| `Modules`             |           `dict`            | Currently fitted modules                                                                                        |
+| `NavRoute`            |           `dict`            | Last plotted multi-hop route[1]                                                                                 |
+| `ModuleInfo`          |           `dict`            | Last loaded ModulesInfo.json data                                                                               |
+| `IsDocked`            |           `bool`            | Whether the Cmdr is currently docked *in their own ship*.                                                       |
+| `OnFoot`[3]           |           `bool`            | Whether the Cmdr is on foot                                                                                     |
+| `Component`           |           `dict`            | 'Component' MicroResources in Odyssey, `int` count each.                                                        |
+| `Item`                |           `dict`            | 'Item' MicroResources in Odyssey, `int` count each.                                                             |
+| `Consumable`          |           `dict`            | 'Consumable' MicroResources in Odyssey, `int` count each.                                                       |
+| `Data`                |           `dict`            | 'Data' MicroResources in Odyssey, `int` count each.                                                             |
+| `BackPack`            |           `dict`            | `dict` of Odyssey MicroResources in backpack.                                                                   |
+| `BackpackJSON`        |           `dict`            | Content of Backpack.json as of last read.                                                                       |
+| `ShipLockerJSON`      |           `dict`            | Content of ShipLocker.json as of last read.                                                                     |
+| `SuitCurrent`         |           `dict`            | CAPI-returned data of currently worn suit.  NB: May be `None` if no data.                                       |
+| `Suits`               |          `dict`[2]          | CAPI-returned data of owned suits.  NB: May be `None` if no data.                                               |
+| `SuitLoadoutCurrent`  |           `dict`            | CAPI-returned data of current Suit Loadout.  NB: May be `None` if no data.                                      |
+| `SuitLoadouts`        |          `dict`[2]          | CAPI-returned data of all Suit Loadouts.  NB: May be `None` if no data.                                         |
+| `Taxi`                |      `Optional[bool]`       | Whether or not we're currently in a taxi. NB: This is best effort with what the journals provide.               |
+| `Dropship`            |      `Optional[bool]`       | Whether or not the above taxi is a Dropship                                                                     |
+| `SystemAddress`[3]    |       `Optional[int]`       | Unique [ID64](http://disc.thargoid.space/ID64) of the star system we're currently in                            |
+| `SystemName`[3]       |       `Optional[str]`       | Name of the star system we're currently in                                                                      |
+| `SystemPopulation`[3] |       `Optional[int]`       | Population of the star system we're currently in                                                                |
+| `StarPos`[3]          |  `Optional[tuple[float]]`   | Galaxy co-ordinates of the system we're currently in                                                            |
+| `Body`[3][4]          |       `Optional[str]`       | Name of the body we're currently on / in the SOI of                                                             |
+| `BodyID`[3][4]        |       `Optional[int]`       | ID of the body we're currently on / in the SOI of                                                               |
+| `BodyType`[3][4]      |       `Optional[str]`       | The type of body that `Body` refers to                                                                          |
+| `StationName`[3]      |       `Optional[str]`       | Name of the station we're docked at, if applicable                                                              |
+| `MarketID`[3]         |       `Optional[str]`       | MarketID of the station we're docked at, if applicable                                                          |
 
 [1] - Contents of `NavRoute` not changed if a `NavRouteClear` event is seen,
 but plugins will see the `NavRouteClear` event.
@@ -807,7 +808,7 @@ now track in the same manner as prior core EDDN plugin code.  Check the
 documentation above for some caveats.  Do not just blindly use this data, or
 the 'Body' name value.
 
-`StationName` added to the `state` dictionary.
+`StationName` and `MarketID` added to the `state` dictionary.
 
 ___
 

--- a/monitor.py
+++ b/monitor.py
@@ -14,7 +14,7 @@ from collections import OrderedDict, defaultdict
 from os import SEEK_END, SEEK_SET, listdir
 from os.path import basename, expanduser, getctime, isdir, join
 from time import gmtime, localtime, mktime, sleep, strftime, strptime, time
-from typing import TYPE_CHECKING, Any, BinaryIO, Dict, List, MutableMapping, Optional
+from typing import TYPE_CHECKING, Any, BinaryIO, MutableMapping
 from typing import OrderedDict as OrderedDictT
 from typing import Tuple
 
@@ -91,11 +91,11 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         # TODO(A_D): A bunch of these should be switched to default values (eg '' for strings) and no longer be Optional
         FileSystemEventHandler.__init__(self)  # futureproofing - not need for current version of watchdog
         self.root: 'tkinter.Tk' = None  # type: ignore # Don't use Optional[] - mypy thinks no methods
-        self.currentdir: Optional[str] = None  # The actual logdir that we're monitoring
-        self.logfile: Optional[str] = None
-        self.observer: Optional['Observer'] = None
+        self.currentdir: str | None = None  # The actual logdir that we're monitoring
+        self.logfile: str | None = None
+        self.observer: 'Observer' | None = None
         self.observed = None  # a watchdog ObservedWatch, or None if polling
-        self.thread: Optional[threading.Thread] = None
+        self.thread: threading.Thread | None = None
         # For communicating journal entries back to main thread
         self.event_queue: queue.Queue = queue.Queue(maxsize=0)
 
@@ -112,27 +112,27 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         self.game_was_running = False  # For generation of the "ShutDown" event
 
         # Context for journal handling
-        self.version: Optional[str] = None
-        self.version_semantic: Optional[semantic_version.Version] = None
+        self.version: str | None = None
+        self.version_semantic: semantic_version.Version | None = None
         self.is_beta = False
-        self.mode: Optional[str] = None
-        self.group: Optional[str] = None
-        self.cmdr: Optional[str] = None
-        self.planet: Optional[str] = None
-        self.system: Optional[str] = None
-        self.station: Optional[str] = None
-        self.station_marketid: Optional[int] = None
-        self.stationtype: Optional[str] = None
-        self.coordinates: Optional[Tuple[float, float, float]] = None
-        self.systemaddress: Optional[int] = None
-        self.systempopulation: Optional[int] = None
-        self.started: Optional[int] = None  # Timestamp of the LoadGame event
+        self.mode: str | None = None
+        self.group: str | None = None
+        self.cmdr: str | None = None
+        self.planet: str | None = None
+        self.system: str | None = None
+        self.station: str | None = None
+        self.station_marketid: int | None = None
+        self.stationtype: str | None = None
+        self.coordinates: Tuple[float, float, float] | None = None
+        self.systemaddress: int | None = None
+        self.systempopulation: int | None = None
+        self.started: int | None = None  # Timestamp of the LoadGame event
 
         self._navroute_retries_remaining = 0
-        self._last_navroute_journal_timestamp: Optional[float] = None
+        self._last_navroute_journal_timestamp: float | None = None
 
         self._fcmaterials_retries_remaining = 0
-        self._last_fcmaterials_journal_timestamp: Optional[float] = None
+        self._last_fcmaterials_journal_timestamp: float | None = None
 
         # For determining Live versus Legacy galaxy.
         # The assumption is gameversion will parse via `coerce()` and always
@@ -274,7 +274,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         logger.debug('Done.')
         return True
 
-    def journal_newest_filename(self, journals_dir) -> Optional[str]:
+    def journal_newest_filename(self, journals_dir) -> str | None:
         """
         Determine the newest Journal file name.
 
@@ -455,7 +455,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
             # Check whether new log file started, e.g. client (re)started.
             if emitter and emitter.is_alive():
-                new_journal_file: Optional[str] = self.logfile  # updated by on_created watchdog callback
+                new_journal_file: str | None = self.logfile  # updated by on_created watchdog callback
 
             else:
                 # Poll
@@ -1918,7 +1918,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         slotid = journal_loadoutid - 4293000000
         return slotid
 
-    def canonicalise(self, item: Optional[str]) -> str:
+    def canonicalise(self, item: str | None) -> str:
         """
         Produce canonical name for a ship module.
 
@@ -1955,7 +1955,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
         return item.capitalize()
 
-    def get_entry(self) -> Optional[MutableMapping[str, Any]]:
+    def get_entry(self) -> MutableMapping[str, Any | None]:
         """
         Pull the next Journal event from the event_queue.
 
@@ -2051,7 +2051,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
         return False
 
-    def ship(self, timestamped=True) -> Optional[MutableMapping[str, Any]]:
+    def ship(self, timestamped=True) -> MutableMapping[str, Any | None]:
         """
         Produce a subset of data for the current ship.
 
@@ -2250,7 +2250,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
         return slots
 
-    def _parse_navroute_file(self) -> Optional[dict[str, Any]]:
+    def _parse_navroute_file(self) -> dict[str, Any | None]:
         """Read and parse NavRoute.json."""
         if self.currentdir is None:
             raise ValueError('currentdir unset')
@@ -2276,7 +2276,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
         return data
 
-    def _parse_fcmaterials_file(self) -> Optional[dict[str, Any]]:
+    def _parse_fcmaterials_file(self) -> dict[str, Any | None]:
         """Read and parse FCMaterials.json."""
         if self.currentdir is None:
             raise ValueError('currentdir unset')
@@ -2348,7 +2348,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         self._last_navroute_journal_timestamp = None
         return True
 
-    def __fcmaterials_retry(self) -> Optional[Dict[str, Any]]:
+    def __fcmaterials_retry(self) -> Dict[str, Any | None]:
         """Retry reading FCMaterials files."""
         if self._fcmaterials_retries_remaining == 0:
             return None

--- a/monitor.py
+++ b/monitor.py
@@ -116,7 +116,6 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         self.mode: str | None = None
         self.group: str | None = None
         self.cmdr: str | None = None
-        self.systempopulation: int | None = None
         self.station: str | None = None
         self.station_marketid: int | None = None
         self.stationtype: str | None = None
@@ -191,6 +190,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             'StarPos':            None,  # Best effort current system's galaxy position.
             'SystemAddress':      None,
             'SystemName':         None,
+            'SystemPopulation':   None,
             'Body':               None,
             'BodyID':             None,
             'BodyType':           None,
@@ -304,6 +304,8 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         self.group = None
         self.cmdr = None
         self.state['SystemAddress'] = None
+        self.state['SystemName'] = None
+        self.state['SystemPopulation'] = None
         self.state['StarPos'] = None
         self.state['Body'] = None
         self.state['BodyID'] = None
@@ -529,7 +531,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             'StarSystem':       self.state['SystemName'],
             'StarPos':          self.state['StarPos'],
             'SystemAddress':    self.state['SystemAddress'],
-            'Population':       self.systempopulation,
+            'Population':       self.state['SystemPopulation'],
         }
 
         if self.state['Body']:
@@ -577,8 +579,9 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.cmdr = None
                 self.mode = None
                 self.group = None
-                self.state['SystemName'] = None
                 self.state['SystemAddress'] = None
+                self.state['SystemName'] = None
+                self.state['SystemPopulation'] = None
                 self.state['StarPos'] = None
                 self.state['Body'] = None
                 self.state['BodyID'] = None
@@ -614,8 +617,9 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     self.mode = entry.get('GameMode')
 
                 self.group = entry.get('Group')
-                self.state['SystemName'] = None
                 self.state['SystemAddress'] = None
+                self.state['SystemName'] = None
+                self.state['SystemPopulation'] = None
                 self.state['StarPos'] = None
                 self.state['Body'] = None
                 self.state['BodyID'] = None
@@ -939,7 +943,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 # Yes, explicitly state `None` here, so it's crystal clear.
                 self.state['SystemAddress'] = entry.get('SystemAddress', None)
 
-                self.systempopulation = entry.get('Population')
+                self.state['SystemPopulation'] = entry.get('Population')
 
                 if entry['StarSystem'] == 'ProvingGround':
                     self.state['SystemName'] = 'CQC'
@@ -1688,6 +1692,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.state['StarPos'] = None
                 self.state['SystemName'] = None
                 self.state['SystemAddress'] = None
+                self.state['SystemPopulation'] = None
                 self.state['StarPos'] = None
                 self.state['Body'] = None
                 self.state['BodyID'] = None
@@ -1706,6 +1711,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.state['Role'] = None
                 self.state['SystemName'] = None
                 self.state['SystemAddress'] = None
+                self.state['SystemPopulation'] = None
                 self.state['StarPos'] = None
                 self.state['Body'] = None
                 self.state['BodyID'] = None

--- a/monitor.py
+++ b/monitor.py
@@ -539,10 +539,10 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             entry['BodyID'] = self.state['BodyID']
             entry['BodyType'] = self.state['BodyType']
 
-        if self.station:
+        if self.state['StationName']:
             entry['Docked'] = True
             entry['MarketID'] = self.station_marketid
-            entry['StationName'] = self.station
+            entry['StationName'] = self.state['StationName']
             entry['StationType'] = self.stationtype
 
         else:

--- a/monitor.py
+++ b/monitor.py
@@ -863,8 +863,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
                     if event_type == 'location':
                         logger.trace_if('journal.locations', '"Location" event')
-                        if entry.get('Docked'):
-                            self.state['IsDocked'] = True
+                        self.state['IsDocked'] = entry.get('Docked', False)
 
                 elif event_type == 'fsdjump':
                     self.state['Body'] = None

--- a/monitor.py
+++ b/monitor.py
@@ -927,6 +927,8 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.state['BodyID'] = entry.get('BodyID')
                 # This isn't in the event, but Journal doc for ApproachBody says:
                 #   when in Supercruise, and distance from planet drops to within the 'Orbital Cruise' zone
+                # Used in plugins/eddn.py for setting entry Body/BodyType
+                # on 'docked' events when Planetary.
                 self.state['BodyType'] = 'Planet'
 
             elif event_type == 'leavebody':

--- a/monitor.py
+++ b/monitor.py
@@ -117,7 +117,6 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         self.group: str | None = None
         self.cmdr: str | None = None
         self.system: str | None = None
-        self.systemaddress: int | None = None
         self.coordinates: Tuple[float, float, float] | None = None
         self.systempopulation: int | None = None
         self.planet: str | None = None
@@ -307,7 +306,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         self.group = None
         self.cmdr = None
         self.system = None
-        self.state['SystemAddress'] = self.systemaddress = None
+        self.state['SystemAddress'] = None
         self.coordinates = None
         self.planet = self.state['Body'] = None
         self.state['BodyID'] = None
@@ -532,7 +531,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             'event':            'StartUp',
             'StarSystem':       self.system,
             'StarPos':          self.coordinates,
-            'SystemAddress':    self.systemaddress,
+            'SystemAddress':    self.state['SystemAddress'],
             'Population':       self.systempopulation,
         }
 
@@ -582,7 +581,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.mode = None
                 self.group = None
                 self.system = None
-                self.state['SystemAddress'] = self.systemaddress = None
+                self.state['SystemAddress'] = None
                 self.state['StarPos'] = self.coordinates = None
                 self.state['Body'] = self.planet = None
                 self.state['BodyID'] = None
@@ -619,7 +618,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
                 self.group = entry.get('Group')
                 self.system = None
-                self.state['SystemAddress'] = self.systemaddress = None
+                self.state['SystemAddress'] = None
                 self.state['StarPos'] = self.coordinates = None
                 self.status['Body'] = self.planet = None
                 self.status['BodyID'] = None
@@ -877,7 +876,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     # Plugins need this as well, so copy in state
                     self.state['StarPos'] = self.coordinates = tuple(entry['StarPos'])  # type: ignore
 
-                self.state['SystemAddress'] = self.systemaddress = entry.get('SystemAddress')
+                self.state['SystemAddress'] = entry.get('SystemAddress')
 
                 self.systempopulation = entry.get('Population')
 
@@ -1608,7 +1607,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.stationtype = None
                 self.stationservices = None
                 self.coordinates = None
-                self.state['SystemAddress'] = self.systemaddress = None
+                self.state['SystemAddress'] = None
                 self.state['OnFoot'] = False
 
                 self.state['Body'] = None
@@ -1629,7 +1628,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.stationtype = None
                 self.stationservices = None
                 self.coordinates = None
-                self.state['SystemAddress'] = self.systemaddress = None
+                self.state['SystemAddress'] = None
 
                 # TODO: on_foot: Will we get an event after this to know ?
 

--- a/monitor.py
+++ b/monitor.py
@@ -892,6 +892,10 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                   player is no longer near the Body.  They can easily utilise
                   Orbital Cruise to rapidly travel around the Body and then
                   land on it again **without a fresh 'ApproachBody'** event.
+
+                  The only way to check for this is to utilise the Body (name)
+                  present in `Status.json` data, as this *will* correctly
+                  reflect the second Body.
                 """
                 ###############################################################
                 # Track: Body

--- a/monitor.py
+++ b/monitor.py
@@ -116,7 +116,6 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         self.mode: str | None = None
         self.group: str | None = None
         self.cmdr: str | None = None
-        self.stationtype: str | None = None
         self.started: int | None = None  # Timestamp of the LoadGame event
 
         self._navroute_retries_remaining = 0
@@ -311,7 +310,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         self.state['BodyType'] = None
         self.state['StationName'] = None
         self.state['MarketID'] = None
-        self.stationtype = None
+        self.state['StationType'] = None
         self.stationservices = None
         self.is_beta = False
         self.state['OnFoot'] = False
@@ -542,7 +541,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             entry['Docked'] = True
             entry['MarketID'] = self.state['MarketID']
             entry['StationName'] = self.state['StationName']
-            entry['StationType'] = self.stationtype
+            entry['StationType'] = self.state['StationType']
 
         else:
             entry['Docked'] = False
@@ -586,7 +585,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.state['BodyID'] = None
                 self.state['StationName'] = None
                 self.state['MarketID'] = None
-                self.stationtype = None
+                self.state['StationType'] = None
                 self.stationservices = None
                 self.started = None
                 self.__init_state()
@@ -625,7 +624,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.state['BodyType'] = None
                 self.state['StationName'] = None
                 self.state['MarketID'] = None
-                self.stationtype = None
+                self.state['StationType'] = None
                 self.stationservices = None
                 self.started = timegm(strptime(entry['timestamp'], '%Y-%m-%dT%H:%M:%SZ'))
                 # Don't set Ship, ShipID etc since this will reflect Fighter or SRV if starting in those
@@ -758,7 +757,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             elif event_type == 'undocked':
                 self.state['StationName'] = None
                 self.state['MarketID'] = None
-                self.stationtype = None
+                self.state['StationType'] = None
                 self.stationservices = None
                 self.state['IsDocked'] = False
 
@@ -847,7 +846,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.state['IsDocked'] = True
                 self.state['StationName'] = entry.get('StationName')  # It may be None
                 self.state['MarketID'] = entry.get('MarketID')  # It may be None
-                self.stationtype = entry.get('StationType')  # It may be None
+                self.state['StationType'] = entry.get('StationType')  # It may be None
                 self.stationservices = entry.get('StationServices')  # None under E:D < 2.4
 
                 # No need to set self.state['Taxi'] or Dropship here, if it's
@@ -959,7 +958,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 if event_type == 'fsdjump':
                     self.state['StationName'] = None
                     self.state['MarketID'] = None
-                    self.stationtype = None
+                    self.state['StationType'] = None
                     self.stationservices = None
 
                 else:
@@ -971,7 +970,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                         self.state['StationName'] = entry.get('Body')
 
                     self.state['MarketID'] = entry.get('MarketID')  # May be None
-                    self.stationtype = entry.get('StationType')  # May be None
+                    self.state['StationType'] = entry.get('StationType')  # May be None
                     self.stationservices = entry.get('StationServices')  # None in Odyssey for on-foot 'Location'
                 ###############################################################
 
@@ -1010,7 +1009,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 ###############################################################
                 self.state['StationName'] = None
                 self.state['MarketID'] = None
-                self.stationtype = None
+                self.state['StationType'] = None
                 self.stationservices = None
                 ###############################################################
 
@@ -1715,7 +1714,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.state['BodyType'] = None
                 self.state['StationName'] = None
                 self.state['MarketID'] = None
-                self.stationtype = None
+                self.state['StationType'] = None
                 self.stationservices = None
                 self.state['OnFoot'] = False
 
@@ -1734,7 +1733,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.state['BodyType'] = None
                 self.state['StationName'] = None
                 self.state['MarketID'] = None
-                self.stationtype = None
+                self.state['StationType'] = None
                 self.stationservices = None
 
                 # TODO: on_foot: Will we get an event after this to know ?

--- a/monitor.py
+++ b/monitor.py
@@ -144,7 +144,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
     def __init_state(self) -> None:
         # Cmdr state shared with EDSM and plugins
         # If you change anything here update PLUGINS.md documentation!
-        self.state: Dict = {
+        self.state: dict = {
             'GameLanguage':       None,  # From `Fileheader
             'GameVersion':        None,  # From `Fileheader
             'GameBuild':          None,  # From `Fileheader
@@ -1955,7 +1955,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
         return item.capitalize()
 
-    def get_entry(self) -> MutableMapping[str, Any | None]:
+    def get_entry(self) -> MutableMapping[str, Any] | None:
         """
         Pull the next Journal event from the event_queue.
 
@@ -2051,7 +2051,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
         return False
 
-    def ship(self, timestamped=True) -> MutableMapping[str, Any | None]:
+    def ship(self, timestamped=True) -> MutableMapping[str, Any] | None:
         """
         Produce a subset of data for the current ship.
 
@@ -2188,7 +2188,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         except OSError:
             logger.exception("OSError writing ship loadout to new filename with utf-8 encoding, aborting.")
 
-    def coalesce_cargo(self, raw_cargo: List[MutableMapping[str, Any]]) -> List[MutableMapping[str, Any]]:
+    def coalesce_cargo(self, raw_cargo: list[MutableMapping[str, Any]]) -> list[MutableMapping[str, Any]]:
         """
         Coalesce multiple entries of the same cargo into one.
 
@@ -2209,7 +2209,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         :return: Coalesced data
         """
         # self.state['Cargo'].update({self.canonicalise(x['Name']): x['Count'] for x in entry['Inventory']})
-        out: List[MutableMapping[str, Any]] = []
+        out: list[MutableMapping[str, Any]] = []
         for inventory_item in raw_cargo:
             if not any(self.canonicalise(x['Name']) == self.canonicalise(inventory_item['Name']) for x in out):
                 out.append(dict(inventory_item))
@@ -2250,7 +2250,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
         return slots
 
-    def _parse_navroute_file(self) -> dict[str, Any | None]:
+    def _parse_navroute_file(self) -> dict[str, Any] | None:
         """Read and parse NavRoute.json."""
         if self.currentdir is None:
             raise ValueError('currentdir unset')
@@ -2276,7 +2276,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
         return data
 
-    def _parse_fcmaterials_file(self) -> dict[str, Any | None]:
+    def _parse_fcmaterials_file(self) -> dict[str, Any] | None:
         """Read and parse FCMaterials.json."""
         if self.currentdir is None:
             raise ValueError('currentdir unset')
@@ -2348,7 +2348,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         self._last_navroute_journal_timestamp = None
         return True
 
-    def __fcmaterials_retry(self) -> Dict[str, Any | None]:
+    def __fcmaterials_retry(self) -> dict[str, Any] | None:
         """Retry reading FCMaterials files."""
         if self._fcmaterials_retries_remaining == 0:
             return None

--- a/monitor.py
+++ b/monitor.py
@@ -116,7 +116,6 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         self.mode: str | None = None
         self.group: str | None = None
         self.cmdr: str | None = None
-        self.system: str | None = None
         self.systempopulation: int | None = None
         self.station: str | None = None
         self.station_marketid: int | None = None
@@ -191,6 +190,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             'Dropship':           None,  # Best effort as to whether or not the above taxi is a dropship.
             'StarPos':            None,  # Best effort current system's galaxy position.
             'SystemAddress':      None,
+            'SystemName':         None,
             'Body':               None,
             'BodyID':             None,
             'BodyType':           None,
@@ -303,7 +303,6 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         self.mode = None
         self.group = None
         self.cmdr = None
-        self.system = None
         self.state['SystemAddress'] = None
         self.state['StarPos'] = None
         self.state['Body'] = None
@@ -527,7 +526,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         entry: dict[str, Any] = {
             'timestamp':        strftime('%Y-%m-%dT%H:%M:%SZ', gmtime()),
             'event':            'StartUp',
-            'StarSystem':       self.system,
+            'StarSystem':       self.state['SystemName'],
             'StarPos':          self.state['StarPos'],
             'SystemAddress':    self.state['SystemAddress'],
             'Population':       self.systempopulation,
@@ -578,7 +577,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.cmdr = None
                 self.mode = None
                 self.group = None
-                self.system = None
+                self.state['SystemName'] = None
                 self.state['SystemAddress'] = None
                 self.state['StarPos'] = None
                 self.state['Body'] = None
@@ -615,7 +614,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     self.mode = entry.get('GameMode')
 
                 self.group = entry.get('Group')
-                self.system = None
+                self.state['SystemName'] = None
                 self.state['SystemAddress'] = None
                 self.state['StarPos'] = None
                 self.state['Body'] = None
@@ -943,10 +942,10 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.systempopulation = entry.get('Population')
 
                 if entry['StarSystem'] == 'ProvingGround':
-                    self.system = 'CQC'
+                    self.state['SystemName'] = 'CQC'
 
                 else:
-                    self.system = entry['StarSystem']
+                    self.state['SystemName'] = entry['StarSystem']
                 ###############################################################
 
                 ###############################################################
@@ -1687,7 +1686,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.state['Captain'] = entry['Captain']
                 self.state['Role'] = 'Idle'
                 self.state['StarPos'] = None
-                self.system = None
+                self.state['SystemName'] = None
                 self.state['SystemAddress'] = None
                 self.state['StarPos'] = None
                 self.state['Body'] = None
@@ -1705,7 +1704,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
             elif event_type == 'quitacrew':
                 self.state['Captain'] = None
                 self.state['Role'] = None
-                self.system = None
+                self.state['SystemName'] = None
                 self.state['SystemAddress'] = None
                 self.state['StarPos'] = None
                 self.state['Body'] = None

--- a/monitor.py
+++ b/monitor.py
@@ -837,6 +837,9 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     self.state['BodyID'] = None
 
             elif event_type == 'docked':
+                ###############################################################
+                # Track: Station
+                ###############################################################
                 self.state['IsDocked'] = True
                 self.station = entry.get('StationName')  # It may be None
                 self.station_marketid = entry.get('MarketID')  # It may be None
@@ -845,8 +848,51 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
                 # No need to set self.state['Taxi'] or Dropship here, if it's
                 # those, the next event is a Disembark anyway
+                ###############################################################
 
             elif event_type in ('location', 'fsdjump', 'carrierjump'):
+                """
+                Notes on tracking of a player's location.
+
+                Body
+                ---
+                There are some caveats about tracking Body name, ID and type,
+                mostly due to close-orbiting binary planets/moons.
+
+                Presence on or near a Body is indicated in several scenarios:
+
+                1. When the player logs in.
+                2. When the player's location changes due to being docked
+                  on a Fleet Carrier when it jumps.
+                3. When the player flies within Orbital Cruise range of a
+                  Body.
+
+                For the first case this will always be a 'Location' event.
+                If landed on a Body, or docked at a surface port then this
+                will be indicated.  However, if docked at an orbital station
+                the 'Body' is the name of that station, with 'BodyType' having
+                'Station' as its value.
+
+                In the second case although it *should* be a 'CarrierJump'
+                event, for a while now it's actually been a 'Location' event.
+                This should follow the same rules as being docked at an
+                orbital station.
+
+                For the last case there are some caveats to do with close
+                orbiting binary bodies:
+
+                1. 'ApproachBody' indicates presence near the Body in question.
+                2. 'LeaveBody' indicates the player is no longer considered
+                  to be near the Body.  This is specifically when no longer
+                  in Orbital Cruise around the Body such that the HUD for that
+                  has been switched out for the normal SuperCruise one.
+                3. 'SupercruiseExit' does not indicate any change of presence
+                  near a Body.
+                4. 'SupercruiseEntry' *also* **DOES NOT** indicate that the
+                  player is no longer near the Body.  They can easily utilise
+                  Orbital Cruise to rapidly travel around the Body and then
+                  land on it again **without a fresh 'ApproachBody'** event.
+                """
                 ###############################################################
                 # Track: Body
                 ###############################################################

--- a/monitor.py
+++ b/monitor.py
@@ -1000,9 +1000,13 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.state['BodyType'] = None
 
             elif event_type == 'supercruiseentry':
-                # NB: Do **NOT** clear Body state, because we won't get a fresh
-                #     ApproachBody if we don't leave Orbital Cruise but land
-                #     again.
+                # We only clear Body state if the Type is Station.  This is
+                # because we won't get a fresh ApproachBody if we don't leave
+                # Orbital Cruise but land again.
+                if self.state['BodyType'] == 'Station':
+                    self.state['Body'] = None
+                    self.state['BodyID'] = None
+                    self.state['BodyType'] = None
 
                 ###############################################################
                 # Track: Current station, if applicable

--- a/monitor.py
+++ b/monitor.py
@@ -116,7 +116,6 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         self.mode: str | None = None
         self.group: str | None = None
         self.cmdr: str | None = None
-        self.station_marketid: int | None = None
         self.stationtype: str | None = None
         self.started: int | None = None  # Timestamp of the LoadGame event
 
@@ -311,7 +310,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         self.state['BodyID'] = None
         self.state['BodyType'] = None
         self.state['StationName'] = None
-        self.station_marketid = None
+        self.state['MarketID'] = None
         self.stationtype = None
         self.stationservices = None
         self.is_beta = False
@@ -541,7 +540,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
         if self.state['StationName']:
             entry['Docked'] = True
-            entry['MarketID'] = self.station_marketid
+            entry['MarketID'] = self.state['MarketID']
             entry['StationName'] = self.state['StationName']
             entry['StationType'] = self.stationtype
 
@@ -586,7 +585,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.state['Body'] = None
                 self.state['BodyID'] = None
                 self.state['StationName'] = None
-                self.station_marketid = None
+                self.state['MarketID'] = None
                 self.stationtype = None
                 self.stationservices = None
                 self.started = None
@@ -625,7 +624,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.state['BodyID'] = None
                 self.state['BodyType'] = None
                 self.state['StationName'] = None
-                self.station_marketid = None
+                self.state['MarketID'] = None
                 self.stationtype = None
                 self.stationservices = None
                 self.started = timegm(strptime(entry['timestamp'], '%Y-%m-%dT%H:%M:%SZ'))
@@ -758,7 +757,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
 
             elif event_type == 'undocked':
                 self.state['StationName'] = None
-                self.station_marketid = None
+                self.state['MarketID'] = None
                 self.stationtype = None
                 self.stationservices = None
                 self.state['IsDocked'] = False
@@ -780,8 +779,10 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 #     • StationType
                 #     • MarketID
                 self.state['StationName'] = None
+                self.state['MarketID'] = None
                 if entry.get('OnStation'):
                     self.state['StationName'] = entry.get('StationName', '')
+                    self.state['MarketID'] = entry.get('MarketID', '')
 
                 self.state['OnFoot'] = False
                 self.state['Taxi'] = entry['Taxi']
@@ -845,7 +846,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 ###############################################################
                 self.state['IsDocked'] = True
                 self.state['StationName'] = entry.get('StationName')  # It may be None
-                self.station_marketid = entry.get('MarketID')  # It may be None
+                self.state['MarketID'] = entry.get('MarketID')  # It may be None
                 self.stationtype = entry.get('StationType')  # It may be None
                 self.stationservices = entry.get('StationServices')  # None under E:D < 2.4
 
@@ -957,7 +958,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 ###############################################################
                 if event_type == 'fsdjump':
                     self.state['StationName'] = None
-                    self.station_marketid = None
+                    self.state['MarketID'] = None
                     self.stationtype = None
                     self.stationservices = None
 
@@ -969,7 +970,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     if entry.get('BodyType') and entry['BodyType'] == 'Station':
                         self.state['StationName'] = entry.get('Body')
 
-                    self.station_marketid = entry.get('MarketID')  # May be None
+                    self.state['MarketID'] = entry.get('MarketID')  # May be None
                     self.stationtype = entry.get('StationType')  # May be None
                     self.stationservices = entry.get('StationServices')  # None in Odyssey for on-foot 'Location'
                 ###############################################################
@@ -1008,7 +1009,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 # Track: Current station, if applicable
                 ###############################################################
                 self.state['StationName'] = None
-                self.station_marketid = None
+                self.state['MarketID'] = None
                 self.stationtype = None
                 self.stationservices = None
                 ###############################################################
@@ -1713,7 +1714,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.state['BodyID'] = None
                 self.state['BodyType'] = None
                 self.state['StationName'] = None
-                self.station_marketid = None
+                self.state['MarketID'] = None
                 self.stationtype = None
                 self.stationservices = None
                 self.state['OnFoot'] = False
@@ -1732,7 +1733,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 self.state['BodyID'] = None
                 self.state['BodyType'] = None
                 self.state['StationName'] = None
-                self.station_marketid = None
+                self.state['MarketID'] = None
                 self.stationtype = None
                 self.stationservices = None
 

--- a/plugins/eddb.py
+++ b/plugins/eddb.py
@@ -199,16 +199,17 @@ def journal_entry(
         # Undocked event.
         this.station_marketid = None
 
-    # Only actually change URLs if we are current provider.
-    if config.get_str('system_provider') == 'eddb':
+    # Only change URL text if we are current provider.
+    if config.get_str('station_provider') == 'eddb':
         this.system_link['text'] = this.system_name
         # Do *NOT* set 'url' here, as it's set to a function that will call
         # through correctly.  We don't want a static string.
         this.system_link.update_idletasks()
 
-    # But only actually change the URL if we are current station provider.
-    if config.get_str('station_provider') == 'eddb':
-        if not this.station_name:
+        if this.station_name:
+            this.station_link['text'] = this.station_name
+
+        else:
             if this.system_population is not None and this.system_population > 0:
                 this.station_link['text'] = this.STATION_UNDOCKED
 

--- a/plugins/eddb.py
+++ b/plugins/eddb.py
@@ -42,7 +42,7 @@
 # ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $#
 # ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $# ! $#
 import tkinter
-from typing import TYPE_CHECKING, Any, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Mapping
 
 import requests
 
@@ -69,12 +69,12 @@ class This:
     def __init__(self) -> None:
         # Main window clicks
         self.system_link: tkinter.Widget
-        self.system: Optional[str] = None
-        self.system_address: Optional[str] = None
-        self.system_population: Optional[int] = None
+        self.system_name: str | None = None
+        self.system_address: str | None = None
+        self.system_population: int | None = None
         self.station_link: tkinter.Widget
-        self.station: Optional[str] = None
-        self.station_marketid: Optional[int] = None
+        self.station: str | None = None
+        self.station_marketid: int | None = None
         self.on_foot = False
 
 
@@ -133,7 +133,7 @@ def plugin_app(parent: 'Tk'):
     """
     # system label in main window
     this.system_link = parent.nametowidget(f".{appname.lower()}.system")
-    this.system = None
+    this.system_name = None
     this.system_address = None
     this.station = None
     this.station_marketid = None  # Frontier MarketID
@@ -185,12 +185,13 @@ def journal_entry(  # noqa: CCR001
 
     this.on_foot = state['OnFoot']
     this.system_address = state['SystemAddress']
+    this.system_name = state['SystemName']
 
     # Always update our system address even if we're not currently the provider for system or station, but dont update
     # on events that contain "future" data, such as FSDTarget
     if entry['event'] in ('Location', 'Docked', 'CarrierJump', 'FSDJump'):
         this.system_address = entry.get('SystemAddress') or this.system_address
-        this.system = entry.get('StarSystem') or this.system
+        this.system_name = entry.get('StarSystem') or this.system_name
 
     # We need pop == 0 to set the value so as to clear 'x' in systems with
     # no stations.
@@ -217,7 +218,7 @@ def journal_entry(  # noqa: CCR001
 
     # Only actually change URLs if we are current provider.
     if config.get_str('system_provider') == 'eddb':
-        this.system_link['text'] = this.system
+        this.system_link['text'] = this.system_name
         # Do *NOT* set 'url' here, as it's set to a function that will call
         # through correctly.  We don't want a static string.
         this.system_link.update_idletasks()
@@ -238,7 +239,7 @@ def journal_entry(  # noqa: CCR001
         this.station_link.update_idletasks()
 
 
-def cmdr_data(data: CAPIData, is_beta: bool) -> Optional[str]:
+def cmdr_data(data: CAPIData, is_beta: bool) -> str | None:
     """
     Process new CAPI data.
 
@@ -251,15 +252,15 @@ def cmdr_data(data: CAPIData, is_beta: bool) -> Optional[str]:
         this.station_marketid = data['lastStarport']['id']
 
     # Only trust CAPI if these aren't yet set
-    if not this.system:
-        this.system = data['lastSystem']['name']
+    if not this.system_name:
+        this.system_name = data['lastSystem']['name']
 
     if not this.station and data['commander']['docked']:
         this.station = data['lastStarport']['name']
 
     # Override standard URL functions
     if config.get_str('system_provider') == 'eddb':
-        this.system_link['text'] = this.system
+        this.system_link['text'] = this.system_name
         # Do *NOT* set 'url' here, as it's set to a function that will call
         # through correctly.  We don't want a static string.
         this.system_link.update_idletasks()

--- a/plugins/eddb.py
+++ b/plugins/eddb.py
@@ -187,12 +187,6 @@ def journal_entry(  # noqa: CCR001
     this.system_address = state['SystemAddress']
     this.system_name = state['SystemName']
 
-    # Always update our system address even if we're not currently the provider for system or station, but dont update
-    # on events that contain "future" data, such as FSDTarget
-    if entry['event'] in ('Location', 'Docked', 'CarrierJump', 'FSDJump'):
-        this.system_address = entry.get('SystemAddress') or this.system_address
-        this.system_name = entry.get('StarSystem') or this.system_name
-
     # We need pop == 0 to set the value so as to clear 'x' in systems with
     # no stations.
     pop = entry.get('Population')

--- a/plugins/eddb.py
+++ b/plugins/eddb.py
@@ -184,6 +184,8 @@ def journal_entry(  # noqa: CCR001
         return
 
     this.on_foot = state['OnFoot']
+    this.system_address = state['SystemAddress']
+
     # Always update our system address even if we're not currently the provider for system or station, but dont update
     # on events that contain "future" data, such as FSDTarget
     if entry['event'] in ('Location', 'Docked', 'CarrierJump', 'FSDJump'):

--- a/plugins/eddb.py
+++ b/plugins/eddb.py
@@ -188,16 +188,7 @@ def journal_entry(
     this.system_name = state['SystemName']
     this.system_population = state['SystemPopulation']
     this.station_name = state['StationName']
-
-    this.station_marketid = entry.get('MarketID') or this.station_marketid
-    # We might pick up StationName in DockingRequested, make sure we clear it if leaving
-    if entry['event'] in ('Undocked', 'FSDJump', 'SupercruiseEntry'):
-        this.station_marketid = None
-
-    if entry['event'] == 'Embark' and not entry.get('OnStation'):
-        # If we're embarking OnStation to a Taxi/Dropship we'll also get an
-        # Undocked event.
-        this.station_marketid = None
+    this.station_marketid = state['MarketID']
 
     # Only change URL text if we are current provider.
     if config.get_str('station_provider') == 'eddb':

--- a/plugins/eddb.py
+++ b/plugins/eddb.py
@@ -186,12 +186,7 @@ def journal_entry(  # noqa: CCR001
     this.on_foot = state['OnFoot']
     this.system_address = state['SystemAddress']
     this.system_name = state['SystemName']
-
-    # We need pop == 0 to set the value so as to clear 'x' in systems with
-    # no stations.
-    pop = entry.get('Population')
-    if pop is not None:
-        this.system_population = pop
+    this.system_population = state['SystemPopulation']
 
     this.station = entry.get('StationName') or this.station
     # on_foot station detection

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -2224,6 +2224,8 @@ def journal_entry(  # noqa: C901, CCR001
         if entry['MusicTrack'] == 'MainMenu':
             this.status_body_name = None
 
+    tracking_ui_update()
+
     # Events with their own EDDN schema
     if config.get_int('output') & config.OUT_EDDN_SEND_NON_STATION and not state['Captain']:
 
@@ -2408,8 +2410,6 @@ def journal_entry(  # noqa: C901, CCR001
         except Exception as e:
             logger.debug(f'Failed exporting {entry["event"]}', exc_info=e)
             return str(e)
-
-    tracking_ui_update()
 
     return None
 

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -2220,14 +2220,6 @@ def journal_entry(  # noqa: C901, CCR001
         # Trigger a send/retry of pending EDDN messages
         this.eddn.parent.after(this.eddn.REPLAY_DELAY, this.eddn.sender.queue_check_and_send, False)
 
-    elif event_name == 'leavebody':
-        # NB: **NOT** SupercruiseEntry, because we won't get a fresh
-        #     ApproachBody if we don't leave Orbital Cruise and land again.
-        # *This* is triggered when you go above Orbital Cruise altitude.
-        # Status.json BodyName clears when the OC/Glide HUD is deactivated.
-        this.body_name = None
-        this.body_id = None
-
     elif event_name == 'music':
         if entry['MusicTrack'] == 'MainMenu':
             this.body_name = None

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -87,6 +87,7 @@ class This:
         self.coordinates: Optional[Tuple] = None
         self.body_name: Optional[str] = None
         self.body_id: Optional[int] = None
+        self.body_type: Optional[int] = None
         self.station_name: str | None = None
         self.station_type: str | None = None
         self.station_marketid: str | None = None
@@ -125,6 +126,7 @@ class This:
         self.ui_system_address: tk.Label
         self.ui_j_body_name: tk.Label
         self.ui_j_body_id: tk.Label
+        self.ui_j_body_type: tk.Label
         self.ui_s_body_name: tk.Label
         self.ui_station_name: tk.Label
         self.ui_station_type: tk.Label
@@ -1978,13 +1980,13 @@ def plugin_app(parent: tk.Tk) -> Optional[tk.Frame]:
         # System
         #######################################################################
         # SystemName
-        system_name_label = tk.Label(this.ui, text="S:Name:")
+        system_name_label = tk.Label(this.ui, text="J:SystemName:")
         system_name_label.grid(row=row, column=0, sticky=tk.W)
         this.ui_system_name = tk.Label(this.ui, name='eddn_track_system_name', anchor=tk.W)
         this.ui_system_name.grid(row=row, column=1, sticky=tk.E)
         row += 1
         # SystemAddress
-        system_address_label = tk.Label(this.ui, text="S:Address:")
+        system_address_label = tk.Label(this.ui, text="J:SystemAddress:")
         system_address_label.grid(row=row, column=0, sticky=tk.W)
         this.ui_system_address = tk.Label(this.ui, name='eddn_track_system_address', anchor=tk.W)
         this.ui_system_address.grid(row=row, column=1, sticky=tk.E)
@@ -2005,6 +2007,12 @@ def plugin_app(parent: tk.Tk) -> Optional[tk.Frame]:
         journal_body_id_label.grid(row=row, column=0, sticky=tk.W)
         this.ui_j_body_id = tk.Label(this.ui, name='eddn_track_j_body_id', anchor=tk.W)
         this.ui_j_body_id.grid(row=row, column=1, sticky=tk.E)
+        row += 1
+        # Body Type from Journal
+        journal_body_type_label = tk.Label(this.ui, text="J:BodyType:")
+        journal_body_type_label.grid(row=row, column=0, sticky=tk.W)
+        this.ui_j_body_type = tk.Label(this.ui, name='eddn_track_j_body_type', anchor=tk.W)
+        this.ui_j_body_type.grid(row=row, column=1, sticky=tk.E)
         row += 1
         # Body Name from Status.json
         status_body_name_label = tk.Label(this.ui, text="S:BodyName:")
@@ -2062,6 +2070,10 @@ def tracking_ui_update() -> None:
     this.ui_j_body_id['text'] = '≪None≫'
     if this.body_id is not None:
         this.ui_j_body_id['text'] = str(this.body_id)
+
+    this.ui_j_body_type['text'] = '≪None≫'
+    if this.body_type is not None:
+        this.ui_j_body_type['text'] = str(this.body_type)
 
     this.ui_s_body_name['text'] = '≪None≫'
     if this.status_body_name is not None:
@@ -2288,6 +2300,7 @@ def journal_entry(  # noqa: C901, CCR001
     # outside of this function.
     this.body_name = state['Body']
     this.body_id = state['BodyID']
+    this.body_type = state['BodyType']
     this.coordinates = state['StarPos']
     this.system_address = state['SystemAddress']
     this.system_name = state['SystemName']

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -2217,16 +2217,6 @@ def journal_entry(  # noqa: C901, CCR001
     this.coordinates = state['StarPos']
     this.systemaddress = state['SystemAddress']
 
-    if event_name in ('location', 'fsdjump', 'docked', 'carrierjump'):
-        if 'StarPos' in entry:
-            this.coordinates = tuple(entry['StarPos'])
-
-        elif this.systemaddress != entry.get('SystemAddress'):
-            this.coordinates = None  # Docked event doesn't include coordinates
-
-        if 'SystemAddress' not in entry:
-            logger.warning(f'"location" event without SystemAddress !!!:\n{entry}\n')
-
     if event_name == 'docked':
         # Trigger a send/retry of pending EDDN messages
         this.eddn.parent.after(this.eddn.REPLAY_DELAY, this.eddn.sender.queue_check_and_send, False)

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -2222,8 +2222,6 @@ def journal_entry(  # noqa: C901, CCR001
 
     elif event_name == 'music':
         if entry['MusicTrack'] == 'MainMenu':
-            this.body_name = None
-            this.body_id = None
             this.status_body_name = None
 
     # Events with their own EDDN schema

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -2323,10 +2323,10 @@ def journal_entry(  # noqa: C901, CCR001
             ]
 
         # add planet to Docked event for planetary stations if known
-        if event_name == 'docked' and this.body_name:
-            # FIXME - Is this correct if using monitor.py tracking ?
-            entry['Body'] = this.body_name
-            entry['BodyType'] = 'Planet'
+        if event_name == 'docked' and state['Body'] is not None:
+            if state['BodyType'] == 'Planet':
+                entry['Body'] = state['Body']
+                entry['BodyType'] = state['BodyType']
 
         # The generic journal schema is for events:
         #   Docked, FSDJump, Scan, Location, SAASignalsFound, CarrierJump

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -2449,7 +2449,7 @@ def cmdr_data(data: CAPIData, is_beta: bool) -> Optional[str]:  # noqa: CCR001
     ):
         this.cmdr_name = cmdr_name
 
-    if (data['commander'].get('docked') or (this.on_foot and monitor.station)
+    if (data['commander'].get('docked') or (this.on_foot and monitor.state['StationName'])
             and config.get_int('output') & config.OUT_EDDN_SEND_STATION_DATA):
         try:
             if this.marketId != data['lastStarport']['id']:

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -1123,11 +1123,10 @@ class EDDN:
             entry['SystemAddress'] = this.systemaddress
 
         if 'StarPos' not in entry:
-            # Prefer the passed-in, probably monitor.state version
+            # Prefer the passed-in version
             if system_coordinates is not None:
                 entry['StarPos'] = system_coordinates
 
-            # TODO: Deprecate in-plugin tracking
             elif this.coordinates is not None:
                 entry['StarPos'] = list(this.coordinates)
 

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -82,10 +82,14 @@ class This:
         self.odyssey = False
 
         # Track location to add to Journal events
-        self.systemaddress: Optional[str] = None
+        self.system_address: Optional[str] = None
+        self.system_name: Optional[str] = None
         self.coordinates: Optional[Tuple] = None
         self.body_name: Optional[str] = None
         self.body_id: Optional[int] = None
+        self.station_name: str | None = None
+        self.station_type: str | None = None
+        self.station_marketid: str | None = None
         # Track Status.json data
         self.status_body_name: Optional[str] = None
 
@@ -117,9 +121,14 @@ class This:
 
         # Tracking UI
         self.ui: tk.Frame
+        self.ui_system_name: tk.Label
+        self.ui_system_address: tk.Label
         self.ui_j_body_name: tk.Label
         self.ui_j_body_id: tk.Label
         self.ui_s_body_name: tk.Label
+        self.ui_station_name: tk.Label
+        self.ui_station_type: tk.Label
+        self.ui_station_marketid: tk.Label
 
 
 this = This()
@@ -1116,11 +1125,11 @@ class EDDN:
                 entry['StarSystem'] = system_name
 
         if 'SystemAddress' not in entry:
-            if this.systemaddress is None:
+            if this.system_address is None:
                 logger.warning("this.systemaddress is None, can't add SystemAddress")
                 return "this.systemaddress is None, can't add SystemAddress"
 
-            entry['SystemAddress'] = this.systemaddress
+            entry['SystemAddress'] = this.system_address
 
         if 'StarPos' not in entry:
             # Prefer the passed-in version
@@ -1159,7 +1168,7 @@ class EDDN:
         #######################################################################
         # In this case should add StarPos, but only if the
         # SystemAddress of where we think we are matches.
-        if this.systemaddress is None or this.systemaddress != entry['SystemAddress']:
+        if this.system_address is None or this.system_address != entry['SystemAddress']:
             logger.warning("SystemAddress isn't current location! Can't add augmentations!")
             return 'Wrong System! Missed jump ?'
 
@@ -1201,7 +1210,7 @@ class EDDN:
         #######################################################################
         # In this case should add StarSystem and StarPos, but only if the
         # SystemAddress of where we think we are matches.
-        if this.systemaddress is None or this.systemaddress != entry['SystemAddress']:
+        if this.system_address is None or this.system_address != entry['SystemAddress']:
             logger.warning("SystemAddress isn't current location! Can't add augmentations!")
             return 'Wrong System! Missed jump ?'
 
@@ -1263,7 +1272,7 @@ class EDDN:
         #######################################################################
         # In this case should add StarPos, but only if the
         # SystemAddress of where we think we are matches.
-        if this.systemaddress is None or this.systemaddress != entry['SystemAddress']:
+        if this.system_address is None or this.system_address != entry['SystemAddress']:
             logger.warning("SystemAddress isn't current location! Can't add augmentations!")
             return 'Wrong System! Missed jump ?'
 
@@ -1357,7 +1366,7 @@ class EDDN:
         #######################################################################
         # In this case should add StarPos, but only if the
         # SystemAddress of where we think we are matches.
-        if this.systemaddress is None or this.systemaddress != entry['SystemAddress']:
+        if this.system_address is None or this.system_address != entry['SystemAddress']:
             logger.warning("SystemAddress isn't current location! Can't add augmentations!")
             return 'Wrong System! Missed jump ?'
 
@@ -1652,7 +1661,7 @@ class EDDN:
         #######################################################################
         # In this case should add SystemName and StarPos, but only if the
         # SystemAddress of where we think we are matches.
-        if this.systemaddress is None or this.systemaddress != entry['SystemAddress']:
+        if this.system_address is None or this.system_address != entry['SystemAddress']:
             logger.warning("SystemAddress isn't current location! Can't add augmentations!")
             return 'Wrong System! Missed jump ?'
 
@@ -1702,7 +1711,7 @@ class EDDN:
         #######################################################################
         # In this case should add StarPos, but only if the
         # SystemAddress of where we think we are matches.
-        if this.systemaddress is None or this.systemaddress != entry['SystemAddress']:
+        if this.system_address is None or this.system_address != entry['SystemAddress']:
             logger.warning("SystemAddress isn't current location! Can't add augmentations!")
             return 'Wrong System! Missed jump ?'
 
@@ -1758,7 +1767,7 @@ class EDDN:
         #######################################################################
         # In this case should add SystemName and StarPos, but only if the
         # SystemAddress of where we think we are matches.
-        if this.systemaddress is None or this.systemaddress != entry['SystemAddress']:
+        if this.system_address is None or this.system_address != entry['SystemAddress']:
             logger.warning("SystemAddress isn't current location! Can't add augmentations!")
             return 'Wrong System! Missed jump ?'
 
@@ -1816,11 +1825,11 @@ class EDDN:
 
         else:
             # Horizons order, so use tracked data for cross-check
-            if this.systemaddress is None or system_name is None or system_starpos is None:
-                logger.error(f'Location tracking failure: {this.systemaddress=}, {system_name=}, {system_starpos=}')
+            if this.system_address is None or system_name is None or system_starpos is None:
+                logger.error(f'Location tracking failure: {this.system_address=}, {system_name=}, {system_starpos=}')
                 return 'Current location not tracked properly, started after game?'
 
-            aug_systemaddress = this.systemaddress
+            aug_systemaddress = this.system_address
             aug_starsystem = system_name
             aug_starpos = system_starpos
 
@@ -1964,23 +1973,69 @@ def plugin_app(parent: tk.Tk) -> Optional[tk.Frame]:
         this.ui = tk.Frame(parent)
 
         row = this.ui.grid_size()[1]
+
+        #######################################################################
+        # System
+        #######################################################################
+        # SystemName
+        system_name_label = tk.Label(this.ui, text="S:Name:")
+        system_name_label.grid(row=row, column=0, sticky=tk.W)
+        this.ui_system_name = tk.Label(this.ui, name='eddn_track_system_name', anchor=tk.W)
+        this.ui_system_name.grid(row=row, column=1, sticky=tk.E)
+        row += 1
+        # SystemAddress
+        system_address_label = tk.Label(this.ui, text="S:Address:")
+        system_address_label.grid(row=row, column=0, sticky=tk.W)
+        this.ui_system_address = tk.Label(this.ui, name='eddn_track_system_address', anchor=tk.W)
+        this.ui_system_address.grid(row=row, column=1, sticky=tk.E)
+        row += 1
+        #######################################################################
+
+        #######################################################################
+        # Body
+        #######################################################################
+        # Body Name from Journal
         journal_body_name_label = tk.Label(this.ui, text="J:BodyName:")
         journal_body_name_label.grid(row=row, column=0, sticky=tk.W)
         this.ui_j_body_name = tk.Label(this.ui, name='eddn_track_j_body_name', anchor=tk.W)
         this.ui_j_body_name.grid(row=row, column=1, sticky=tk.E)
         row += 1
-
+        # Body ID from Journal
         journal_body_id_label = tk.Label(this.ui, text="J:BodyID:")
         journal_body_id_label.grid(row=row, column=0, sticky=tk.W)
         this.ui_j_body_id = tk.Label(this.ui, name='eddn_track_j_body_id', anchor=tk.W)
         this.ui_j_body_id.grid(row=row, column=1, sticky=tk.E)
         row += 1
-
+        # Body Name from Status.json
         status_body_name_label = tk.Label(this.ui, text="S:BodyName:")
         status_body_name_label.grid(row=row, column=0, sticky=tk.W)
         this.ui_s_body_name = tk.Label(this.ui, name='eddn_track_s_body_name', anchor=tk.W)
         this.ui_s_body_name.grid(row=row, column=1, sticky=tk.E)
         row += 1
+        #######################################################################
+
+        #######################################################################
+        # Station
+        #######################################################################
+        # Name
+        status_station_name_label = tk.Label(this.ui, text="J:StationName:")
+        status_station_name_label.grid(row=row, column=0, sticky=tk.W)
+        this.ui_station_name = tk.Label(this.ui, name='eddn_track_station_name', anchor=tk.W)
+        this.ui_station_name.grid(row=row, column=1, sticky=tk.E)
+        row += 1
+        # Type
+        status_station_type_label = tk.Label(this.ui, text="J:StationType:")
+        status_station_type_label.grid(row=row, column=0, sticky=tk.W)
+        this.ui_station_type = tk.Label(this.ui, name='eddn_track_station_type', anchor=tk.W)
+        this.ui_station_type.grid(row=row, column=1, sticky=tk.E)
+        row += 1
+        # MarketID
+        status_station_marketid_label = tk.Label(this.ui, text="J:StationID:")
+        status_station_marketid_label.grid(row=row, column=0, sticky=tk.W)
+        this.ui_station_marketid = tk.Label(this.ui, name='eddn_track_station_id', anchor=tk.W)
+        this.ui_station_marketid.grid(row=row, column=1, sticky=tk.E)
+        row += 1
+        #######################################################################
 
         return this.ui
 
@@ -1991,6 +2046,14 @@ def tracking_ui_update() -> None:
     """Update the Tracking UI with current data, if required."""
     if not config.eddn_tracking_ui:
         return
+
+    this.ui_system_name['text'] = '≪None≫'
+    if this.ui_system_name is not None:
+        this.ui_system_name['text'] = this.system_name
+
+    this.ui_system_address['text'] = '≪None≫'
+    if this.ui_system_address is not None:
+        this.ui_system_address['text'] = this.system_address
 
     this.ui_j_body_name['text'] = '≪None≫'
     if this.body_name is not None:
@@ -2003,6 +2066,18 @@ def tracking_ui_update() -> None:
     this.ui_s_body_name['text'] = '≪None≫'
     if this.status_body_name is not None:
         this.ui_s_body_name['text'] = this.status_body_name
+
+    this.ui_station_name['text'] = '≪None≫'
+    if this.station_name is not None:
+        this.ui_station_name['text'] = this.station_name
+
+    this.ui_station_type['text'] = '≪None≫'
+    if this.station_type is not None:
+        this.ui_station_type['text'] = this.station_type
+
+    this.ui_station_marketid['text'] = '≪None≫'
+    if this.station_marketid is not None:
+        this.ui_station_marketid['text'] = this.station_marketid
 
     this.ui.update_idletasks()
 
@@ -2214,7 +2289,11 @@ def journal_entry(  # noqa: C901, CCR001
     this.body_name = state['Body']
     this.body_id = state['BodyID']
     this.coordinates = state['StarPos']
-    this.systemaddress = state['SystemAddress']
+    this.system_address = state['SystemAddress']
+    this.system_name = state['SystemName']
+    this.station_name = state['StationName']
+    this.station_type = state['StationType']
+    this.station_marketid = state['MarketID']
 
     if event_name == 'docked':
         # Trigger a send/retry of pending EDDN messages
@@ -2339,7 +2418,7 @@ def journal_entry(  # noqa: C901, CCR001
 
         # add mandatory StarSystem and StarPos properties to events
         if 'StarSystem' not in entry:
-            if this.systemaddress is None or this.systemaddress != entry['SystemAddress']:
+            if this.system_address is None or this.system_address != entry['SystemAddress']:
                 logger.warning(f"event({entry['event']}) has no StarSystem, but SystemAddress isn't current location")
                 return "Wrong System! Delayed Scan event?"
 
@@ -2356,7 +2435,7 @@ def journal_entry(  # noqa: C901, CCR001
 
             # Gazelle[TD] reported seeing a lagged Scan event with incorrect
             # augmented StarPos: <https://github.com/EDCD/EDMarketConnector/issues/961>
-            if this.systemaddress is None or this.systemaddress != entry['SystemAddress']:
+            if this.system_address is None or this.system_address != entry['SystemAddress']:
                 logger.warning(f"event({entry['event']}) has no StarPos, but SystemAddress isn't current location")
                 return "Wrong System! Delayed Scan event?"
 

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -2208,6 +2208,14 @@ def journal_entry(  # noqa: C901, CCR001
             entry
         )
 
+    # TODO - uncomment this, i.e. use monitor.py tracking, not also here
+    # Copy some state into module-held variables because we might need it
+    # outside of this function.
+    # this.body_name = state['Body']
+    # this.body_id = state['BodyID']
+    # this.coordinates = state['StarPos']
+    # this.systemaddress = state['SystemAddress']
+
     # Track location
     if event_name == 'supercruiseexit':
         # For any orbital station we have no way of determining the body
@@ -2360,6 +2368,7 @@ def journal_entry(  # noqa: C901, CCR001
 
         # add planet to Docked event for planetary stations if known
         if event_name == 'docked' and this.body_name:
+            # FIXME - Is this correct if using monitor.py tracking ?
             entry['Body'] = this.body_name
             entry['BodyType'] = 'Planet'
 

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -119,7 +119,7 @@ class This:
 
         # Main window clicks
         self.system_link: tk.Widget = None  # type: ignore
-        self.system: Optional[str] = None  # type: ignore
+        self.system_name: Optional[str] = None  # type: ignore
         self.system_address: Optional[str] = None  # type: ignore
         self.system_population: Optional[int] = None
         self.station_link: tk.Widget = None  # type: ignore
@@ -169,10 +169,12 @@ if DEBUG:
 def system_url(system_name: str) -> str:
     """Get a URL for the current system."""
     if this.system_address:
-        return requests.utils.requote_uri(f'https://inara.cz/galaxy-starsystem/?search={this.system_address}')
+        return requests.utils.requote_uri(f'https://inara.cz/galaxy-starsystem/'
+                                          f'?search={this.system_address}')
 
     elif system_name:
-        return requests.utils.requote_uri(f'https://inara.cz/galaxy-starsystem/?search={system_name}')
+        return requests.utils.requote_uri(f'https://inara.cz/galaxy-starsystem/'
+                                          f'?search={system_name}')
 
     return ''
 
@@ -188,11 +190,13 @@ def station_url(system_name: str, station_name: str) -> str:
     :return: A URL to inara for the given system and station
     """
     if system_name and station_name:
-        return requests.utils.requote_uri(f'https://inara.cz/galaxy-station/?search={system_name}%20[{station_name}]')
+        return requests.utils.requote_uri(f'https://inara.cz/galaxy-station/'
+                                          f'?search={system_name}%20[{station_name}]')
 
     # monitor state might think these are gone, but we don't yet
-    if this.system and this.station:
-        return requests.utils.requote_uri(f'https://inara.cz/galaxy-station/?search={this.system}%20[{this.station}]')
+    if this.system_name and this.station:
+        return requests.utils.requote_uri(f'https://inara.cz/galaxy-station/'
+                                          f'?search={this.system_name}%20[{this.station}]')
 
     if system_name:
         return system_url(system_name)
@@ -371,6 +375,31 @@ def journal_entry(  # noqa: C901, CCR001
 
     :return: str - empty if no error, else error string.
     """
+    # This overall killswitch check is first in case, e.g. an EDMC bug is
+    # causing users to spam Inara with 'URL provider' queries, and we want to
+    # stop that.
+    should_return: bool
+    new_entry: Dict[str, Any] = {}
+
+    should_return, new_entry = killswitch.check_killswitch('plugins.inara.journal', entry, logger)
+    if should_return:
+        plug.show_error(_('Inara disabled. See Log.'))  # LANG: INARA support disabled via killswitch
+        logger.trace('returning due to killswitch match')
+        return ''
+
+    # But then we update all the tracking copies before any other checks,
+    # because they're relevant for URL providing even if *sending* isn't
+    # appropriate.
+    this.on_foot = state['OnFoot']
+    event_name: str = entry['event']
+    this.cmdr = cmdr
+    this.FID = state['FID']
+    this.multicrew = bool(state['Role'])
+    this.system_name = state['SystemName']
+    this.system_address = state['SystemAddress']
+    this.station = state['StationName']
+    this.station_marketid = state['MarketID']
+
     if not monitor.is_live_galaxy():
         # Since Update 14 on 2022-11-29 Inara only accepts Live data.
         if (
@@ -387,15 +416,6 @@ def journal_entry(  # noqa: C901, CCR001
 
         return ''
 
-    should_return: bool
-    new_entry: Dict[str, Any] = {}
-
-    should_return, new_entry = killswitch.check_killswitch('plugins.inara.journal', entry, logger)
-    if should_return:
-        plug.show_error(_('Inara disabled. See Log.'))  # LANG: INARA support disabled via killswitch
-        logger.trace('returning due to killswitch match')
-        return ''
-
     should_return, new_entry = killswitch.check_killswitch(
         f'plugins.inara.journal.event.{entry["event"]}', new_entry, logger
     )
@@ -405,12 +425,6 @@ def journal_entry(  # noqa: C901, CCR001
         return ''
 
     entry = new_entry
-    this.on_foot = state['OnFoot']
-    event_name: str = entry['event']
-    this.cmdr = cmdr
-    this.FID = state['FID']
-    this.multicrew = bool(state['Role'])
-
     if event_name == 'LoadGame' or this.newuser:
         # clear cached state
         if event_name == 'LoadGame':
@@ -431,10 +445,6 @@ def journal_entry(  # noqa: C901, CCR001
         this.loadout = None
         this.fleet = None
         this.shipswap = False
-        this.system = None
-        this.system_address = None
-        this.station = None
-        this.station_marketid = None
 
     elif event_name in ('Resurrect', 'ShipyardBuy', 'ShipyardSell', 'SellShipOnRebuy'):
         # Events that mean a significant change in credits, so we should send credits after next "Update"
@@ -442,35 +452,6 @@ def journal_entry(  # noqa: C901, CCR001
 
     elif event_name in ('ShipyardNew', 'ShipyardSwap') or (event_name == 'Location' and entry['Docked']):
         this.suppress_docked = True
-
-    # Always update our system address even if we're not currently the provider for system or station, but dont update
-    # on events that contain "future" data, such as FSDTarget
-    if entry['event'] in ('Location', 'Docked', 'CarrierJump', 'FSDJump'):
-        this.system_address = entry.get('SystemAddress') or this.system_address
-        this.system = entry.get('StarSystem') or this.system
-
-    # We need pop == 0 to set the value so as to clear 'x' in systems with
-    # no stations.
-    pop: Optional[int] = entry.get('Population')
-    if pop is not None:
-        this.system_population = pop
-
-    this.station = entry.get('StationName', this.station)
-    # on_foot station detection
-    if entry['event'] == 'Location' and entry['BodyType'] == 'Station':
-        this.station = entry['Body']
-
-    this.station_marketid = entry.get('MarketID', this.station_marketid) or this.station_marketid
-    # We might pick up StationName in DockingRequested, make sure we clear it if leaving
-    if event_name in ('Undocked', 'FSDJump', 'SupercruiseEntry'):
-        this.station = None
-        this.station_marketid = None
-
-    if entry['event'] == 'Embark' and not entry.get('OnStation'):
-        # If we're embarking OnStation to a Taxi/Dropship we'll also get an
-        # Undocked event.
-        this.station = None
-        this.station_marketid = None
 
     if config.get_int('inara_out') and not is_beta and not this.multicrew and credentials(cmdr):
         current_credentials = Credentials(this.cmdr, this.FID, str(credentials(this.cmdr)))
@@ -1158,7 +1139,7 @@ def journal_entry(  # noqa: C901, CCR001
 
             to_send_data: Optional[Dict[str, Any]] = {}  # This is a glorified sentinel until lower down.
             # On Horizons, neither of these exist on TouchDown
-            star_system_name = entry.get('StarSystem', this.system)
+            star_system_name = entry.get('StarSystem', this.system_name)
             body_name = entry.get('Body', state['Body'] if state['BodyType'] == 'Planet' else None)
 
             if star_system_name is None:
@@ -1377,7 +1358,7 @@ def journal_entry(  # noqa: C901, CCR001
 
     # Only actually change URLs if we are current provider.
     if config.get_str('system_provider') == 'Inara':
-        this.system_link['text'] = this.system
+        this.system_link['text'] = this.system_name
         # Do *NOT* set 'url' here, as it's set to a function that will call
         # through correctly.  We don't want a static string.
         this.system_link.update_idletasks()
@@ -1407,14 +1388,14 @@ def cmdr_data(data: CAPIData, is_beta):  # noqa: CCR001
         this.station_marketid = data['commander']['docked'] and data['lastStarport']['id']
 
     # Only trust CAPI if these aren't yet set
-    this.system = this.system if this.system else data['lastSystem']['name']
+    this.system_name = this.system_name if this.system_name else data['lastSystem']['name']
 
     if not this.station and data['commander']['docked']:
         this.station = data['lastStarport']['name']
 
     # Override standard URL functions
     if config.get_str('system_provider') == 'Inara':
-        this.system_link['text'] = this.system
+        this.system_link['text'] = this.system_name
         # Do *NOT* set 'url' here, as it's set to a function that will call
         # through correctly.  We don't want a static string.
         this.system_link.update_idletasks()


### PR DESCRIPTION
As well as being duplicate code in the core plugins, there's also a bug related to plugins not receiving events during Journal catch up.  This means that current release plugins/eddn.py code doesn't properly know where it is if you relog on a body surface, meaning the CodexEntry handling then doesn't have the data for cross-checks.

Fix this by extending monitor.state tracking to include the necessary data, and relying on that in the EDDN plugin.

NB: Still need to check the *other* core plugins to update their tracking to reflect they can just rely on `journal_entry()`'s `state` now.

Closes #1042 