### PR TITLE
Fix cAPI Hanging Auth Issue on EDMC Protocol

### DIFF
--- a/companion.py
+++ b/companion.py
@@ -15,6 +15,7 @@ import json
 import numbers
 import os
 import random
+import sys
 import threading
 import time
 import tkinter as tk
@@ -743,6 +744,10 @@ class Session(object):
             self.state = Session.STATE_INIT  # Will try to authorize again on next login or query
             self.auth = None
             raise  # Bad thing happened
+        if getattr(sys, 'frozen', False):
+            tk.messagebox.showinfo(title="Authentication Successful",
+                                   message="Authentication with cAPI Successful.\n"
+                                           "You may now close the Frontier login tab if it is still open.")
 
     def close(self) -> None:
         """Close the `request.Session()."""

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -52,7 +52,7 @@ appcmdname = 'EDMC'
 # <https://semver.org/#semantic-versioning-specification-semver>
 # Major.Minor.Patch(-prerelease)(+buildmetadata)
 # NB: Do *not* import this, use the functions appversion() and appversion_nobuild()
-_static_appversion = '5.9.2'
+_static_appversion = '5.9.4-alpha1'
 _cached_version: Optional[semantic_version.Version] = None
 copyright = '© 2015-2019 Jonathan Harris, 2020-2023 EDCD'
 

--- a/resources/EDMC_Installer_Config_template.txt
+++ b/resources/EDMC_Installer_Config_template.txt
@@ -74,21 +74,20 @@ begin
 end;
 
 
-
 [Registry]
 ; Create the main registry key under HKCR
-Root: HKCR; Subkey: "edmc"; Flags: uninsdeletevalue
+Root: HKCR; Subkey: "edmc"; Flags: uninsdeletekey
 ; Create a default value under the "edmc" key
-Root: HKCR; Subkey: "edmc"; ValueType: string; ValueName: ""; ValueData: "{#MyAppName}"; Flags: uninsdeletevalue
+Root: HKCR; Subkey: "edmc"; ValueType: string; ValueName: ""; ValueData: "{#MyAppName}"; Flags: uninsdeletekey
 ; Create the "URL Protocol" value under the "edmc" key
-Root: HKCR; Subkey: "edmc"; ValueType: string; ValueName: "URL Protocol"; ValueData: ""; Flags: uninsdeletevalue
+Root: HKCR; Subkey: "edmc"; ValueType: string; ValueName: "URL Protocol"; ValueData: ""; Flags: uninsdeletekey
 ; Create the "DefaultIcon" subkey under the "edmc" key
-Root: HKCR; Subkey: "edmc\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\EDMarketConnector.exe,0"; Flags: uninsdeletevalue
+Root: HKCR; Subkey: "edmc\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\EDMarketConnector.exe,0"; Flags: uninsdeletekey
 ; Create the "shell" subkey under the "edmc" key
-Root: HKCR; Subkey: "edmc\shell"; Flags: uninsdeletevalue
+Root: HKCR; Subkey: "edmc\shell"; Flags: uninsdeletekey
 ; Create the "open" subkey under the "shell" subkey
-Root: HKCR; Subkey: "edmc\shell\open"; Flags: uninsdeletevalue
+Root: HKCR; Subkey: "edmc\shell\open"; Flags: uninsdeletekey
 ; Create the "command" subkey under the "open" subkey
-Root: HKCR; Subkey: "edmc\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\EDMarketConnector.exe"" ""%1"""; Flags: uninsdeletevalue
+Root: HKCR; Subkey: "edmc\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\EDMarketConnector.exe"" ""%1"""; Flags: uninsdeletekey
 ; Create the "ddeexec" subkey under the "open" subkey
-Root: HKCR; Subkey: "edmc\shell\open\ddeexec"; ValueType: string; ValueName: ""; ValueData: "Open(""%1"")"; Flags: uninsdeletevalue
+Root: HKCR; Subkey: "edmc\shell\open\ddeexec"; ValueType: string; ValueName: ""; ValueData: "Open(""%1"")"; Flags: uninsdeletekey

--- a/resources/EDMC_Installer_Config_template.txt
+++ b/resources/EDMC_Installer_Config_template.txt
@@ -1,4 +1,5 @@
 #define MyAppName "EDMarketConnector"
+#define MyAppLongName "Elite Dangerous Market Connector"
 #define MyAppVersion "$appver"
 #define MyAppPublisher "EDCD"
 #define MyAppURL "https://edcd.github.io/"
@@ -45,8 +46,8 @@ Source: "dist.win32\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
 Source: "dist.win32\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
-Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
-Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+Name: "{autoprograms}\{#MyAppLongName}"; Filename: "{app}\{#MyAppExeName}"; Comment: "EDMC";
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon;
 
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent

--- a/resources/EDMC_Installer_Config_template.txt
+++ b/resources/EDMC_Installer_Config_template.txt
@@ -32,7 +32,7 @@ LicenseFile=LICENSE
 AlwaysShowDirOnReadyPage=yes
 UninstallDisplayIcon={app}\{#MyAppExeName}
 MinVersion=6.2
-
+ChangesAssociations = yes
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -53,28 +53,42 @@ Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChang
 
 ;Check if a WiX-based installation exists. If so, kill it with fire.
 [Code]
+function IsWixInstalled: Boolean;
+var
+  Uninstall: String;
+begin
+  Result := RegQueryStringValue(HKLM, 'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{5E9AD4D3-0365-41D5-9586-9368745DD109}', 'UninstallString', Uninstall);
+end;
+
 procedure CurStepChanged(CurStep: TSetupStep);
 var
   ResultCode: Integer;
   Uninstall: String;
 begin
-  if (CurStep = ssInstall) then begin
-    if RegQueryStringValue(HKLM, 'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{5E9AD4D3-0365-41D5-9586-9368745DD109}', 'UninstallString', Uninstall) then begin
-      MsgBox('Warning: an old version of EDMC is installed! Please close EDMC while we remove the old version!', mbInformation, MB_OK);
-      Uninstall := '/x {5E9AD4D3-0365-41D5-9586-9368745DD109}';
-      Exec('MsiExec.exe', Uninstall, '', SW_SHOW, ewWaitUntilTerminated, ResultCode);
-    end;
+  if (CurStep = ssInstall) and IsWixInstalled then
+  begin
+    MsgBox('Warning: an old version of EDMC is installed! Please close EDMC while we remove the old version!', mbInformation, MB_OK);
+    Uninstall := '/x {5E9AD4D3-0365-41D5-9586-9368745DD109}';
+    Exec('MsiExec.exe', Uninstall, '', SW_SHOW, ewWaitUntilTerminated, ResultCode);
   end;
 end;
 
 
-[Registry]
-; Create the registry key for the custom file type
-Root: HKCR; Subkey: "edmc"; Flags: uninsdeletekey
-; Create the registry values for the custom file type
-Root: HKCR; Subkey: "edmc"; ValueType: string; ValueName: ""; ValueData: "{#MyAppName}"; Flags: uninsdeletevalue
-Root: HKCR; Subkey: "edmc\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\{#MyAppExeName},0"; Flags: uninsdeletevalue
-Root: HKCR; Subkey: "edmc\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#MyAppExeName}"" ""%1"""; Flags: uninsdeletevalue
 
-; Register the URL protocol handler
+[Registry]
+; Create the main registry key under HKCR
+Root: HKCR; Subkey: "edmc"; Flags: uninsdeletevalue
+; Create a default value under the "edmc" key
+Root: HKCR; Subkey: "edmc"; ValueType: string; ValueName: ""; ValueData: "{#MyAppName}"; Flags: uninsdeletevalue
+; Create the "URL Protocol" value under the "edmc" key
 Root: HKCR; Subkey: "edmc"; ValueType: string; ValueName: "URL Protocol"; ValueData: ""; Flags: uninsdeletevalue
+; Create the "DefaultIcon" subkey under the "edmc" key
+Root: HKCR; Subkey: "edmc\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\EDMarketConnector.exe,0"; Flags: uninsdeletevalue
+; Create the "shell" subkey under the "edmc" key
+Root: HKCR; Subkey: "edmc\shell"; Flags: uninsdeletevalue
+; Create the "open" subkey under the "shell" subkey
+Root: HKCR; Subkey: "edmc\shell\open"; Flags: uninsdeletevalue
+; Create the "command" subkey under the "open" subkey
+Root: HKCR; Subkey: "edmc\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\EDMarketConnector.exe"" ""%1"""; Flags: uninsdeletevalue
+; Create the "ddeexec" subkey under the "open" subkey
+Root: HKCR; Subkey: "edmc\shell\open\ddeexec"; ValueType: string; ValueName: ""; ValueData: "Open(""%1"")"; Flags: uninsdeletevalue


### PR DESCRIPTION
# Description

This Pull fixes an additional issue with the new installer and the EDMC:// protocol. This puts in a more preferred handler key to ensure traffic is redirected appropriately. This is a temporary fix, and the next version (5.10.0) should investigate inverting the preference of the EDMC protocol vs local authentication. 

Also changes the name of the default shortcut to be clearer.

Fixes #2057, #2058, #2059, #2062

## Full Changes:
- Adds additional handler key to Windows registry
- Adds a message box that displays on a successful authentication event.

## Type of change
- Bug Fix 

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- Multiple install runs, clean installs, self-updates, and others made to confirm functionality, including under a variety of existing pre-install situations. 
- All PyTest tests pass