### PR TITLE
5.9.2 Collective Roundup - Frontier Auth Registry Keys

### DIFF
--- a/.github/workflows/submodule-update.yml
+++ b/.github/workflows/submodule-update.yml
@@ -1,11 +1,10 @@
----
 name: Submodule Updates
 
 on:
   push:
-    branches: [ develop ]
-  # schedule:
-  # - cron: '0 12 * * *'
+    branches: [develop]
+  schedule:
+    - cron: '0 12 * * *'
 
 jobs:
   check_submodules:
@@ -44,25 +43,44 @@ jobs:
             echo 'changes=false' >> $GITHUB_OUTPUT
           fi
           exit 0
-      
-      - name: Create submodules changes branch
+
+      - name: Create or Update submodules changes branch
         if: steps.check_for_changes.outputs.changes == 'true'
         run: |
-          git checkout -b "submodule-change/$GITHUB_RUN_ID" $CHECKOUT_BRANCH
+          git fetch origin "submodule-change/$GITHUB_RUN_ID" || git checkout -b "submodule-change/$GITHUB_RUN_ID" $CHECKOUT_BRANCH
           git commit -am "updating submodules"
           git push --set-upstream origin "submodule-change/$GITHUB_RUN_ID"
 
-      - name: Create pull request against target branch
+      - name: Create or Update pull request against target branch
         if: steps.check_for_changes.outputs.changes == 'true'
         uses: actions/github-script@v6
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           script: |
-            await github.rest.pulls.create({
+            const { data: pulls } = await github.rest.pulls.list({
               owner: '${{ github.repository_owner }}',
               repo: '${{ github.repository }}'.split('/')[1].trim(),
               head: 'submodule-change/${{ github.run_id }}',
               base: '${{ env.PR_AGAINST_BRANCH }}',
-              title: `[Auto-generated] Submodule Updates ${process.env.GITHUB_RUN_ID}`,
-              body: '${{ steps.check_for_changes.outputs.changes_text }}',
+              state: 'open',
             });
+            if (pulls.length > 0) {
+              // If an open pull request exists, update it
+              const pull_number = pulls[0].number;
+              await github.rest.pulls.update({
+                owner: '${{ github.repository_owner }}',
+                repo: '${{ github.repository }}'.split('/')[1].trim(),
+                pull_number,
+                body: '${{ steps.check_for_changes.outputs.changes_text }}',
+              });
+            } else {
+              // If no open pull request exists, create a new one
+              await github.rest.pulls.create({
+                owner: '${{ github.repository_owner }}',
+                repo: '${{ github.repository }}'.split('/')[1].trim(),
+                head: 'submodule-change/${{ github.run_id }}',
+                base: '${{ env.PR_AGAINST_BRANCH }}',
+                title: `[Auto-generated] Submodule Updates ${process.env.GITHUB_RUN_ID}`,
+                body: '${{ steps.check_for_changes.outputs.changes_text }}',
+              });
+            }

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -33,6 +33,21 @@ produce the Windows executables and installer.
   currently used version in a given branch.
 
 ---
+Release 5.9.1
+===
+This release updates the build system in use for EDMC to a more feature-rich installer, as well 
+as updating the commodity information to be up-to-date for Update 16.
+
+NOTE: This version hands over the installer to an EXE file for Windows instead of an MSI.
+This does not change any functionality or plugin capability of EDMC. You **_may_** need to 
+manually close EDMC during the update process if updating from version 5.9.0 or earlier.
+
+* Removed the old WiX Build System
+* Handed over the Build system to Inno Setup
+* Broke apart the Build and Installer scripts for ease of development
+* Updated FDevIDs to latest version
+* Updated coriolis-data to latest version
+* Updated some internal documentation.
 
 Release 5.9.0
 ===

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -427,7 +427,7 @@ import tkinter as tk
 import tkinter.filedialog
 import tkinter.font
 import tkinter.messagebox
-from tkinter import ttk
+from tkinter import ttk, constants as tkc
 
 import commodity
 import plug
@@ -1844,7 +1844,11 @@ class AppWindow(object):
             # version <link to changelog>
             tk.Label(frame).grid(row=row, column=0)  # spacer
             row += 1
-            self.appversion_label = tk.Label(frame, text=appversion())
+            self.appversion_label = tk.Text(frame, height=1, width=20, wrap=tkc.NONE, bd=0)
+            self.appversion_label.insert("1.0", str(appversion()))
+            self.appversion_label.tag_configure("center", justify="center")
+            self.appversion_label.tag_add("center", "1.0", "end")
+            self.appversion_label.config(state=tkc.DISABLED, bg=frame.cget("background"), font="TkDefaultFont")
             self.appversion_label.grid(row=row, column=0, sticky=tk.E)
             # LANG: Help > Release Notes
             self.appversion = HyperlinkLabel(frame, compound=tk.RIGHT, text=_('Release Notes'),

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -1844,7 +1844,7 @@ class AppWindow(object):
             # version <link to changelog>
             tk.Label(frame).grid(row=row, column=0)  # spacer
             row += 1
-            self.appversion_label = tk.Text(frame, height=1, width=20, wrap=tkc.NONE, bd=0)
+            self.appversion_label = tk.Text(frame, height=1, width=len(str(appversion())), wrap=tkc.NONE, bd=0)
             self.appversion_label.insert("1.0", str(appversion()))
             self.appversion_label.tag_configure("center", justify="center")
             self.appversion_label.tag_add("center", "1.0", "end")

--- a/build.py
+++ b/build.py
@@ -143,7 +143,8 @@ def build() -> None:
     )
 
     version_info: dict = {
-        "description": "Downloads commodity market and other station data from the game"
+        "description": "Elite Dangerous Market Connector (EDMC)",
+        "comments": "Downloads commodity market and other station data from the game"
         " Elite Dangerous for use with all popular online and offline trading tools.",
         "company_name": "EDCD",  # Used by WinSparkle
         "product_name": appname,  # Used by WinSparkle

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -52,7 +52,7 @@ appcmdname = 'EDMC'
 # <https://semver.org/#semantic-versioning-specification-semver>
 # Major.Minor.Patch(-prerelease)(+buildmetadata)
 # NB: Do *not* import this, use the functions appversion() and appversion_nobuild()
-_static_appversion = '5.9.1'
+_static_appversion = '5.9.2'
 _cached_version: Optional[semantic_version.Version] = None
 copyright = '© 2015-2019 Jonathan Harris, 2020-2023 EDCD'
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -52,7 +52,7 @@ appcmdname = 'EDMC'
 # <https://semver.org/#semantic-versioning-specification-semver>
 # Major.Minor.Patch(-prerelease)(+buildmetadata)
 # NB: Do *not* import this, use the functions appversion() and appversion_nobuild()
-_static_appversion = '5.9.1-alpha0'
+_static_appversion = '5.9.1'
 _cached_version: Optional[semantic_version.Version] = None
 copyright = '© 2015-2019 Jonathan Harris, 2020-2023 EDCD'
 

--- a/plug.py
+++ b/plug.py
@@ -60,8 +60,8 @@ class Plugin(object):
                 filename += name.encode(encoding='ascii', errors='replace').decode('utf-8').replace('.', '_')
                 spec = importlib.util.spec_from_file_location(filename, loadfile)  # type: ignore
                 module = importlib.util.module_from_spec(spec)  # type: ignore
-                spec.loader.exec_module(module)
-
+                spec.loader.exec_module(module)  # type: ignore
+                # These type-ignores will need to be looked at. MyPy is wrong.
                 if getattr(module, 'plugin_start3', None):
                     newname = module.plugin_start3(os.path.dirname(loadfile))
                     self.name = newname and str(newname) or name

--- a/plug.py
+++ b/plug.py
@@ -58,10 +58,9 @@ class Plugin(object):
             try:
                 filename = 'plugin_'
                 filename += name.encode(encoding='ascii', errors='replace').decode('utf-8').replace('.', '_')
-                module = importlib.machinery.SourceFileLoader(
-                    filename,
-                    loadfile
-                ).load_module()
+                spec = importlib.util.spec_from_file_location(filename, loadfile)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
 
                 if getattr(module, 'plugin_start3', None):
                     newname = module.plugin_start3(os.path.dirname(loadfile))

--- a/plug.py
+++ b/plug.py
@@ -58,8 +58,8 @@ class Plugin(object):
             try:
                 filename = 'plugin_'
                 filename += name.encode(encoding='ascii', errors='replace').decode('utf-8').replace('.', '_')
-                spec = importlib.util.spec_from_file_location(filename, loadfile)
-                module = importlib.util.module_from_spec(spec)
+                spec = importlib.util.spec_from_file_location(filename, loadfile)  # type: ignore
+                module = importlib.util.module_from_spec(spec)  # type: ignore
                 spec.loader.exec_module(module)
 
                 if getattr(module, 'plugin_start3', None):

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -125,6 +125,7 @@ class This:
 
 
 this = This()
+show_password_var = tk.BooleanVar()
 
 STATION_UNDOCKED: str = '×'  # "Station" name to display when not docked = U+00D7
 __cleanup = str.maketrans({' ': None, '\n': None})
@@ -275,6 +276,14 @@ def plugin_stop() -> None:
     logger.debug('Done.')
 
 
+def toggle_password_visibility():
+    """Toggle if the API Key is visible or not."""
+    if show_password_var.get():
+        this.apikey.config(show="")
+    else:
+        this.apikey.config(show="*")
+
+
 def plugin_prefs(parent: ttk.Notebook, cmdr: str | None, is_beta: bool) -> tk.Frame:
     """
     Plugin preferences setup hook.
@@ -346,10 +355,19 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str | None, is_beta: bool) -> tk.Fr
     # LANG: EDSM API key label
     this.apikey_label = nb.Label(frame, text=_('API Key'))  # EDSM setting
     this.apikey_label.grid(row=cur_row, padx=PADX, sticky=tk.W)
-    this.apikey = nb.Entry(frame)
+    this.apikey = nb.Entry(frame, show="*", width=50)
     this.apikey.grid(row=cur_row, column=1, padx=PADX, pady=PADY, sticky=tk.EW)
 
     prefs_cmdr_changed(cmdr, is_beta)
+
+    show_password_var.set(False)  # Password is initially masked
+    show_password_checkbox = nb.Checkbutton(
+        frame,
+        text="Show API Key",
+        variable=show_password_var,
+        command=toggle_password_visibility,
+    )
+    show_password_checkbox.grid(columnspan=2, padx=BUTTONX, pady=(5, 0), sticky=tk.W)
 
     return frame
 

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -279,9 +279,9 @@ def plugin_stop() -> None:
 def toggle_password_visibility():
     """Toggle if the API Key is visible or not."""
     if show_password_var.get():
-        this.apikey.config(show="")
+        this.apikey.config(show="")  # type: ignore
     else:
-        this.apikey.config(show="*")
+        this.apikey.config(show="*")  # type: ignore
 
 
 def plugin_prefs(parent: ttk.Notebook, cmdr: str | None, is_beta: bool) -> tk.Frame:

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -152,6 +152,8 @@ class This:
 
 
 this = This()
+show_password_var = tk.BooleanVar()
+
 # last time we updated, if unset in config this is 0, which means an instant update
 LAST_UPDATE_CONF_KEY = 'inara_last_update'
 EVENT_COLLECT_TIME = 31  # Minimum time to take collecting events before requesting a send
@@ -242,6 +244,14 @@ def plugin_stop() -> None:
     logger.debug('Done.')
 
 
+def toggle_password_visibility():
+    """Toggle if the API Key is visible or not."""
+    if show_password_var.get():
+        this.apikey.config(show="")
+    else:
+        this.apikey.config(show="*")
+
+
 def plugin_prefs(parent: ttk.Notebook, cmdr: str, is_beta: bool) -> tk.Frame:
     """Plugin Preferences UI hook."""
     x_padding = 10
@@ -281,10 +291,19 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str, is_beta: bool) -> tk.Frame:
     # LANG: Inara API key label
     this.apikey_label = nb.Label(frame, text=_('API Key'))  # Inara setting
     this.apikey_label.grid(row=12, padx=x_padding, sticky=tk.W)
-    this.apikey = nb.Entry(frame)
+    this.apikey = nb.Entry(frame, show="*", width=50)
     this.apikey.grid(row=12, column=1, padx=x_padding, pady=y_padding, sticky=tk.EW)
 
     prefs_cmdr_changed(cmdr, is_beta)
+
+    show_password_var.set(False)  # Password is initially masked
+    show_password_checkbox = nb.Checkbutton(
+        frame,
+        text="Show API Key",
+        variable=show_password_var,
+        command=toggle_password_visibility,
+    )
+    show_password_checkbox.grid(columnspan=2, padx=x_padding, pady=(5, 0), sticky=tk.W)
 
     return frame
 

--- a/resources/EDMC_Installer_Config_template.txt
+++ b/resources/EDMC_Installer_Config_template.txt
@@ -65,3 +65,15 @@ begin
     end;
   end;
 end;
+
+
+[Registry]
+; Create the registry key for the custom file type
+Root: HKCR; Subkey: "edmc"; Flags: uninsdeletekey
+; Create the registry values for the custom file type
+Root: HKCR; Subkey: "edmc"; ValueType: string; ValueName: ""; ValueData: "{#MyAppName}"; Flags: uninsdeletevalue
+Root: HKCR; Subkey: "edmc\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\{#MyAppExeName},0"; Flags: uninsdeletevalue
+Root: HKCR; Subkey: "edmc\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#MyAppExeName}"" ""%1"""; Flags: uninsdeletevalue
+
+; Register the URL protocol handler
+Root: HKCR; Subkey: "edmc"; ValueType: string; ValueName: "URL Protocol"; ValueData: ""; Flags: uninsdeletevalue

--- a/resources/EDMC_Installer_Config_template.txt
+++ b/resources/EDMC_Installer_Config_template.txt
@@ -31,6 +31,7 @@ OutputDir=.
 LicenseFile=LICENSE
 AlwaysShowDirOnReadyPage=yes
 UninstallDisplayIcon={app}\{#MyAppExeName}
+MinVersion=6.2
 
 
 [Languages]


### PR DESCRIPTION
Fixes a critical bug with the installer on new installs not creating registry keys (#2046)

Also includes a number of minor enhancements:
- Re-enables automatic submodule updates (#1443)
- Allows Help -> About Version String can now be copied to clipboard (#1936)
- EDSM Task Manager Printout now is less useless (#2045)
- Deprecated load_module() is now retired (#1462)
- API Keys are masked in Settings (#2047)
- Installer will now refuse to install on Win7 and Earlier (#1122)