### PR TITLE
Force Latest Winsparkle for Builds

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -103,11 +103,18 @@ jobs:
           pip install wheel
           pip install -r requirements-dev.txt
 
-      - name: Download winsparkle
+      - name: Download latest WinSparkle release
         run: |
-          Invoke-Webrequest -UseBasicParsing https://github.com/vslavik/winsparkle/releases/download/v0.8.0/WinSparkle-0.8.0.zip -OutFile out.zip
-          Expand-Archive out.zip
-          Move-Item 'out\WinSparkle-0.8.0\Release\*' '.\'
+          $url = "https://api.github.com/repos/vslavik/winsparkle/releases/latest"
+          $response = Invoke-RestMethod -Uri $url
+          $latestAsset = $response.assets | Where-Object { $_.name -match "WinSparkle.*\.zip" -and $_.name -notmatch "-src" }
+
+          $downloadUrl = $latestAsset.browser_download_url
+          Invoke-WebRequest -Uri $downloadUrl -OutFile WinSparkle-Latest.zip
+
+          Expand-Archive -Path WinSparkle-Latest.zip -DestinationPath .
+          $extractedFolder = Get-ChildItem -Filter "WinSparkle-*" -Directory
+          Move-Item -Path "$($extractedFolder.FullName)\Release\*" -Destination .
 
       - name: Build EDMC
         run: |


### PR DESCRIPTION
# Description

Updates the build Github action to automatically poll the GitHub API and pull the latest version of WinSparkle. This will ensure that we are using the latest version should a new version be released without needing to set it in the action manually. Yay, automation!

Closes #1009 

## Full Changes:
- Updates GitHub action to use the latest API release. 

## Type of change
- Feature Enhancement - improves existing features in a non-breaking manner

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- A test build was successfully completed using GitHub actions on a private repository. The test artifact worked successfully and the action was completed without error.