### PR TITLE
Migrate all ctypes code to use pywin32 instead, if possible

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -287,7 +287,6 @@ if __name__ == '__main__':  # noqa: C901
                                 )
                                 if token_information == user_sid:
                                     if len(sys.argv) > 1 and sys.argv[1].startswith(protocolhandler_redirect):
-                                        logger.debug("This process is trying to do edmc:// ...")
                                         pythoncom.CoInitializeEx(
                                             pythoncom.COINIT_APARTMENTTHREADED | pythoncom.COINIT_DISABLE_OLE1DDE
                                         )

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -254,9 +254,6 @@ if __name__ == '__main__':  # noqa: C901
                 import win32process
                 import win32security
 
-                COINIT_APARTMENTTHREADED = 0x2  # noqa: N806
-                COINIT_DISABLE_OLE1DDE = 0x4  # noqa: N806
-
                 def window_title(h: int) -> Optional[str]:
                     if h:
                         return win32gui.GetWindowText(h)
@@ -290,7 +287,10 @@ if __name__ == '__main__':  # noqa: C901
                                 )
                                 if token_information == user_sid:
                                     if len(sys.argv) > 1 and sys.argv[1].startswith(protocolhandler_redirect):
-                                        pythoncom.CoInitializeEx(COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE)
+                                        logger.debug("This process is trying to do edmc:// ...")
+                                        pythoncom.CoInitializeEx(
+                                            pythoncom.COINIT_APARTMENTTHREADED | pythoncom.COINIT_DISABLE_OLE1DDE
+                                        )
                                         # Wait for it to be responsive to avoid ShellExecute recursing
                                         win32gui.ShowWindow(window_handle, win32con.SW_RESTORE)
                                         win32api.ShellExecute(0, None, sys.argv[1], None, None, win32con.SW_RESTORE)

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -246,6 +246,10 @@ if __name__ == '__main__':  # noqa: C901
             # now need to do the edmc:// checks for auth callback
             if locked != JournalLockResult.LOCKED:
                 import ctypes
+                import win32api
+                import win32con
+                import win32gui
+                import win32process
                 from ctypes.wintypes import BOOL, HWND, INT, LPARAM, LPCWSTR, LPWSTR
 
                 EnumWindows = ctypes.windll.user32.EnumWindows  # noqa: N806
@@ -253,7 +257,6 @@ if __name__ == '__main__':  # noqa: C901
                 GetClassName.argtypes = [HWND, LPWSTR, ctypes.c_int]
                 GetWindowText = ctypes.windll.user32.GetWindowTextW  # noqa: N806
                 GetWindowText.argtypes = [HWND, LPWSTR, ctypes.c_int]
-                GetWindowTextLength = ctypes.windll.user32.GetWindowTextLengthW  # noqa: N806
                 GetProcessHandleFromHwnd = ctypes.windll.oleacc.GetProcessHandleFromHwnd  # noqa: N806
 
                 SW_RESTORE = 9  # noqa: N806
@@ -271,10 +274,7 @@ if __name__ == '__main__':  # noqa: C901
 
                 def window_title(h: int) -> Optional[str]:
                     if h:
-                        text_length = GetWindowTextLength(h) + 1
-                        buf = ctypes.create_unicode_buffer(text_length)
-                        if GetWindowText(h, buf, text_length):
-                            return buf.value
+                        return win32gui.GetWindowText(h)
 
                     return None
 

--- a/hotkey/windows.py
+++ b/hotkey/windows.py
@@ -41,7 +41,7 @@ WM_APP = 0x8000
 WM_SND_GOOD = WM_APP + 1
 WM_SND_BAD = WM_APP + 2
 
-MapVirtualKey = ctypes.windll.user32.MapVirtualKeyW
+# Virtual key values
 VK_BACK = 0x08
 VK_CLEAR = 0x0c
 VK_RETURN = 0x0d
@@ -64,6 +64,14 @@ VK_NUMLOCK = 0x90
 VK_SCROLL = 0x91
 VK_PROCESSKEY = 0xe5
 VK_OEM_CLEAR = 0xfe
+
+# VirtualKey mapping values
+# <https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-mapvirtualkeyexa>
+MAPVK_VK_TO_VSC = 0
+MAPVK_VSC_TO_VK = 1
+MAPVK_VK_TO_CHAR = 2
+MAPVK_VSC_TO_VK_EX = 3
+MAPVK_VK_TO_VSC_EX = 4
 
 GetForegroundWindow = ctypes.windll.user32.GetForegroundWindow
 GetWindowText = ctypes.windll.user32.GetWindowTextW
@@ -359,7 +367,8 @@ class WindowsHotkeyMgr(AbstractHotkeyMgr):
             text += WindowsHotkeyMgr.DISPLAY[keycode]
 
         else:
-            c = MapVirtualKey(keycode, 2)  # printable ?
+            # <https://mhammond.github.io/pywin32/win32api__MapVirtualKey_meth.html>
+            c = win32api.MapVirtualKey(keycode, MAPVK_VK_TO_CHAR)  # printable ?
             if not c:  # oops not printable
                 text += '⁈'
 

--- a/hotkey/windows.py
+++ b/hotkey/windows.py
@@ -20,6 +20,7 @@ assert sys.platform == 'win32'
 
 logger = get_main_logger()
 
+# Not yet implmented in pywin32 - <https://github.com/mhammond/pywin32/issues/2004>
 UnregisterHotKey = ctypes.windll.user32.UnregisterHotKey
 # These don't seem to be in pywin32 at all
 # Ref: <https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-registerhotkey>

--- a/hotkey/windows.py
+++ b/hotkey/windows.py
@@ -10,6 +10,7 @@ from ctypes.wintypes import DWORD, HWND, LONG, LPWSTR, MSG, ULONG, WORD
 from typing import Optional, Tuple, Union
 
 import pywintypes
+import win32api
 import win32gui
 
 from config import config
@@ -40,7 +41,6 @@ WM_APP = 0x8000
 WM_SND_GOOD = WM_APP + 1
 WM_SND_BAD = WM_APP + 2
 
-GetKeyState = ctypes.windll.user32.GetKeyState
 MapVirtualKey = ctypes.windll.user32.MapVirtualKeyW
 VK_BACK = 0x08
 VK_CLEAR = 0x0c
@@ -288,11 +288,11 @@ class WindowsHotkeyMgr(AbstractHotkeyMgr):
         :param event: tk event ?
         :return: False to retain previous, None to not use, else (keycode, modifiers)
         """
-        modifiers = ((GetKeyState(VK_MENU) & 0x8000) and MOD_ALT) \
-            | ((GetKeyState(VK_CONTROL) & 0x8000) and MOD_CONTROL) \
-            | ((GetKeyState(VK_SHIFT) & 0x8000) and MOD_SHIFT) \
-            | ((GetKeyState(VK_LWIN) & 0x8000) and MOD_WIN) \
-            | ((GetKeyState(VK_RWIN) & 0x8000) and MOD_WIN)
+        modifiers = ((win32api.GetKeyState(VK_MENU) & 0x8000) and MOD_ALT) \
+            | ((win32api.GetKeyState(VK_CONTROL) & 0x8000) and MOD_CONTROL) \
+            | ((win32api.GetKeyState(VK_SHIFT) & 0x8000) and MOD_SHIFT) \
+            | ((win32api.GetKeyState(VK_LWIN) & 0x8000) and MOD_WIN) \
+            | ((win32api.GetKeyState(VK_RWIN) & 0x8000) and MOD_WIN)
         keycode = event.keycode
 
         if keycode in [VK_SHIFT, VK_CONTROL, VK_MENU, VK_LWIN, VK_RWIN]:

--- a/monitor.py
+++ b/monitor.py
@@ -2035,7 +2035,15 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                     # <https://mhammond.github.io/pywin32/win32api__OpenProcess_meth.html>
                     # The first arg can't simply be `0`, and `win32con.PROCESS_TERMINATE` works
                     handle = win32api.OpenProcess(win32con.PROCESS_TERMINATE, False, process_id)
-                    if handle:  # If OpenProcess succeeds then the app is already running as this user
+                    if handle:
+                        # If OpenProcess succeeds then the app is already running in this User session
+                        # That *specifically* means "either this exact user, in this session, or another user via
+                        # `runas`, but in this session", i.e. visible in the windows UI.
+                        # If the process is running *in another session*, such that it's not actually visible right
+                        # now, then this code will not find it.
+                        #
+                        # Checking if the process User matches that of the current session is trickier.
+                        # There's a method using `wmi`, but it's **VERY SLOW**, so not appropriate here.
                         hwnds.append(hwnd)
 
                 return True

--- a/monitor.py
+++ b/monitor.py
@@ -55,22 +55,41 @@ elif sys.platform == 'win32':
     from watchdog.events import FileCreatedEvent, FileSystemEventHandler
     from watchdog.observers import Observer
 
+    # <https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-enumwindows>
     # BOOL EnumWindows(
     #   [in] WNDENUMPROC lpEnumFunc,
     #   [in] LPARAM      lParam
     # );
     EnumWindowsProc = WINFUNCTYPE(BOOL, HWND, LPARAM)
     prototype = WINFUNCTYPE(BOOL, EnumWindowsProc, LPARAM)
-    paramflags = (1, "lpEnumFunc"), (1, "lParam")
-    EnumWindows = prototype(("EnumWindows", windll.user32), paramflags)
+    paramflags_enumwindows = (1, "lpEnumFunc"), (1, "lParam")
+    EnumWindows = prototype(("EnumWindows", windll.user32), paramflags_enumwindows)
 
+    # <https://learn.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-closehandle>
+    # BOOL CloseHandle(
+    #   [in] HANDLE hObject
+    # );
     prototype = WINFUNCTYPE(BOOL, HANDLE)
     paramflags_closehandle = (1, "hObject"),
     CloseHandle = prototype(("CloseHandle", windll.kernel32), paramflags_closehandle)
 
-    GetWindowText = ctypes.windll.user32.GetWindowTextW
-    GetWindowText.argtypes = [HWND, LPWSTR, ctypes.c_int]
-    GetWindowTextLengthW = ctypes.windll.user32.GetWindowTextLengthW
+    # <https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getwindowtextw>
+    # int GetWindowTextW(
+    #   [in]  HWND   hWnd,
+    #   [out] LPWSTR lpString,
+    #   [in]  int    nMaxCount
+    # );
+    prototype = WINFUNCTYPE(ctypes.c_int, HWND, LPWSTR, ctypes.c_int)
+    paramflags_getwindowtextw = (1, "hWnd"), (2, "lpString"), (1, "nMaxCount")
+    GetWindowTextW = prototype(("GetWindowTextW", windll.user32), paramflags_getwindowtextw)
+
+    # <https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getwindowtextlengthw>
+    # int GetWindowTextLengthW(
+    #   [in] HWND hWnd
+    # );
+    prototype = WINFUNCTYPE(ctypes.c_int, HWND)
+    paramflags_getwindowtextlengthw = (1, "hWnd"),
+    GetWindowTextLengthW = prototype(("GetWindowTextLengthW", windll.user32), paramflags_getwindowtextw)
 
     GetProcessHandleFromHwnd = ctypes.windll.oleacc.GetProcessHandleFromHwnd
 
@@ -2043,7 +2062,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
                 if h:
                     length = GetWindowTextLengthW(h) + 1
                     buf = ctypes.create_unicode_buffer(length)
-                    if GetWindowText(h, buf, length):
+                    if GetWindowTextW(h, buf, length):
                         return buf.value
                 return None
 

--- a/monitor.py
+++ b/monitor.py
@@ -50,7 +50,7 @@ if sys.platform == 'darwin':
 elif sys.platform == 'win32':
     import ctypes
     from ctypes import WINFUNCTYPE, windll
-    from ctypes.wintypes import BOOL, HWND, LPARAM, LPWSTR
+    from ctypes.wintypes import BOOL, HANDLE, HWND, LPARAM, LPWSTR
 
     from watchdog.events import FileCreatedEvent, FileSystemEventHandler
     from watchdog.observers import Observer
@@ -64,7 +64,9 @@ elif sys.platform == 'win32':
     paramflags = (1, "lpEnumFunc"), (1, "lParam")
     EnumWindows = prototype(("EnumWindows", windll.user32), paramflags)
 
-    CloseHandle = ctypes.windll.kernel32.CloseHandle
+    prototype = WINFUNCTYPE(BOOL, HANDLE)
+    paramflags_closehandle = (1, "hObject"),
+    CloseHandle = prototype(("CloseHandle", windll.kernel32), paramflags_closehandle)
 
     GetWindowText = ctypes.windll.user32.GetWindowTextW
     GetWindowText.argtypes = [HWND, LPWSTR, ctypes.c_int]

--- a/monitor.py
+++ b/monitor.py
@@ -1977,7 +1977,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         if entry['event'] == 'Location':
             logger.trace_if('journal.locations', '"Location" event')
 
-        if not self.live and entry['event'] not in (None, 'Fileheader'):
+        if not self.live and entry['event'] not in (None, 'Fileheader', 'ShutDown'):
             # Game not running locally, but Journal has been updated
             self.live = True
             if self.station:

--- a/monitor.py
+++ b/monitor.py
@@ -61,7 +61,7 @@ elif sys.platform == 'win32':
 
     GetWindowText = ctypes.windll.user32.GetWindowTextW
     GetWindowText.argtypes = [HWND, LPWSTR, ctypes.c_int]
-    GetWindowTextLength = ctypes.windll.user32.GetWindowTextLengthW
+    GetWindowTextLengthW = ctypes.windll.user32.GetWindowTextLengthW
 
     GetProcessHandleFromHwnd = ctypes.windll.oleacc.GetProcessHandleFromHwnd
 
@@ -2032,7 +2032,7 @@ class EDLogs(FileSystemEventHandler):  # type: ignore # See below
         elif sys.platform == 'win32':
             def WindowTitle(h):  # noqa: N802 # type: ignore
                 if h:
-                    length = GetWindowTextLength(h) + 1
+                    length = GetWindowTextLengthW(h) + 1
                     buf = ctypes.create_unicode_buffer(length)
                     if GetWindowText(h, buf, length):
                         return buf.value

--- a/monitor.py
+++ b/monitor.py
@@ -49,13 +49,20 @@ if sys.platform == 'darwin':
 
 elif sys.platform == 'win32':
     import ctypes
+    from ctypes import WINFUNCTYPE, windll
     from ctypes.wintypes import BOOL, HWND, LPARAM, LPWSTR
 
     from watchdog.events import FileCreatedEvent, FileSystemEventHandler
     from watchdog.observers import Observer
 
-    EnumWindows = ctypes.windll.user32.EnumWindows
-    EnumWindowsProc = ctypes.WINFUNCTYPE(BOOL, HWND, LPARAM)
+    # BOOL EnumWindows(
+    #   [in] WNDENUMPROC lpEnumFunc,
+    #   [in] LPARAM      lParam
+    # );
+    EnumWindowsProc = WINFUNCTYPE(BOOL, HWND, LPARAM)
+    prototype = WINFUNCTYPE(BOOL, EnumWindowsProc, LPARAM)
+    paramflags = (1, "lpEnumFunc"), (1, "lParam")
+    EnumWindows = prototype(("EnumWindows", windll.user32), paramflags)
 
     CloseHandle = ctypes.windll.kernel32.CloseHandle
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -48,8 +48,6 @@ pytest==7.2.0
 pytest-cov==4.0.0  # Pytest code coverage support
 coverage[toml]==7.0.5 # pytest-cov dep. This is here to ensure that it includes TOML support for pyproject.toml configs
 coverage-conditional-plugin==0.8.0
-# For manipulating folder permissions and the like.
-pywin32==305; sys_platform == 'win32'
 
 
 # All of the normal requirements

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,8 @@ infi.systray==0.1.12; sys_platform == 'win32'
 # pyyaml==5.3.1 watchdog dep
 semantic-version==2.10.0
 
+# Used both by some tests *and* now in monitor.py
+pywin32==305; sys_platform == 'win32'
+
 # Base requirement for MacOS
 pyobjc; sys_platform == 'darwin'


### PR DESCRIPTION
This started out as properly prototyping the ctypes code in `monitor.py`, so that nothing gets confused by return types on 64-bit python/windows...

... but after struggling for far too long with `GetWindowTextW()`, due to its *second* (out of three) parameter being 'out'... and realising that ctypes 'helpfully' returns all 'out' as the function return, and that means you need to define a function to assign to the `.errcheck` property in order to actually check result (return) ... I came across how to do the same thing with pywin32 modules instead.

And now I've managed to eliminate all the ctypes code from `monitor.py`.  I'll look into all the other ctypes code as well.

This does mean we'll start having `pywin32` as a PIP-level dependency ... and I *am* wondering if py2exe will do the right thing with all the separate little modules it provides.  They *are* explicit imports in our code, so here's hoping.

Close #1805 