### PR TITLE
#510 Open Log Directory

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -699,7 +699,7 @@ class AppWindow(object):
             self.help_menu.add_command(command=lambda: self.updater.check_for_updates())  # Check for Updates...
             # About E:D Market Connector
             self.help_menu.add_command(command=lambda: not self.HelpAbout.showing and self.HelpAbout(self.w))
-            self.help_menu.add_command(command=self.help_open_log_folder)  # Open Log Folder
+            self.help_menu.add_command(command=prefs.help_open_log_folder)  # Open Log Folder
 
             self.menubar.add_cascade(menu=self.help_menu)
             if sys.platform == 'win32':
@@ -1793,20 +1793,6 @@ class AppWindow(object):
         """Open Wiki Privacy page in browser."""
         webbrowser.open("https://github.com/EDCD/EDMarketConnector/issues/new?assignees=&labels=bug%2C+unconfirmed"
                         "&template=bug_report.md&title=")
-
-    def help_open_log_folder(self, event=None) -> None:
-        """Open the folder logs are stored in."""
-        logfile_loc = pathlib.Path(tempfile.gettempdir())
-        logfile_loc /= f'{appname}'
-        if sys.platform.startswith('win'):
-            # On Windows, use the "start" command to open the folder
-            system(f'start "" "{logfile_loc}"')
-        elif sys.platform.startswith('darwin'):
-            # On macOS, use the "open" command to open the folder
-            system(f'open "{logfile_loc}"')
-        elif sys.platform.startswith('linux'):
-            # On Linux, use the "xdg-open" command to open the folder
-            system(f'xdg-open "{logfile_loc}"')
 
     def help_privacy(self, event=None) -> None:
         """Open Wiki Privacy page in browser."""

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -13,7 +13,7 @@ import sys
 import threading
 import webbrowser
 from builtins import object, str
-from os import chdir, environ
+from os import chdir, environ, system
 from os.path import dirname, join
 from time import localtime, strftime, time
 from typing import TYPE_CHECKING, Any, Literal, Optional, Tuple, Union
@@ -699,6 +699,7 @@ class AppWindow(object):
             self.help_menu.add_command(command=lambda: self.updater.check_for_updates())  # Check for Updates...
             # About E:D Market Connector
             self.help_menu.add_command(command=lambda: not self.HelpAbout.showing and self.HelpAbout(self.w))
+            self.help_menu.add_command(command=self.help_open_log_folder)  # Open Log Folder
 
             self.menubar.add_cascade(menu=self.help_menu)
             if sys.platform == 'win32':
@@ -935,6 +936,8 @@ class AppWindow(object):
             self.help_menu.entryconfigure(3, label=_('Report A Bug'))  # LANG: Help > Report A Bug
             self.help_menu.entryconfigure(4, label=_('Privacy Policy'))  # LANG: Help > Privacy Policy
             self.help_menu.entryconfigure(5, label=_('Release Notes'))  # LANG: Help > Release Notes
+            self.help_menu.entryconfigure(6, label=_('Open Log Folder'))  # LANG: Help > Open Log Folder
+
         else:
             self.menubar.entryconfigure(1, label=_('File'))  # LANG: 'File' menu title
             self.menubar.entryconfigure(2, label=_('Edit'))  # LANG: 'Edit' menu title
@@ -957,6 +960,7 @@ class AppWindow(object):
             self.help_menu.entryconfigure(4, label=_('Release Notes'))  # LANG: Help > Release Notes
             self.help_menu.entryconfigure(5, label=_('Check for Updates...'))  # LANG: Help > Check for Updates...
             self.help_menu.entryconfigure(6, label=_("About {APP}").format(APP=applongname))  # LANG: Help > About App
+            self.help_menu.entryconfigure(7, label=_('Open Log Folder'))  # LANG: Help > Open Log Folder
 
         # Edit menu
         self.edit_menu.entryconfigure(0, label=_('Copy'))  # LANG: Label for 'Copy' as in 'Copy and Paste'
@@ -1789,6 +1793,20 @@ class AppWindow(object):
         """Open Wiki Privacy page in browser."""
         webbrowser.open("https://github.com/EDCD/EDMarketConnector/issues/new?assignees=&labels=bug%2C+unconfirmed"
                         "&template=bug_report.md&title=")
+
+    def help_open_log_folder(self, event=None) -> None:
+        """Open the folder logs are stored in."""
+        logfile_loc = pathlib.Path(tempfile.gettempdir())
+        logfile_loc /= f'{appname}'
+        if sys.platform.startswith('win'):
+            # On Windows, use the "start" command to open the folder
+            system(f'start "" "{logfile_loc}"')
+        elif sys.platform.startswith('darwin'):
+            # On macOS, use the "open" command to open the folder
+            system(f'open "{logfile_loc}"')
+        elif sys.platform.startswith('linux'):
+            # On Linux, use the "xdg-open" command to open the folder
+            system(f'xdg-open "{logfile_loc}"')
 
     def help_privacy(self, event=None) -> None:
         """Open Wiki Privacy page in browser."""

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -13,7 +13,7 @@ import sys
 import threading
 import webbrowser
 from builtins import object, str
-from os import chdir, environ, system
+from os import chdir, environ
 from os.path import dirname, join
 from time import localtime, strftime, time
 from typing import TYPE_CHECKING, Any, Literal, Optional, Tuple, Union

--- a/prefs.py
+++ b/prefs.py
@@ -3,9 +3,12 @@
 
 import contextlib
 import logging
+import pathlib
 import sys
+import tempfile
 import tkinter as tk
 import webbrowser
+from os import system
 from os.path import expanduser, expandvars, join, normpath
 from tkinter import colorchooser as tkColorChooser  # type: ignore # noqa: N812
 from tkinter import ttk
@@ -16,12 +19,12 @@ import myNotebook as nb  # noqa: N813
 import plug
 from config import applongname, appversion_nobuild, config
 from EDMCLogging import edmclogger, get_main_logger
+from constants import appname
 from hotkey import hotkeymgr
 from l10n import Translations
 from monitor import monitor
 from theme import theme
 from ttkHyperlinkLabel import HyperlinkLabel
-
 logger = get_main_logger()
 
 if TYPE_CHECKING:
@@ -36,6 +39,21 @@ if TYPE_CHECKING:
 ###########################################################################
 
 # May be imported by plugins
+
+
+def help_open_log_folder() -> None:
+    """Open the folder logs are stored in."""
+    logfile_loc = pathlib.Path(tempfile.gettempdir())
+    logfile_loc /= f'{appname}'
+    if sys.platform.startswith('win'):
+        # On Windows, use the "start" command to open the folder
+        system(f'start "" "{logfile_loc}"')
+    elif sys.platform.startswith('darwin'):
+        # On macOS, use the "open" command to open the folder
+        system(f'open "{logfile_loc}"')
+    elif sys.platform.startswith('linux'):
+        # On Linux, use the "xdg-open" command to open the folder
+        system(f'xdg-open "{logfile_loc}"')
 
 
 class PrefsVersion:
@@ -673,6 +691,13 @@ class PreferencesDialog(tk.Toplevel):
 
             self.loglevel_dropdown.configure(width=15)
             self.loglevel_dropdown.grid(column=1, sticky=tk.W, row=cur_row)
+
+            nb.Button(
+                config_frame,
+                # LANG: Label on button used to open a filesystem folder
+                text=_('Open Log Folder'),  # Button that opens a folder in Explorer/Finder
+                command=lambda: help_open_log_folder()
+            ).grid(column=2, padx=(0, self.PADX), sticky=tk.NSEW, row=cur_row)
 
         # Big spacer
         nb.Label(config_frame).grid(sticky=tk.W, row=row.get())


### PR DESCRIPTION
# Description

This Pull adds a menu option to open the file that logs are stored in the help menu and adds the same option to the preferences menu. This will allow for easier locating of logs and also resolves a long-standing request. 

Fixes #510

## Full Changes:
- Adds Open Log Folder to Help Menu
- Adds Open Log Folder to Config Menu

## Type of change
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Tests with included alterations to Release auto build made and output confirmed.
- Multiple install runs, clean installs, self-updates, and others made to confirm functionality
- All PyTest tests pass

![E6tjVbD3uV](https://github.com/EDCD/EDMarketConnector/assets/26337384/82c07083-dc88-4cd3-bf5e-e41c9177c9d5)
![image](https://github.com/EDCD/EDMarketConnector/assets/26337384/aee721c3-f365-4eed-a851-73b229ece030)
