### PR TITLE
Create a custom .zip archive for releases

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -71,7 +71,7 @@ jobs:
   release:
     name: Release new version
     runs-on: ubuntu-latest
-    needs: test
+    needs: windows_build
     if: "${{ github.event_name != 'workflow_dispatch' }}"
 
     steps:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -7,13 +7,6 @@ on:
       - "Release/*"
   workflow_dispatch:
 
-env:
-  # If this value gets too long it can cause issues with Windows
-  # command-line length and zip/tar will fail
-  # And all the exclusions need to be prefixed with the 'root'
-  # directory.
-  ARCHIVE_EXCLUSIONS: 'EDMarketConnector/EDMarketConnector-release-*.* EDMarketConnector/dist.win32 EDMarketConnector/__pycache__/ EDMarketConnector/.editorconfig EDMarketConnector/.flake8 EDMarketConnector/.git* EDMarketConnector/.mypy.ini EDMarketConnector/.pre-commit-config.yaml EDMarketConnector/Build-exe-and-msi.py EDMarketConnector/*.manifest EDMarketConnector/coriolis-data/ EDMarketConnector/img/ EDMarketConnector/out/ EDMarketConnector/out.zip EDMarketConnector/pyproject.toml EDMarketConnector/scripts/ EDMarketConnector/tests/ EDMarketConnector/wix/ EDMarketConnector/WinSparkle.*'
-
 jobs:
   variables:
     outputs:
@@ -79,7 +72,7 @@ jobs:
           #   directory.
           # NB: If this gets too long it can cause zip 'Command Line Error',
           #   presumably due to a Windows CL length limit.
-          exclusions: ${{ env.ARCHIVE_EXCLUSIONS }}
+          exclusions: 'EDMarketConnector/EDMarketConnector-release-*.* EDMarketConnector/dist.win32 EDMarketConnector/__pycache__/ EDMarketConnector/.editorconfig EDMarketConnector/.flake8 EDMarketConnector/.git* EDMarketConnector/.mypy.ini EDMarketConnector/.pre-commit-config.yaml EDMarketConnector/Build-exe-and-msi.py EDMarketConnector/*.manifest EDMarketConnector/coriolis-data/ EDMarketConnector/img/ EDMarketConnector/out/ EDMarketConnector/out.zip EDMarketConnector/pyproject.toml EDMarketConnector/scripts/ EDMarketConnector/tests/ EDMarketConnector/wix/ EDMarketConnector/WinSparkle.*'
 
       - name: Make tar archive
         uses: thedoctor0/zip-release@main
@@ -88,7 +81,8 @@ jobs:
           type: 'tar'
           path: 'EDMarketConnector'
           filename: 'EDMarketConnector/EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.tar.gz'
-          exclusions: ${{ env.ARCHIVE_EXCLUSIONS }}
+          # For 'tar' we can only specify filenames, not any directory location
+          exclusions: 'EDMarketConnector-release-*.* dist.win32 __pycache__ .editorconfig .flake8 .git* .mypy.ini .pre-commit-config.yaml Build-exe-and-msi.py *.manifest coriolis-data img out out.zip pyproject.toml scripts tests wix WinSparkle.*'
 
       - name: Upload build files
         uses: actions/upload-artifact@v3

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,3 +1,4 @@
+# vim: tabstop=2 shiftwidth=2
 name: Build EDMC for Windows
 
 on:
@@ -5,6 +6,13 @@ on:
     tags:
       - "Release/*"
   workflow_dispatch:
+
+env:
+  # If this value gets too long it can cause issues with Windows
+  # command-line length and zip/tar will fail
+  # And all the exclusions need to be prefixed with the 'root'
+  # directory.
+  ARCHIVE_EXCLUSIONS: 'EDMarketConnector/EDMarketConnector-release-*.* EDMarketConnector/dist.win32 EDMarketConnector/__pycache__/ EDMarketConnector/.editorconfig EDMarketConnector/.flake8 EDMarketConnector/.git* EDMarketConnector/.mypy.ini EDMarketConnector/.pre-commit-config.yaml EDMarketConnector/Build-exe-and-msi.py EDMarketConnector/*.manifest EDMarketConnector/coriolis-data/ EDMarketConnector/img/ EDMarketConnector/out/ EDMarketConnector/out.zip EDMarketConnector/pyproject.toml EDMarketConnector/scripts/ EDMarketConnector/tests/ EDMarketConnector/wix/ EDMarketConnector/WinSparkle.*'
 
 jobs:
   variables:
@@ -19,11 +27,6 @@ jobs:
         with:
           script: |
             core.setOutput('sem_ver', '${{ github.ref_name }}'.replaceAll('Release\/', ''))
-            # If this value gets too long it can cause issues with Windows
-            # command-line length and zip/tar will fail
-            # And all the exclusions need to be prefixed with the 'root'
-            # directory.
-            core.setOutput('archive_exclusions', 'EDMarketConnector/EDMarketConnector-release-*.* EDMarketConnector/dist.win32 EDMarketConnector/__pycache__/ EDMarketConnector/.editorconfig EDMarketConnector/.flake8 EDMarketConnector/.git* EDMarketConnector/.mypy.ini EDMarketConnector/.pre-commit-config.yaml EDMarketConnector/Build-exe-and-msi.py EDMarketConnector/*.manifest EDMarketConnector/coriolis-data/ EDMarketConnector/img/ EDMarketConnector/out/ EDMarketConnector/out.zip EDMarketConnector/pyproject.toml EDMarketConnector/scripts/ EDMarketConnector/tests/ EDMarketConnector/wix/ EDMarketConnector/WinSparkle.*')
 
   windows_build:
     needs: [variables]
@@ -76,7 +79,7 @@ jobs:
           #   directory.
           # NB: If this gets too long it can cause zip 'Command Line Error',
           #   presumably due to a Windows CL length limit.
-          exclusions: ${{ needs.variables.outputs.archive_exclusions }}
+          exclusions: ${{ env.ARCHIVE_EXCLUSIONS }}
 
       - name: Make tar archive
         uses: thedoctor0/zip-release@main
@@ -85,7 +88,7 @@ jobs:
           type: 'tar'
           path: 'EDMarketConnector'
           filename: 'EDMarketConnector/EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.tar.gz'
-          exclusions: ${{ needs.variables.outputs.archive_exclusions }}
+          exclusions: ${{ env.ARCHIVE_EXCLUSIONS }}
 
       - name: Upload build files
         uses: actions/upload-artifact@v3

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -57,8 +57,10 @@ jobs:
         uses: thedoctor0/zip-release@main
         with:
           type: 'zip'
+          directory: '..'
+          path: 'EDMarketConnector'
           filename: 'EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.zip'
-          exclusions: 'EDMarketConnector-release-*.zip .editorconfig .flake8 .git* .mypy.ini .pre-commit-config.yaml Build-exe-and-msi.py *.manifest coriolis-data/* img/* pyproject.toml scripts/* tests/* wix/*'
+          exclusions: 'dist.win32/* dist.win32 __pycache__/* __pycache__ .editorconfig .flake8 .git* .mypy.ini .pre-commit-config.yaml Build-exe-and-msi.py *.manifest coriolis-data/* coriolis-data/.??* coriolis-data img/* img out/* out out.zip pyproject.toml scripts/* scripts tests/* tests wix/* wix WinSparkle.*'
 
       - name: Upload build files
         uses: actions/upload-artifact@v3
@@ -66,7 +68,7 @@ jobs:
           name: Built files
           path: |
               EDMarketConnector_win*.msi
-              EDMarketConnector-release-*.zip
+              ../EDMarketConnector-release-*.zip
 
   release:
     name: Release new version

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -35,7 +35,7 @@ jobs:
           # For 'tar' we can only specify filename/glob exclusions, not any
           # directory location
           tar -c -v -z \
-              -f EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.tar.gz \
+              -f ../EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.tar.gz \
               -C .. \
               --exclude=EDMarketConnector-release-*.* \
               --exclude=.editorconfig \
@@ -52,6 +52,7 @@ jobs:
               --exclude=tests \
               --exclude=wix \
               EDMarketConnector
+            mv ../EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.tar.gz .
 
       - name: Upload build files
         uses: actions/upload-artifact@v3
@@ -124,7 +125,7 @@ jobs:
   release:
     name: Release new version
     runs-on: ubuntu-latest
-    needs: windows_build
+    needs: [ windows_build, linux_build ]
     if: "${{ github.event_name != 'workflow_dispatch' }}"
 
     steps:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -10,6 +10,7 @@ jobs:
   variables:
     outputs:
       sem_ver: ${{ steps.var.outputs.sem_ver }}
+      archive_exclusions: ${{ steps.var.outputs.archive_exclusions }}
     runs-on: "ubuntu-latest"
     steps:
       - name: Setting global variables
@@ -18,6 +19,11 @@ jobs:
         with:
           script: |
             core.setOutput('sem_ver', '${{ github.ref_name }}'.replaceAll('Release\/', ''))
+            # If this value gets too long it can cause issues with Windows
+            # command-line length and zip/tar will fail
+            # And all the exclusions need to be prefixed with the 'root'
+            # directory.
+            core.setOutput('archive_exclusions', 'EDMarketConnector/EDMarketConnector-release-*.* EDMarketConnector/dist.win32 EDMarketConnector/__pycache__/ EDMarketConnector/.editorconfig EDMarketConnector/.flake8 EDMarketConnector/.git* EDMarketConnector/.mypy.ini EDMarketConnector/.pre-commit-config.yaml EDMarketConnector/Build-exe-and-msi.py EDMarketConnector/*.manifest EDMarketConnector/coriolis-data/ EDMarketConnector/img/ EDMarketConnector/out/ EDMarketConnector/out.zip EDMarketConnector/pyproject.toml EDMarketConnector/scripts/ EDMarketConnector/tests/ EDMarketConnector/wix/ EDMarketConnector/WinSparkle.*')
 
   windows_build:
     needs: [variables]
@@ -70,15 +76,25 @@ jobs:
           #   directory.
           # NB: If this gets too long it can cause zip 'Command Line Error',
           #   presumably due to a Windows CL length limit.
-          exclusions: 'EDMarketConnector/EDMarketConnector-release-*.zip EDMarketConnector/dist.win32 EDMarketConnector/__pycache__/ EDMarketConnector/.editorconfig EDMarketConnector/.flake8 EDMarketConnector/.git* EDMarketConnector/.mypy.ini EDMarketConnector/.pre-commit-config.yaml EDMarketConnector/Build-exe-and-msi.py EDMarketConnector/*.manifest EDMarketConnector/coriolis-data/ EDMarketConnector/img/ EDMarketConnector/out/ EDMarketConnector/out.zip EDMarketConnector/pyproject.toml EDMarketConnector/scripts/ EDMarketConnector/tests/ EDMarketConnector/wix/ EDMarketConnector/WinSparkle.*'
+          exclusions: ${{ needs.variables.outputs.archive_exclusions }}
+
+      - name: Make tar archive
+        uses: thedoctor0/zip-release@main
+        with:
+          # See the 'zip' version above for commentary on these values
+          type: 'tar'
+          path: 'EDMarketConnector'
+          filename: 'EDMarketConnector/EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.tar.gz'
+          exclusions: ${{ needs.variables.outputs.archive_exclusions }}
 
       - name: Upload build files
         uses: actions/upload-artifact@v3
         with:
           name: Built files
           path: |
-              EDMarketConnector_win*.msi
+              EDMarketConnector_win_*.msi
               EDMarketConnector-release-*.zip
+              EDMarketConnector-release-*.tar.gz
 
   release:
     name: Release new version
@@ -94,7 +110,7 @@ jobs:
           path: ./
           
       - name: Hash files
-        run: sha256sum EDMarketConnector_win*.msi EDMarketConnector-release*.zip > ./hashes.sum
+        run: sha256sum EDMarketConnector_win_*.msi EDMarketConnector-release-*.{zip,tar.gz} > ./hashes.sum
 
       - name: Create Draft Release
         uses: "softprops/action-gh-release@v1"
@@ -104,6 +120,7 @@ jobs:
           prerelease: true
           discussion_category_name: "Announcement"
           files: |
-            ./EDMarketConnector_win*.msi
+            ./EDMarketConnector_win_*.msi
             ./EDMarketConnector-release-*.zip
+            ./EDMarketConnector-release-*.tar.gz
             ./hashes.sum

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -68,7 +68,7 @@ jobs:
           filename: 'EDMarketConnector/EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.zip'
           # 4. And all the exclusions need to be prefixed with the 'root'
           #   directory.
-          exclusions: 'EDMarketConnector/EDMarketConnector-release-*.zip EDMarketConnector/dist.win32/* EDMarketConnector/dist.win32 EDMarketConnector/__pycache__/* EDMarketConnector/__pycache__ EDMarketConnector/.editorconfig EDMarketConnector/.flake8 EDMarketConnector/.git* EDMarketConnector/.mypy.ini EDMarketConnector/.pre-commit-config.yaml EDMarketConnector/Build-exe-and-msi.py EDMarketConnector/*.manifest EDMarketConnector/coriolis-data/* EDMarketConnector/coriolis-data/.??* EDMarketConnector/coriolis-data EDMarketConnector/img/* EDMarketConnector/img EDMarketConnector/out/* EDMarketConnector/out EDMarketConnector/out.zip EDMarketConnector/pyproject.toml EDMarketConnector/scripts/* EDMarketConnector/scripts EDMarketConnector/tests/* EDMarketConnector/tests EDMarketConnector/wix/* EDMarketConnector/wix EDMarketConnector/WinSparkle.*'
+          exclusions: 'EDMarketConnector/EDMarketConnector-release-*.zip EDMarketConnector/dist.win32 EDMarketConnector/__pycache__/ EDMarketConnector/.editorconfig EDMarketConnector/.flake8 EDMarketConnector/.git* EDMarketConnector/.mypy.ini EDMarketConnector/.pre-commit-config.yaml EDMarketConnector/Build-exe-and-msi.py EDMarketConnector/*.manifest EDMarketConnector/coriolis-data/ EDMarketConnector/img/ EDMarketConnector/out/ EDMarketConnector/out.zip EDMarketConnector/pyproject.toml EDMarketConnector/scripts/ EDMarketConnector/tests/ EDMarketConnector/wix/ EDMarketConnector/WinSparkle.*'
 
       - name: Upload build files
         uses: actions/upload-artifact@v3

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -26,27 +26,26 @@ jobs:
           submodules: true
 
       - name: Make tar archive
-        with:
-          script: |
-            # For 'tar' we can only specify filename/glob exclusions, not any
-            # directory location
-            tar -C .. -c -v -z \
-                -f EDMarketConnector/EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.tar.gz \
-                --exclude=EDMarketConnector-release-*.* \
-                --exclude=.editorconfig \
-                --exclude=.flake8 \
-                --exclude=.git* \
-                --exclude=.mypy.ini \
-                --exclude=.pre-commit-config.yaml \
-                --exclude=Build-exe-and-msi.py \
-                --exclude=*.manifest \
-                --exclude=coriolis-data \
-                --exclude=img \
-                --exclude=pyproject.toml \
-                --exclude=scripts \
-                --exclude=tests \
-                --exclude=wix \
-                EDMarketConnector
+        run: |
+          # For 'tar' we can only specify filename/glob exclusions, not any
+          # directory location
+          tar -C .. -c -v -z \
+              -f EDMarketConnector/EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.tar.gz \
+              --exclude=EDMarketConnector-release-*.* \
+              --exclude=.editorconfig \
+              --exclude=.flake8 \
+              --exclude=.git* \
+              --exclude=.mypy.ini \
+              --exclude=.pre-commit-config.yaml \
+              --exclude=Build-exe-and-msi.py \
+              --exclude=*.manifest \
+              --exclude=coriolis-data \
+              --exclude=img \
+              --exclude=pyproject.toml \
+              --exclude=scripts \
+              --exclude=tests \
+              --exclude=wix \
+              EDMarketConnector
 
       - name: Upload build files
         uses: actions/upload-artifact@v3

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -59,7 +59,7 @@ jobs:
           type: 'zip'
           directory: '..'
           path: 'EDMarketConnector'
-          filename: 'EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.zip'
+          filename: 'EDMarketConnector/EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.zip'
           exclusions: 'EDMarketConnector-release-*.zip dist.win32/* dist.win32 __pycache__/* __pycache__ .editorconfig .flake8 .git* .mypy.ini .pre-commit-config.yaml Build-exe-and-msi.py *.manifest coriolis-data/* coriolis-data/.??* coriolis-data img/* img out/* out out.zip pyproject.toml scripts/* scripts tests/* tests wix/* wix WinSparkle.*'
 
       - name: Upload build files

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -22,6 +22,8 @@ jobs:
             core.setOutput('sem_ver', '${{ github.ref_name }}'.replaceAll('Release\/', ''))
 
   linux_build:
+    needs: [variables]
+    name: Linux environment build steps
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -21,16 +21,6 @@ jobs:
           script: |
             core.setOutput('sem_ver', '${{ github.ref_name }}'.replaceAll('Release\/', ''))
 
-  windows_build:
-    needs: [variables]
-    name: Build EDMC
-    runs-on: windows-2019
-
-    defaults:
-      run:
-        shell: powershell
-
-    steps:
       - uses: actions/checkout@v3
         with:
           submodules: true
@@ -44,8 +34,29 @@ jobs:
           path: 'EDMarketConnector'
           filename: 'EDMarketConnector/EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.tar.gz'
           # For 'tar' we can only specify filenames, not any directory location
-          # exclusions: 'EDMarketConnector-release-*.* .editorconfig .flake8 .git* .mypy.ini .pre-commit-config.yaml Build-exe-and-msi.py *.manifest coriolis-data img pyproject.toml scripts tests wix'
-          exclusions: 'EDMarketConnector/EDMarketConnector-release-*.* EDMarketConnector/.editorconfig EDMarketConnector/.flake8 EDMarketConnector/.git* EDMarketConnector/.mypy.ini EDMarketConnector/.pre-commit-config.yaml EDMarketConnector/Build-exe-and-msi.py EDMarketConnector/*.manifest EDMarketConnector/coriolis-data/ EDMarketConnector/img/ EDMarketConnector/pyproject.toml EDMarketConnector/scripts/ EDMarketConnector/tests/ EDMarketConnector/wix/'
+          exclusions: 'EDMarketConnector-release-*.* .editorconfig .flake8 .git* .mypy.ini .pre-commit-config.yaml Build-exe-and-msi.py *.manifest coriolis-data img pyproject.toml scripts tests wix'
+          # exclusions: 'EDMarketConnector/EDMarketConnector-release-*.* EDMarketConnector/.editorconfig EDMarketConnector/.flake8 EDMarketConnector/.git* EDMarketConnector/.mypy.ini EDMarketConnector/.pre-commit-config.yaml EDMarketConnector/Build-exe-and-msi.py EDMarketConnector/*.manifest EDMarketConnector/coriolis-data/ EDMarketConnector/img/ EDMarketConnector/pyproject.toml EDMarketConnector/scripts/ EDMarketConnector/tests/ EDMarketConnector/wix/'
+
+      - name: Upload build files
+        uses: actions/upload-artifact@v3
+        with:
+          name: Built files
+          path: |
+              EDMarketConnector-release-*.tar.gz
+
+  windows_build:
+    needs: [variables]
+    name: Build EDMC
+    runs-on: windows-2019
+
+    defaults:
+      run:
+        shell: powershell
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Make zip archive
         uses: thedoctor0/zip-release@main
@@ -93,7 +104,6 @@ jobs:
           path: |
               EDMarketConnector_win_*.msi
               EDMarketConnector-release-*.zip
-              EDMarketConnector-release-*.tar.gz
 
   release:
     name: Release new version

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -7,7 +7,20 @@ on:
   workflow_dispatch:
 
 jobs:
+  variables:
+    outputs:
+      sem_ver: ${{ steps.var.outputs.sem_ver }}
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Setting global variables
+        uses: actions/github-script@v6
+        id: var
+        with:
+          script: |
+            core.setOutput('sem_ver', '${{ github.ref_name }}'.replaceAll('Release\/', ''))
+
   windows_build:
+    needs: [variables]
     name: Build EDMC
     runs-on: windows-2019
 
@@ -40,11 +53,20 @@ jobs:
         run: |
           python Build-exe-and-msi.py
 
+      - name: Make zip archive
+        uses: thedoctor0/zip-release@main
+        with:
+          type: 'zip'
+          filename: 'EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.zip'
+          exclusions: 'EDMarketConnector-release-*.zip .editorconfig .flake8 .git* .mypy.ini .pre-commit-config.yaml Build-exe-and-msi.py *.manifest coriolis-data/* img/* pyproject.toml scripts/* tests/* wix/*'
+
       - name: Upload build files
         uses: actions/upload-artifact@v3
         with:
           name: Built files
-          path: EDMarketConnector_win*.msi
+          path: |
+              EDMarketConnector_win*.msi
+              EDMarketConnector-release-*.zip
 
   release:
     name: Release new version
@@ -60,7 +82,7 @@ jobs:
           path: ./
           
       - name: Hash files
-        run: sha256sum EDMarketConnector_win*.msi > ./hashes.sum
+        run: sha256sum EDMarketConnector_win*.msi EDMarketConnector-release*.zip > ./hashes.sum
 
       - name: Create Draft Release
         uses: "softprops/action-gh-release@v1"
@@ -71,4 +93,5 @@ jobs:
           discussion_category_name: "Announcement"
           files: |
             ./EDMarketConnector_win*.msi
+            ./EDMarketConnector-release-*.zip
             ./hashes.sum

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -29,8 +29,9 @@ jobs:
         run: |
           # For 'tar' we can only specify filename/glob exclusions, not any
           # directory location
-          tar -C .. -c -v -z \
-              -f EDMarketConnector/EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.tar.gz \
+          tar -c -v -z \
+              -f EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.tar.gz \
+              -C .. \
               --exclude=EDMarketConnector-release-*.* \
               --exclude=.editorconfig \
               --exclude=.flake8 \

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -60,7 +60,7 @@ jobs:
           directory: '..'
           path: 'EDMarketConnector'
           filename: 'EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.zip'
-          exclusions: 'dist.win32/* dist.win32 __pycache__/* __pycache__ .editorconfig .flake8 .git* .mypy.ini .pre-commit-config.yaml Build-exe-and-msi.py *.manifest coriolis-data/* coriolis-data/.??* coriolis-data img/* img out/* out out.zip pyproject.toml scripts/* scripts tests/* tests wix/* wix WinSparkle.*'
+          exclusions: 'EDMarketConnector-release-*.zip dist.win32/* dist.win32 __pycache__/* __pycache__ .editorconfig .flake8 .git* .mypy.ini .pre-commit-config.yaml Build-exe-and-msi.py *.manifest coriolis-data/* coriolis-data/.??* coriolis-data img/* img out/* out out.zip pyproject.toml scripts/* scripts tests/* tests wix/* wix WinSparkle.*'
 
       - name: Upload build files
         uses: actions/upload-artifact@v3
@@ -68,7 +68,7 @@ jobs:
           name: Built files
           path: |
               EDMarketConnector_win*.msi
-              ../EDMarketConnector-release-*.zip
+              EDMarketConnector-release-*.zip
 
   release:
     name: Release new version

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -26,16 +26,27 @@ jobs:
           submodules: true
 
       - name: Make tar archive
-        uses: thedoctor0/zip-release@main
         with:
-          # See the 'zip' version for commentary on these values
-          type: 'tar'
-          directory: '..'
-          path: 'EDMarketConnector'
-          filename: 'EDMarketConnector/EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.tar.gz'
-          # For 'tar' we can only specify filenames, not any directory location
-          exclusions: 'EDMarketConnector-release-*.* .editorconfig .flake8 .git* .mypy.ini .pre-commit-config.yaml Build-exe-and-msi.py *.manifest coriolis-data img pyproject.toml scripts tests wix'
-          # exclusions: 'EDMarketConnector/EDMarketConnector-release-*.* EDMarketConnector/.editorconfig EDMarketConnector/.flake8 EDMarketConnector/.git* EDMarketConnector/.mypy.ini EDMarketConnector/.pre-commit-config.yaml EDMarketConnector/Build-exe-and-msi.py EDMarketConnector/*.manifest EDMarketConnector/coriolis-data/ EDMarketConnector/img/ EDMarketConnector/pyproject.toml EDMarketConnector/scripts/ EDMarketConnector/tests/ EDMarketConnector/wix/'
+          script: |
+            # For 'tar' we can only specify filename/glob exclusions, not any
+            # directory location
+            tar -C .. -c -v -z \
+                -f EDMarketConnector/EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.tar.gz \
+                --exclude=EDMarketConnector-release-*.* \
+                --exclude=.editorconfig \
+                --exclude=.flake8 \
+                --exclude=.git* \
+                --exclude=.mypy.ini \
+                --exclude=.pre-commit-config.yaml \
+                --exclude=Build-exe-and-msi.py \
+                --exclude=*.manifest \
+                --exclude=coriolis-data \
+                --exclude=img \
+                --exclude=pyproject.toml \
+                --exclude=scripts \
+                --exclude=tests \
+                --exclude=wix \
+                EDMarketConnector
 
       - name: Upload build files
         uses: actions/upload-artifact@v3

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -35,6 +35,36 @@ jobs:
         with:
           submodules: true
 
+      - name: Make tar archive
+        uses: thedoctor0/zip-release@main
+        with:
+          # See the 'zip' version for commentary on these values
+          type: 'tar'
+          directory: '..'
+          path: 'EDMarketConnector'
+          filename: 'EDMarketConnector/EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.tar.gz'
+          # For 'tar' we can only specify filenames, not any directory location
+          exclusions: 'EDMarketConnector-release-*.* .editorconfig .flake8 .git* .mypy.ini .pre-commit-config.yaml Build-exe-and-msi.py *.manifest coriolis-data img pyproject.toml scripts tests wix'
+
+      - name: Make zip archive
+        uses: thedoctor0/zip-release@main
+        with:
+          type: 'zip'
+          # We want an in-zip prefix of `EDMarketConnector/` for all files, so
+          # we specify that:
+          # 1. We work from the parent directory
+          directory: '..'
+          # 2. The path we're using is the 'root' directory
+          path: 'EDMarketConnector'
+          # 3. The .zip file has to be in the 'root' so that upload-artifact
+          #   will process it.  Can't use relative paths.
+          filename: 'EDMarketConnector/EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.zip'
+          # 4. And all the exclusions need to be prefixed with the 'root'
+          #   directory.
+          # NB: If this gets too long it can cause zip 'Command Line Error',
+          #   presumably due to a Windows CL length limit.
+          exclusions: 'EDMarketConnector/EDMarketConnector-release-*.* EDMarketConnector/.editorconfig EDMarketConnector/.flake8 EDMarketConnector/.git* EDMarketConnector/.mypy.ini EDMarketConnector/.pre-commit-config.yaml EDMarketConnector/Build-exe-and-msi.py EDMarketConnector/*.manifest EDMarketConnector/coriolis-data/ EDMarketConnector/img/ EDMarketConnector/pyproject.toml EDMarketConnector/scripts/ EDMarketConnector/tests/ EDMarketConnector/wix/'
+
       - uses: actions/setup-python@v4
         with:
           python-version-file: '.python-version'
@@ -54,35 +84,6 @@ jobs:
       - name: Build EDMC
         run: |
           python Build-exe-and-msi.py
-
-      - name: Make zip archive
-        uses: thedoctor0/zip-release@main
-        with:
-          type: 'zip'
-          # We want an in-zip prefix of `EDMarketConnector/` for all files, so
-          # we specify that:
-          # 1. We work from the parent directory
-          directory: '..'
-          # 2. The path we're using is the 'root' directory
-          path: 'EDMarketConnector'
-          # 3. The .zip file has to be in the 'root' so that upload-artifact
-          #   will process it.  Can't use relative paths.
-          filename: 'EDMarketConnector/EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.zip'
-          # 4. And all the exclusions need to be prefixed with the 'root'
-          #   directory.
-          # NB: If this gets too long it can cause zip 'Command Line Error',
-          #   presumably due to a Windows CL length limit.
-          exclusions: 'EDMarketConnector/EDMarketConnector-release-*.* EDMarketConnector/dist.win32 EDMarketConnector/__pycache__/ EDMarketConnector/.editorconfig EDMarketConnector/.flake8 EDMarketConnector/.git* EDMarketConnector/.mypy.ini EDMarketConnector/.pre-commit-config.yaml EDMarketConnector/Build-exe-and-msi.py EDMarketConnector/*.manifest EDMarketConnector/coriolis-data/ EDMarketConnector/img/ EDMarketConnector/out/ EDMarketConnector/out.zip EDMarketConnector/pyproject.toml EDMarketConnector/scripts/ EDMarketConnector/tests/ EDMarketConnector/wix/ EDMarketConnector/WinSparkle.*'
-
-      - name: Make tar archive
-        uses: thedoctor0/zip-release@main
-        with:
-          # See the 'zip' version above for commentary on these values
-          type: 'tar'
-          path: 'EDMarketConnector'
-          filename: 'EDMarketConnector/EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.tar.gz'
-          # For 'tar' we can only specify filenames, not any directory location
-          exclusions: 'EDMarketConnector-release-*.* dist.win32 __pycache__ .editorconfig .flake8 .git* .mypy.ini .pre-commit-config.yaml Build-exe-and-msi.py *.manifest coriolis-data img out out.zip pyproject.toml scripts tests wix WinSparkle.*'
 
       - name: Upload build files
         uses: actions/upload-artifact@v3

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -21,6 +21,9 @@ jobs:
           script: |
             core.setOutput('sem_ver', '${{ github.ref_name }}'.replaceAll('Release\/', ''))
 
+  linux_build:
+    runs-on: "ubuntu-latest"
+    steps:
       - uses: actions/checkout@v3
         with:
           submodules: true

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -44,7 +44,8 @@ jobs:
           path: 'EDMarketConnector'
           filename: 'EDMarketConnector/EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.tar.gz'
           # For 'tar' we can only specify filenames, not any directory location
-          exclusions: 'EDMarketConnector-release-*.* .editorconfig .flake8 .git* .mypy.ini .pre-commit-config.yaml Build-exe-and-msi.py *.manifest coriolis-data img pyproject.toml scripts tests wix'
+          # exclusions: 'EDMarketConnector-release-*.* .editorconfig .flake8 .git* .mypy.ini .pre-commit-config.yaml Build-exe-and-msi.py *.manifest coriolis-data img pyproject.toml scripts tests wix'
+          exclusions: 'EDMarketConnector/EDMarketConnector-release-*.* EDMarketConnector/.editorconfig EDMarketConnector/.flake8 EDMarketConnector/.git* EDMarketConnector/.mypy.ini EDMarketConnector/.pre-commit-config.yaml EDMarketConnector/Build-exe-and-msi.py EDMarketConnector/*.manifest EDMarketConnector/coriolis-data/ EDMarketConnector/img/ EDMarketConnector/pyproject.toml EDMarketConnector/scripts/ EDMarketConnector/tests/ EDMarketConnector/wix/'
 
       - name: Make zip archive
         uses: thedoctor0/zip-release@main

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  windows_build:
     name: Build EDMC
     runs-on: windows-2019
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -68,6 +68,8 @@ jobs:
           filename: 'EDMarketConnector/EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.zip'
           # 4. And all the exclusions need to be prefixed with the 'root'
           #   directory.
+          # NB: If this gets too long it can cause zip 'Command Line Error',
+          #   presumably due to a Windows CL length limit.
           exclusions: 'EDMarketConnector/EDMarketConnector-release-*.zip EDMarketConnector/dist.win32 EDMarketConnector/__pycache__/ EDMarketConnector/.editorconfig EDMarketConnector/.flake8 EDMarketConnector/.git* EDMarketConnector/.mypy.ini EDMarketConnector/.pre-commit-config.yaml EDMarketConnector/Build-exe-and-msi.py EDMarketConnector/*.manifest EDMarketConnector/coriolis-data/ EDMarketConnector/img/ EDMarketConnector/out/ EDMarketConnector/out.zip EDMarketConnector/pyproject.toml EDMarketConnector/scripts/ EDMarketConnector/tests/ EDMarketConnector/wix/ EDMarketConnector/WinSparkle.*'
 
       - name: Upload build files

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -57,10 +57,18 @@ jobs:
         uses: thedoctor0/zip-release@main
         with:
           type: 'zip'
+          # We want an in-zip prefix of `EDMarketConnector/` for all files, so
+          # we specify that:
+          # 1. We work from the parent directory
           directory: '..'
+          # 2. The path we're using is the 'root' directory
           path: 'EDMarketConnector'
+          # 3. The .zip file has to be in the 'root' so that upload-artifact
+          #   will process it.  Can't use relative paths.
           filename: 'EDMarketConnector/EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.zip'
-          exclusions: 'EDMarketConnector-release-*.zip dist.win32/* dist.win32 __pycache__/* __pycache__ .editorconfig .flake8 .git* .mypy.ini .pre-commit-config.yaml Build-exe-and-msi.py *.manifest coriolis-data/* coriolis-data/.??* coriolis-data img/* img out/* out out.zip pyproject.toml scripts/* scripts tests/* tests wix/* wix WinSparkle.*'
+          # 4. And all the exclusions need to be prefixed with the 'root'
+          #   directory.
+          exclusions: 'EDMarketConnector/EDMarketConnector-release-*.zip EDMarketConnector/dist.win32/* EDMarketConnector/dist.win32 EDMarketConnector/__pycache__/* EDMarketConnector/__pycache__ EDMarketConnector/.editorconfig EDMarketConnector/.flake8 EDMarketConnector/.git* EDMarketConnector/.mypy.ini EDMarketConnector/.pre-commit-config.yaml EDMarketConnector/Build-exe-and-msi.py EDMarketConnector/*.manifest EDMarketConnector/coriolis-data/* EDMarketConnector/coriolis-data/.??* EDMarketConnector/coriolis-data EDMarketConnector/img/* EDMarketConnector/img EDMarketConnector/out/* EDMarketConnector/out EDMarketConnector/out.zip EDMarketConnector/pyproject.toml EDMarketConnector/scripts/* EDMarketConnector/scripts EDMarketConnector/tests/* EDMarketConnector/tests EDMarketConnector/wix/* EDMarketConnector/wix EDMarketConnector/WinSparkle.*'
 
       - name: Upload build files
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Because the GitHub automatic .zip (and .tar.gz) archive is based purely on the files in *this* repo it doesn't include the two necessary files from the FDevIDs sub-module.

So, this PR adds an extra build step to make such an archive *with* those files.  Actually I felt it easiest to just include all the FDevIDs files.  The resulting .zip file is then an extra build artifact which is included in subsequent steps, i.e. hashes.sum and release draft creation.

I've left the most recent successful draft release at https://github.com/EDCD/EDMarketConnector/releases/tag/untagged-d68b90c527b0e582d027 (likely only viewable by collaborators).

We should be able to extend this to a custom .tar.gz as well.

Close #1801 