### PR TITLE
Switch off the submodule PR cronjob in favour of 'push to develop'

### DIFF
--- a/.github/workflows/submodule-update.yml
+++ b/.github/workflows/submodule-update.yml
@@ -2,10 +2,10 @@
 name: Submodule Updates
 
 on:
-  #  push:
-  #    branches: [ develop ]
-  schedule:
-    - cron: '0 12 * * *'
+  push:
+    branches: [ develop ]
+  # schedule:
+  # - cron: '0 12 * * *'
 
 jobs:
   check_submodules:


### PR DESCRIPTION
No-one seems to have cared to apply any of the auto-generated PRs, or to make this small change.

Apply this, apply the latest 'spam' PR, then delete all the other 'spam' PRs.