### PR TITLE
Fixed translation hook in EDSM.py and Inara.py

### DIFF
--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -352,7 +352,7 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: Optional[str], is_beta: bool) -> tk
 
     show_password_checkbox = nb.Checkbutton(
         frame,
-        text="Show API Key",
+        text=_('Show API Key'), # LANG: Text EDSM Show API Key
         variable=show_password_var,
         command=toggle_password_visibility
     )

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -292,7 +292,7 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str, is_beta: bool) -> tk.Frame:
     show_password_var.set(False)  # Password is initially masked
     show_password_checkbox = nb.Checkbutton(
         frame,
-        text="Show API Key",
+        text=_('Show API Key'), # LANG: Text Inara Show API key
         variable=show_password_var,
         command=toggle_password_visibility,
     )


### PR DESCRIPTION
Corrected the text of code line 295 of the EDSM.py file and code line 355 of the Inara.py file;
The text text="Show API Key" cannot be translated as indicated, so I rewrote it as text=_('Show API Key').