### PR TITLE
Fix and standardize Settings UI

### DIFF
--- a/plugins/coriolis.py
+++ b/plugins/coriolis.py
@@ -84,6 +84,8 @@ def plugin_start3(path: str) -> str:
 def plugin_prefs(parent: ttk.Notebook, cmdr: str | None, is_beta: bool) -> tk.Frame:
     """Set up plugin preferences."""
     PADX = 10  # noqa: N806
+    PADY = 1  # noqa: N806
+    BOXY = 2  # noqa: N806  # box spacing
 
     conf_frame = nb.Frame(parent)
     conf_frame.columnconfigure(index=1, weight=1)
@@ -91,33 +93,39 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str | None, is_beta: bool) -> tk.Fr
     # LANG: Settings>Coriolis: Help/hint for changing coriolis URLs
     nb.Label(conf_frame, text=_(
         "Set the URL to use with coriolis.io ship loadouts. Note that this MUST end with '/import?data='"
-    )).grid(sticky=tk.EW, row=cur_row, column=0, padx=PADX, columnspan=3)
+    )).grid(sticky=tk.EW, row=cur_row, column=0, padx=PADX, pady=PADY, columnspan=3)
     cur_row += 1
 
     # LANG: Settings>Coriolis: Label for 'NOT alpha/beta game version' URL
-    nb.Label(conf_frame, text=_('Normal URL')).grid(sticky=tk.W, row=cur_row, column=0, padx=PADX)
+    nb.Label(conf_frame, text=_('Normal URL')).grid(sticky=tk.W, row=cur_row, column=0, padx=PADX, pady=PADY)
     nb.Entry(conf_frame,
-             textvariable=coriolis_config.normal_textvar).grid(sticky=tk.EW, row=cur_row, column=1, padx=PADX)
+             textvariable=coriolis_config.normal_textvar).grid(
+                sticky=tk.EW, row=cur_row, column=1, padx=PADX, pady=BOXY
+            )
     # LANG: Generic 'Reset' button label
     nb.Button(conf_frame, text=_("Reset"),
               command=lambda: coriolis_config.normal_textvar.set(value=DEFAULT_NORMAL_URL)).grid(
-        sticky=tk.W, row=cur_row, column=2, padx=PADX
+        sticky=tk.W, row=cur_row, column=2, padx=PADX, pady=0
     )
     cur_row += 1
 
     # LANG: Settings>Coriolis: Label for 'alpha/beta game version' URL
-    nb.Label(conf_frame, text=_('Beta URL')).grid(sticky=tk.W, row=cur_row, column=0, padx=PADX)
-    nb.Entry(conf_frame, textvariable=coriolis_config.beta_textvar).grid(sticky=tk.EW, row=cur_row, column=1, padx=PADX)
+    nb.Label(conf_frame, text=_('Beta URL')).grid(sticky=tk.W, row=cur_row, column=0, padx=PADX, pady=PADY)
+    nb.Entry(conf_frame, textvariable=coriolis_config.beta_textvar).grid(
+        sticky=tk.EW, row=cur_row, column=1, padx=PADX, pady=BOXY
+    )
     # LANG: Generic 'Reset' button label
     nb.Button(conf_frame, text=_('Reset'),
               command=lambda: coriolis_config.beta_textvar.set(value=DEFAULT_BETA_URL)).grid(
-        sticky=tk.W, row=cur_row, column=2, padx=PADX
+        sticky=tk.W, row=cur_row, column=2, padx=PADX, pady=0
     )
     cur_row += 1
 
     # TODO: This needs a help/hint text to be sure users know what it's for.
     # LANG: Settings>Coriolis: Label for selection of using Normal, Beta or 'auto' Coriolis URL
-    nb.Label(conf_frame, text=_('Override Beta/Normal Selection')).grid(sticky=tk.W, row=cur_row, column=0, padx=PADX)
+    nb.Label(conf_frame, text=_('Override Beta/Normal Selection')).grid(
+        sticky=tk.W, row=cur_row, column=0, padx=PADX, pady=PADY
+    )
     nb.OptionMenu(
         conf_frame,
         coriolis_config.override_textvar,
@@ -125,7 +133,7 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str | None, is_beta: bool) -> tk.Fr
         _('Normal'),  # LANG: 'Normal' label for Coriolis site override selection
         _('Beta'),  # LANG: 'Beta' label for Coriolis site override selection
         _('Auto')  # LANG: 'Auto' label for Coriolis site override selection
-    ).grid(sticky=tk.W, row=cur_row, column=1, padx=PADX)
+    ).grid(sticky=tk.W, row=cur_row, column=1, padx=PADX, pady=BOXY)
     cur_row += 1
 
     return conf_frame

--- a/plugins/coriolis.py
+++ b/plugins/coriolis.py
@@ -91,7 +91,7 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str | None, is_beta: bool) -> tk.Fr
     # LANG: Settings>Coriolis: Help/hint for changing coriolis URLs
     nb.Label(conf_frame, text=_(
         "Set the URL to use with coriolis.io ship loadouts. Note that this MUST end with '/import?data='"
-    )).grid(sticky=tk.EW, row=cur_row, column=0, columnspan=3)
+    )).grid(sticky=tk.EW, row=cur_row, column=0, padx=PADX, columnspan=3)
     cur_row += 1
 
     # LANG: Settings>Coriolis: Label for 'NOT alpha/beta game version' URL

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -2098,13 +2098,15 @@ def plugin_prefs(parent, cmdr: str, is_beta: bool) -> Frame:
 
     eddnframe = nb.Frame(parent)
 
+    cur_row = 0
     HyperlinkLabel(
         eddnframe,
         text='Elite Dangerous Data Network',
         background=nb.Label().cget('background'),
         url='https://github.com/EDCD/EDDN#eddn---elite-dangerous-data-network',
         underline=True
-    ).grid(padx=PADX, sticky=tk.W)  # Don't translate
+    ).grid(row=cur_row, padx=PADX, sticky=tk.W)  # Don't translate
+    cur_row += 1
 
     this.eddn_station = tk.IntVar(value=(output & config.OUT_EDDN_SEND_STATION_DATA) and 1)
     this.eddn_station_button = nb.Checkbutton(
@@ -2114,8 +2116,9 @@ def plugin_prefs(parent, cmdr: str, is_beta: bool) -> Frame:
         variable=this.eddn_station,
         command=prefsvarchanged
     )  # Output setting
+    this.eddn_station_button.grid(row=cur_row, padx=BUTTONX, pady=(5, 0), sticky=tk.W)
+    cur_row += 1
 
-    this.eddn_station_button.grid(padx=BUTTONX, pady=(5, 0), sticky=tk.W)
     this.eddn_system = tk.IntVar(value=(output & config.OUT_EDDN_SEND_NON_STATION) and 1)
     # Output setting new in E:D 2.2
     this.eddn_system_button = nb.Checkbutton(
@@ -2125,8 +2128,9 @@ def plugin_prefs(parent, cmdr: str, is_beta: bool) -> Frame:
         variable=this.eddn_system,
         command=prefsvarchanged
     )
+    this.eddn_system_button.grid(row=cur_row, padx=BUTTONX, pady=(5, 0), sticky=tk.W)
+    cur_row += 1
 
-    this.eddn_system_button.grid(padx=BUTTONX, pady=(5, 0), sticky=tk.W)
     this.eddn_delay = tk.IntVar(value=(output & config.OUT_EDDN_DELAY) and 1)
     # Output setting under 'Send system and scan data to the Elite Dangerous Data Network' new in E:D 2.2
     this.eddn_delay_button = nb.Checkbutton(
@@ -2135,7 +2139,7 @@ def plugin_prefs(parent, cmdr: str, is_beta: bool) -> Frame:
         text=_('Delay sending until docked'),
         variable=this.eddn_delay
     )
-    this.eddn_delay_button.grid(padx=BUTTONX, sticky=tk.W)
+    this.eddn_delay_button.grid(row=cur_row, padx=BUTTONX, sticky=tk.W)
 
     return eddnframe
 

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -2089,7 +2089,7 @@ def plugin_prefs(parent, cmdr: str, is_beta: bool) -> Frame:
     """
     PADX = 10  # noqa: N806
     BUTTONX = 12  # noqa: N806 # indent Checkbuttons and Radiobuttons
-    PADY = 2  # noqa: N806
+    PADY = 1  # noqa: N806
 
     if prefsVersion.shouldSetDefaults('0.0.0.0', not bool(config.get_int('output'))):
         output: int = config.OUT_EDDN_SEND_STATION_DATA | config.OUT_EDDN_SEND_NON_STATION  # default settings
@@ -2106,7 +2106,7 @@ def plugin_prefs(parent, cmdr: str, is_beta: bool) -> Frame:
         background=nb.Label().cget('background'),
         url='https://github.com/EDCD/EDDN#eddn---elite-dangerous-data-network',
         underline=True
-    ).grid(row=cur_row, padx=PADX, sticky=tk.W)  # Don't translate
+    ).grid(row=cur_row, padx=PADX, pady=PADY, sticky=tk.W)  # Don't translate
     cur_row += 1
 
     this.eddn_station = tk.IntVar(value=(output & config.OUT_EDDN_SEND_STATION_DATA) and 1)

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -2089,6 +2089,7 @@ def plugin_prefs(parent, cmdr: str, is_beta: bool) -> Frame:
     """
     PADX = 10  # noqa: N806
     BUTTONX = 12  # noqa: N806 # indent Checkbuttons and Radiobuttons
+    PADY = 2
 
     if prefsVersion.shouldSetDefaults('0.0.0.0', not bool(config.get_int('output'))):
         output: int = config.OUT_EDDN_SEND_STATION_DATA | config.OUT_EDDN_SEND_NON_STATION  # default settings
@@ -2116,7 +2117,7 @@ def plugin_prefs(parent, cmdr: str, is_beta: bool) -> Frame:
         variable=this.eddn_station,
         command=prefsvarchanged
     )  # Output setting
-    this.eddn_station_button.grid(row=cur_row, padx=BUTTONX, pady=(5, 0), sticky=tk.W)
+    this.eddn_station_button.grid(row=cur_row, padx=BUTTONX, pady=PADY, sticky=tk.W)
     cur_row += 1
 
     this.eddn_system = tk.IntVar(value=(output & config.OUT_EDDN_SEND_NON_STATION) and 1)
@@ -2128,7 +2129,7 @@ def plugin_prefs(parent, cmdr: str, is_beta: bool) -> Frame:
         variable=this.eddn_system,
         command=prefsvarchanged
     )
-    this.eddn_system_button.grid(row=cur_row, padx=BUTTONX, pady=(5, 0), sticky=tk.W)
+    this.eddn_system_button.grid(row=cur_row, padx=BUTTONX, pady=PADY, sticky=tk.W)
     cur_row += 1
 
     this.eddn_delay = tk.IntVar(value=(output & config.OUT_EDDN_DELAY) and 1)
@@ -2139,7 +2140,7 @@ def plugin_prefs(parent, cmdr: str, is_beta: bool) -> Frame:
         text=_('Delay sending until docked'),
         variable=this.eddn_delay
     )
-    this.eddn_delay_button.grid(row=cur_row, padx=BUTTONX, sticky=tk.W)
+    this.eddn_delay_button.grid(row=cur_row, padx=BUTTONX, pady=PADY, sticky=tk.W)
 
     return eddnframe
 

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -2089,7 +2089,7 @@ def plugin_prefs(parent, cmdr: str, is_beta: bool) -> Frame:
     """
     PADX = 10  # noqa: N806
     BUTTONX = 12  # noqa: N806 # indent Checkbuttons and Radiobuttons
-    PADY = 2
+    PADY = 2  # noqa: N806
 
     if prefsVersion.shouldSetDefaults('0.0.0.0', not bool(config.get_int('output'))):
         output: int = config.OUT_EDDN_SEND_STATION_DATA | config.OUT_EDDN_SEND_NON_STATION  # default settings

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -294,6 +294,7 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str | None, is_beta: bool) -> tk.Fr
     PADX = 10  # noqa: N806
     BUTTONX = 12  # noqa: N806
     PADY = 2  # noqa: N806
+    SEPY = 10 # noqa: N806
 
     frame = nb.Frame(parent)
     frame.columnconfigure(1, weight=1)
@@ -319,7 +320,9 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str | None, is_beta: bool) -> tk.Fr
         this.log_button.grid(row=cur_row, columnspan=2, padx=BUTTONX, pady=(5, 0), sticky=tk.W)
         cur_row += 1
 
-    nb.Label(frame).grid(row=cur_row, sticky=tk.W)  # big spacer
+    ttk.Separator(frame, orient=tk.HORIZONTAL).grid(
+        columnspan=2, padx=PADX, pady=SEPY, sticky=tk.EW, row=cur_row
+    )
     cur_row += 1
 
     this.label = HyperlinkLabel(

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -298,13 +298,15 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str | None, is_beta: bool) -> tk.Fr
     frame = nb.Frame(parent)
     frame.columnconfigure(1, weight=1)
 
+    cur_row = 0
     HyperlinkLabel(
         frame,
         text='Elite Dangerous Star Map',
         background=nb.Label().cget('background'),
         url='https://www.edsm.net/',
         underline=True
-    ).grid(columnspan=2, padx=PADX, sticky=tk.W)
+    ).grid(row=cur_row, columnspan=2, padx=PADX, sticky=tk.W)
+    cur_row += 1
 
     this.log = tk.IntVar(value=config.get_int('edsm_out') and 1)
     this.log_button = nb.Checkbutton(
@@ -314,9 +316,11 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str | None, is_beta: bool) -> tk.Fr
         command=prefsvarchanged
     )
     if this.log_button:
-        this.log_button.grid(columnspan=2, padx=BUTTONX, pady=(5, 0), sticky=tk.W)
+        this.log_button.grid(row=cur_row, columnspan=2, padx=BUTTONX, pady=(5, 0), sticky=tk.W)
+        cur_row += 1
 
-    nb.Label(frame).grid(sticky=tk.W)  # big spacer
+    nb.Label(frame).grid(row=cur_row, sticky=tk.W)  # big spacer
+    cur_row += 1
 
     this.label = HyperlinkLabel(
         frame,
@@ -325,10 +329,10 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str | None, is_beta: bool) -> tk.Fr
         url='https://www.edsm.net/settings/api',
         underline=True
     )
-    cur_row = 10
     if this.label:
-        this.label.grid(columnspan=2, padx=PADX, sticky=tk.W)
+        this.label.grid(row=cur_row, columnspan=2, padx=PADX, sticky=tk.W)
     # LANG: Game Commander name label in EDSM settings
+    cur_row += 1
     this.cmdr_label = nb.Label(frame, text=_('Cmdr'))
     this.cmdr_label.grid(row=cur_row, padx=PADX, sticky=tk.W)
     this.cmdr_text = nb.Label(frame)
@@ -347,6 +351,7 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str | None, is_beta: bool) -> tk.Fr
     this.apikey_label.grid(row=cur_row, padx=PADX, sticky=tk.W)
     this.apikey = nb.Entry(frame, show="*", width=50)
     this.apikey.grid(row=cur_row, column=1, padx=PADX, pady=PADY, sticky=tk.EW)
+    cur_row += 1
 
     prefs_cmdr_changed(cmdr, is_beta)
 
@@ -358,7 +363,7 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str | None, is_beta: bool) -> tk.Fr
         variable=show_password_var,
         command=toggle_password_visibility
     )
-    show_password_checkbox.grid(columnspan=2, padx=BUTTONX, pady=(5, 0), sticky=tk.W)
+    show_password_checkbox.grid(row=cur_row, columnspan=2, padx=BUTTONX, pady=(5, 0), sticky=tk.W)
 
     return frame
 

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -293,8 +293,9 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str | None, is_beta: bool) -> tk.Fr
     """
     PADX = 10  # noqa: N806
     BUTTONX = 12  # noqa: N806
-    PADY = 2  # noqa: N806
-    SEPY = 10 # noqa: N806
+    PADY = 1  # noqa: N806
+    BOXY = 2  # noqa: N806
+    SEPY = 10  # noqa: N806
 
     frame = nb.Frame(parent)
     frame.columnconfigure(1, weight=1)
@@ -306,7 +307,7 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str | None, is_beta: bool) -> tk.Fr
         background=nb.Label().cget('background'),
         url='https://www.edsm.net/',
         underline=True
-    ).grid(row=cur_row, columnspan=2, padx=PADX, sticky=tk.W)
+    ).grid(row=cur_row, columnspan=2, padx=PADX, pady=PADY, sticky=tk.W)
     cur_row += 1
 
     this.log = tk.IntVar(value=config.get_int('edsm_out') and 1)
@@ -317,7 +318,7 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str | None, is_beta: bool) -> tk.Fr
         command=prefsvarchanged
     )
     if this.log_button:
-        this.log_button.grid(row=cur_row, columnspan=2, padx=BUTTONX, pady=(5, 0), sticky=tk.W)
+        this.log_button.grid(row=cur_row, columnspan=2, padx=BUTTONX, pady=PADY, sticky=tk.W)
         cur_row += 1
 
     ttk.Separator(frame, orient=tk.HORIZONTAL).grid(
@@ -333,27 +334,27 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str | None, is_beta: bool) -> tk.Fr
         underline=True
     )
     if this.label:
-        this.label.grid(row=cur_row, columnspan=2, padx=PADX, sticky=tk.W)
+        this.label.grid(row=cur_row, columnspan=2, padx=PADX, pady=PADY, sticky=tk.W)
     # LANG: Game Commander name label in EDSM settings
     cur_row += 1
     this.cmdr_label = nb.Label(frame, text=_('Cmdr'))
-    this.cmdr_label.grid(row=cur_row, padx=PADX, sticky=tk.W)
+    this.cmdr_label.grid(row=cur_row, padx=PADX, pady=PADY, sticky=tk.W)
     this.cmdr_text = nb.Label(frame)
-    this.cmdr_text.grid(row=cur_row, column=1, padx=PADX, pady=PADY, sticky=tk.W)
+    this.cmdr_text.grid(row=cur_row, column=1, padx=PADX, pady=BOXY, sticky=tk.W)
 
     cur_row += 1
     # LANG: EDSM Commander name label in EDSM settings
     this.user_label = nb.Label(frame, text=_('Commander Name'))
-    this.user_label.grid(row=cur_row, padx=PADX, sticky=tk.W)
+    this.user_label.grid(row=cur_row, padx=PADX, pady=PADY, sticky=tk.W)
     this.user = nb.Entry(frame)
-    this.user.grid(row=cur_row, column=1, padx=PADX, pady=PADY, sticky=tk.EW)
+    this.user.grid(row=cur_row, column=1, padx=PADX, pady=BOXY, sticky=tk.EW)
 
     cur_row += 1
     # LANG: EDSM API key label
     this.apikey_label = nb.Label(frame, text=_('API Key'))
-    this.apikey_label.grid(row=cur_row, padx=PADX, sticky=tk.W)
+    this.apikey_label.grid(row=cur_row, padx=PADX, pady=PADY, sticky=tk.W)
     this.apikey = nb.Entry(frame, show="*", width=50)
-    this.apikey.grid(row=cur_row, column=1, padx=PADX, pady=PADY, sticky=tk.EW)
+    this.apikey.grid(row=cur_row, column=1, padx=PADX, pady=BOXY, sticky=tk.EW)
     cur_row += 1
 
     prefs_cmdr_changed(cmdr, is_beta)
@@ -366,7 +367,7 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str | None, is_beta: bool) -> tk.Fr
         variable=show_password_var,
         command=toggle_password_visibility
     )
-    show_password_checkbox.grid(row=cur_row, columnspan=2, padx=BUTTONX, pady=(5, 0), sticky=tk.W)
+    show_password_checkbox.grid(row=cur_row, columnspan=2, padx=BUTTONX, pady=PADY, sticky=tk.W)
 
     return frame
 

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -247,9 +247,10 @@ def toggle_password_visibility():
 
 def plugin_prefs(parent: ttk.Notebook, cmdr: str, is_beta: bool) -> tk.Frame:
     """Plugin Preferences UI hook."""
-    x_padding = 10
-    x_button_padding = 12  # indent Checkbuttons and Radiobuttons
-    y_padding = 2		# close spacing
+    PADX = 10
+    BUTTONX = 12  # indent Checkbuttons and Radiobuttons
+    PADY = 2  # close spacing
+    SEPY = 10  # seperator line spacing
     cur_row = 0
 
     frame = nb.Frame(parent)
@@ -257,7 +258,7 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str, is_beta: bool) -> tk.Frame:
 
     HyperlinkLabel(
         frame, text='Inara', background=nb.Label().cget('background'), url='https://inara.cz/', underline=True
-    ).grid(row=cur_row, columnspan=2, padx=x_padding, sticky=tk.W)  # Don't translate
+    ).grid(row=cur_row, columnspan=2, padx=PADX, sticky=tk.W)  # Don't translate
     cur_row += 1
 
     this.log = tk.IntVar(value=config.get_int('inara_out') and 1)
@@ -268,10 +269,12 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str, is_beta: bool) -> tk.Frame:
         command=prefsvarchanged
     )
 
-    this.log_button.grid(row=cur_row, columnspan=2, padx=x_button_padding, pady=(5, 0), sticky=tk.W)
+    this.log_button.grid(row=cur_row, columnspan=2, padx=BUTTONX, pady=(5, 0), sticky=tk.W)
     cur_row += 1
 
-    nb.Label(frame).grid(row=cur_row, sticky=tk.W)  # big spacer
+    ttk.Separator(frame, orient=tk.HORIZONTAL).grid(
+        columnspan=2, padx=PADX, pady=SEPY, sticky=tk.EW, row=cur_row
+    )
     cur_row += 1
 
     # Section heading in settings
@@ -283,14 +286,14 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str, is_beta: bool) -> tk.Frame:
         underline=True
     )
 
-    this.label.grid(row=cur_row, columnspan=2, padx=x_padding, sticky=tk.W)
+    this.label.grid(row=cur_row, columnspan=2, padx=PADX, sticky=tk.W)
     cur_row += 1
 
     # LANG: Inara API key label
     this.apikey_label = nb.Label(frame, text=_('API Key'))  # Inara setting
-    this.apikey_label.grid(row=cur_row, padx=x_padding, sticky=tk.W)
+    this.apikey_label.grid(row=cur_row, padx=PADX, sticky=tk.W)
     this.apikey = nb.Entry(frame, show="*", width=50)
-    this.apikey.grid(row=cur_row, column=1, padx=x_padding, pady=y_padding, sticky=tk.EW)
+    this.apikey.grid(row=cur_row, column=1, padx=PADX, pady=PADY, sticky=tk.EW)
     cur_row += 1
 
     prefs_cmdr_changed(cmdr, is_beta)
@@ -302,7 +305,7 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str, is_beta: bool) -> tk.Frame:
         variable=show_password_var,
         command=toggle_password_visibility,
     )
-    show_password_checkbox.grid(row=cur_row, columnspan=2, padx=x_padding, pady=(5, 0), sticky=tk.W)
+    show_password_checkbox.grid(row=cur_row, columnspan=2, padx=BUTTONX, pady=(5, 0), sticky=tk.W)
 
     return frame
 

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -247,11 +247,11 @@ def toggle_password_visibility():
 
 def plugin_prefs(parent: ttk.Notebook, cmdr: str, is_beta: bool) -> tk.Frame:
     """Plugin Preferences UI hook."""
-    PADX = 10
-    BUTTONX = 12  # indent Checkbuttons and Radiobuttons
-    PADY = 2  # close spacing
-    SEPY = 10  # seperator line spacing
-    cur_row = 0
+    PADX = 10  # noqa: N806
+    BUTTONX = 12  # noqa: N806  # indent Checkbuttons and Radiobuttons
+    PADY = 2  # noqa: N806  # close spacing
+    SEPY = 10  # noqa: N806  # seperator line spacing
+    cur_row = 0  # noqa: N806
 
     frame = nb.Frame(parent)
     frame.columnconfigure(1, weight=1)

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -249,16 +249,17 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str, is_beta: bool) -> tk.Frame:
     """Plugin Preferences UI hook."""
     PADX = 10  # noqa: N806
     BUTTONX = 12  # noqa: N806  # indent Checkbuttons and Radiobuttons
-    PADY = 2  # noqa: N806  # close spacing
+    PADY = 1  # noqa: N806  # close spacing
+    BOXY = 2  # noqa: N806  # box spacing
     SEPY = 10  # noqa: N806  # seperator line spacing
-    cur_row = 0  # noqa: N806
+    cur_row = 0
 
     frame = nb.Frame(parent)
     frame.columnconfigure(1, weight=1)
 
     HyperlinkLabel(
         frame, text='Inara', background=nb.Label().cget('background'), url='https://inara.cz/', underline=True
-    ).grid(row=cur_row, columnspan=2, padx=PADX, sticky=tk.W)  # Don't translate
+    ).grid(row=cur_row, columnspan=2, padx=PADX, pady=PADY, sticky=tk.W)  # Don't translate
     cur_row += 1
 
     this.log = tk.IntVar(value=config.get_int('inara_out') and 1)
@@ -269,7 +270,7 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str, is_beta: bool) -> tk.Frame:
         command=prefsvarchanged
     )
 
-    this.log_button.grid(row=cur_row, columnspan=2, padx=BUTTONX, pady=(5, 0), sticky=tk.W)
+    this.log_button.grid(row=cur_row, columnspan=2, padx=BUTTONX, pady=PADY, sticky=tk.W)
     cur_row += 1
 
     ttk.Separator(frame, orient=tk.HORIZONTAL).grid(
@@ -286,14 +287,14 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str, is_beta: bool) -> tk.Frame:
         underline=True
     )
 
-    this.label.grid(row=cur_row, columnspan=2, padx=PADX, sticky=tk.W)
+    this.label.grid(row=cur_row, columnspan=2, padx=PADX, pady=PADY, sticky=tk.W)
     cur_row += 1
 
     # LANG: Inara API key label
     this.apikey_label = nb.Label(frame, text=_('API Key'))  # Inara setting
-    this.apikey_label.grid(row=cur_row, padx=PADX, sticky=tk.W)
+    this.apikey_label.grid(row=cur_row, padx=PADX, pady=PADY, sticky=tk.W)
     this.apikey = nb.Entry(frame, show="*", width=50)
-    this.apikey.grid(row=cur_row, column=1, padx=PADX, pady=PADY, sticky=tk.EW)
+    this.apikey.grid(row=cur_row, column=1, padx=PADX, pady=BOXY, sticky=tk.EW)
     cur_row += 1
 
     prefs_cmdr_changed(cmdr, is_beta)
@@ -305,7 +306,7 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str, is_beta: bool) -> tk.Frame:
         variable=show_password_var,
         command=toggle_password_visibility,
     )
-    show_password_checkbox.grid(row=cur_row, columnspan=2, padx=BUTTONX, pady=(5, 0), sticky=tk.W)
+    show_password_checkbox.grid(row=cur_row, columnspan=2, padx=BUTTONX, pady=PADY, sticky=tk.W)
 
     return frame
 

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -250,13 +250,15 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str, is_beta: bool) -> tk.Frame:
     x_padding = 10
     x_button_padding = 12  # indent Checkbuttons and Radiobuttons
     y_padding = 2		# close spacing
+    cur_row = 0
 
     frame = nb.Frame(parent)
     frame.columnconfigure(1, weight=1)
 
     HyperlinkLabel(
         frame, text='Inara', background=nb.Label().cget('background'), url='https://inara.cz/', underline=True
-    ).grid(columnspan=2, padx=x_padding, sticky=tk.W)  # Don't translate
+    ).grid(row=cur_row, columnspan=2, padx=x_padding, sticky=tk.W)  # Don't translate
+    cur_row += 1
 
     this.log = tk.IntVar(value=config.get_int('inara_out') and 1)
     this.log_button = nb.Checkbutton(
@@ -266,9 +268,11 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str, is_beta: bool) -> tk.Frame:
         command=prefsvarchanged
     )
 
-    this.log_button.grid(columnspan=2, padx=x_button_padding, pady=(5, 0), sticky=tk.W)
+    this.log_button.grid(row=cur_row, columnspan=2, padx=x_button_padding, pady=(5, 0), sticky=tk.W)
+    cur_row += 1
 
-    nb.Label(frame).grid(sticky=tk.W)  # big spacer
+    nb.Label(frame).grid(row=cur_row, sticky=tk.W)  # big spacer
+    cur_row += 1
 
     # Section heading in settings
     this.label = HyperlinkLabel(
@@ -279,13 +283,15 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str, is_beta: bool) -> tk.Frame:
         underline=True
     )
 
-    this.label.grid(columnspan=2, padx=x_padding, sticky=tk.W)
+    this.label.grid(row=cur_row, columnspan=2, padx=x_padding, sticky=tk.W)
+    cur_row += 1
 
     # LANG: Inara API key label
     this.apikey_label = nb.Label(frame, text=_('API Key'))  # Inara setting
-    this.apikey_label.grid(row=12, padx=x_padding, sticky=tk.W)
+    this.apikey_label.grid(row=cur_row, padx=x_padding, sticky=tk.W)
     this.apikey = nb.Entry(frame, show="*", width=50)
-    this.apikey.grid(row=12, column=1, padx=x_padding, pady=y_padding, sticky=tk.EW)
+    this.apikey.grid(row=cur_row, column=1, padx=x_padding, pady=y_padding, sticky=tk.EW)
+    cur_row += 1
 
     prefs_cmdr_changed(cmdr, is_beta)
 
@@ -296,7 +302,7 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str, is_beta: bool) -> tk.Frame:
         variable=show_password_var,
         command=toggle_password_visibility,
     )
-    show_password_checkbox.grid(columnspan=2, padx=x_padding, pady=(5, 0), sticky=tk.W)
+    show_password_checkbox.grid(row=cur_row, columnspan=2, padx=x_padding, pady=(5, 0), sticky=tk.W)
 
     return frame
 

--- a/prefs.py
+++ b/prefs.py
@@ -289,8 +289,9 @@ class PreferencesDialog(tk.Toplevel):
         self.PADX = 10
         self.BUTTONX = 12  # indent Checkbuttons and Radiobuttons
         self.LISTX = 25  # indent listed items
-        self.PADY = 2  # close spacing
-        self.SEPY = 10 # seperator line spacing
+        self.PADY = 1  # close spacing
+        self.BOXY = 2  # box spacing
+        self.SEPY = 10  # seperator line spacing
 
         # Set up different tabs
         self.__setup_output_tab(notebook)
@@ -353,7 +354,7 @@ class PreferencesDialog(tk.Toplevel):
 
         # LANG: Settings > Output - choosing what data to save to files
         self.out_label = nb.Label(output_frame, text=_('Please choose what data to save'))
-        self.out_label.grid(columnspan=2, padx=self.PADX, sticky=tk.W, row=row.get())
+        self.out_label.grid(columnspan=2, padx=self.PADX, pady=self.PADY, sticky=tk.W, row=row.get())
 
         self.out_csv = tk.IntVar(value=1 if (output & config.OUT_MKT_CSV) else 0)
         self.out_csv_button = nb.Checkbutton(
@@ -362,7 +363,7 @@ class PreferencesDialog(tk.Toplevel):
             variable=self.out_csv,
             command=self.outvarchanged
         )
-        self.out_csv_button.grid(columnspan=2, padx=self.BUTTONX, sticky=tk.W, row=row.get())
+        self.out_csv_button.grid(columnspan=2, padx=self.BUTTONX, pady=self.PADY, sticky=tk.W, row=row.get())
 
         self.out_td = tk.IntVar(value=1 if (output & config.OUT_MKT_TD) else 0)
         self.out_td_button = nb.Checkbutton(
@@ -371,7 +372,7 @@ class PreferencesDialog(tk.Toplevel):
             variable=self.out_td,
             command=self.outvarchanged
         )
-        self.out_td_button.grid(columnspan=2, padx=self.BUTTONX, sticky=tk.W, row=row.get())
+        self.out_td_button.grid(columnspan=2, padx=self.BUTTONX, pady=self.PADY, sticky=tk.W, row=row.get())
         self.out_ship = tk.IntVar(value=1 if (output & config.OUT_SHIP) else 0)
 
         # Output setting
@@ -381,7 +382,7 @@ class PreferencesDialog(tk.Toplevel):
             variable=self.out_ship,
             command=self.outvarchanged
         )
-        self.out_ship_button.grid(columnspan=2, padx=self.BUTTONX, pady=(5, 0), sticky=tk.W, row=row.get())
+        self.out_ship_button.grid(columnspan=2, padx=self.BUTTONX, pady=self.PADY, sticky=tk.W, row=row.get())
         self.out_auto = tk.IntVar(value=0 if output & config.OUT_MKT_MANUAL else 1)  # inverted
 
         # Output setting
@@ -391,17 +392,17 @@ class PreferencesDialog(tk.Toplevel):
             variable=self.out_auto,
             command=self.outvarchanged
         )
-        self.out_auto_button.grid(columnspan=2, padx=self.BUTTONX, pady=(5, 0), sticky=tk.W, row=row.get())
+        self.out_auto_button.grid(columnspan=2, padx=self.BUTTONX, pady=self.PADY, sticky=tk.W, row=row.get())
 
         self.outdir = tk.StringVar()
         self.outdir.set(str(config.get_str('outdir')))
         # LANG: Settings > Output - Label for "where files are located"
         self.outdir_label = nb.Label(output_frame, text=_('File location')+':')  # Section heading in settings
         # Type ignored due to incorrect type annotation. a 2 tuple does padding for each side
-        self.outdir_label.grid(padx=self.PADX, pady=(0, self.PADY), sticky=tk.W, row=row.get())  # type: ignore
+        self.outdir_label.grid(padx=self.PADX, pady=self.PADY, sticky=tk.W, row=row.get())  # type: ignore
 
         self.outdir_entry = nb.Entry(output_frame, takefocus=False)
-        self.outdir_entry.grid(columnspan=2, padx=self.PADX, pady=(0, self.PADY), sticky=tk.EW, row=row.get())
+        self.outdir_entry.grid(columnspan=2, padx=self.PADX, pady=self.BOXY, sticky=tk.EW, row=row.get())
 
         if sys.platform == 'darwin':
             text = (_('Change...'))  # LANG: macOS Preferences - files location selection button
@@ -449,9 +450,9 @@ class PreferencesDialog(tk.Toplevel):
             config_frame,
             # LANG: Settings > Configuration - Label for Journal files location
             text=_('E:D journal file location')+':'
-        ).grid(columnspan=4, padx=self.PADX, sticky=tk.W, row=row.get())
+        ).grid(columnspan=4, padx=self.PADX, pady=self.PADY, sticky=tk.W, row=row.get())
 
-        self.logdir_entry.grid(columnspan=4, padx=self.PADX, pady=(0, self.PADY), sticky=tk.EW, row=row.get())
+        self.logdir_entry.grid(columnspan=4, padx=self.PADX, pady=self.BOXY, sticky=tk.EW, row=row.get())
 
         if sys.platform == 'darwin':
             text = (_('Change...'))  # LANG: macOS Preferences - files location selection button
@@ -488,14 +489,14 @@ class PreferencesDialog(tk.Toplevel):
         nb.Label(
                 config_frame,
                 text=_('CAPI Settings')  # LANG: Settings > Configuration - Label for CAPI section
-            ).grid(padx=self.PADX, sticky=tk.W, row=row.get())
+            ).grid(padx=self.PADX, pady=self.PADY, sticky=tk.W, row=row.get())
 
         nb.Checkbutton(
                 config_frame,
                 # LANG: Configuration - Enable or disable the Fleet Carrier CAPI calls
                 text=_('Enable Fleetcarrier CAPI Queries'),
                 variable=self.capi_fleetcarrier
-            ).grid(columnspan=4, padx=self.BUTTONX, pady=(5, 0), sticky=tk.W, row=row.get())
+            ).grid(columnspan=4, padx=self.BUTTONX, pady=self.PADY, sticky=tk.W, row=row.get())
 
         if sys.platform in ('darwin', 'win32'):
             ttk.Separator(config_frame, orient=tk.HORIZONTAL).grid(
@@ -512,7 +513,7 @@ class PreferencesDialog(tk.Toplevel):
                     text=_('Keyboard shortcut') if  # LANG: Hotkey/Shortcut settings prompt on OSX
                     sys.platform == 'darwin' else
                     _('Hotkey')  # LANG: Hotkey/Shortcut settings prompt on Windows
-                ).grid(padx=self.PADX, sticky=tk.W, row=cur_row)
+                ).grid(padx=self.PADX, pady=self.PADY, sticky=tk.W, row=cur_row)
 
                 if sys.platform == 'darwin' and not was_accessible_at_launch:
                     if AXIsProcessTrusted():
@@ -522,7 +523,7 @@ class PreferencesDialog(tk.Toplevel):
                             # LANG: macOS Preferences > Configuration - restart the app message
                             text=_('Re-start {APP} to use shortcuts').format(APP=applongname),
                             foreground='firebrick'
-                        ).grid(padx=self.PADX, sticky=tk.W, row=cur_row)
+                        ).grid(padx=self.PADX, pady=self.PADY, sticky=tk.W, row=cur_row)
 
                     else:
                         # Shortcut settings prompt on OSX
@@ -531,11 +532,11 @@ class PreferencesDialog(tk.Toplevel):
                             # LANG: macOS - Configuration - need to grant the app permission for keyboard shortcuts
                             text=_('{APP} needs permission to use shortcuts').format(APP=applongname),
                             foreground='firebrick'
-                        ).grid(columnspan=4, padx=self.PADX, sticky=tk.W, row=cur_row)
+                        ).grid(columnspan=4, padx=self.PADX, pady=self.PADY, sticky=tk.W, row=cur_row)
 
                         # LANG: Shortcut settings button on OSX
                         nb.Button(config_frame, text=_('Open System Preferences'), command=self.enableshortcuts).grid(
-                            padx=self.PADX, sticky=tk.E, row=cur_row
+                            padx=self.PADX, pady=self.BOXY, sticky=tk.E, row=cur_row
                         )
 
                 else:
@@ -551,7 +552,7 @@ class PreferencesDialog(tk.Toplevel):
 
                     self.hotkey_text.bind('<FocusIn>', self.hotkeystart)
                     self.hotkey_text.bind('<FocusOut>', self.hotkeyend)
-                    self.hotkey_text.grid(column=1, columnspan=2, pady=(5, 0), sticky=tk.W, row=cur_row)
+                    self.hotkey_text.grid(column=1, columnspan=2, pady=self.BOXY, sticky=tk.W, row=cur_row)
 
                 # Hotkey/Shortcut setting
                 self.hotkey_only_btn = nb.Checkbutton(
@@ -562,7 +563,7 @@ class PreferencesDialog(tk.Toplevel):
                     state=tk.NORMAL if self.hotkey_code else tk.DISABLED
                 )
 
-                self.hotkey_only_btn.grid(columnspan=4, padx=self.BUTTONX, pady=(5, 0), sticky=tk.W, row=row.get())
+                self.hotkey_only_btn.grid(columnspan=4, padx=self.BUTTONX, pady=self.PADY, sticky=tk.W, row=row.get())
 
                 # Hotkey/Shortcut setting
                 self.hotkey_play_btn = nb.Checkbutton(
@@ -573,7 +574,7 @@ class PreferencesDialog(tk.Toplevel):
                     state=tk.NORMAL if self.hotkey_code else tk.DISABLED
                 )
 
-                self.hotkey_play_btn.grid(columnspan=4, padx=self.BUTTONX, sticky=tk.W, row=row.get())
+                self.hotkey_play_btn.grid(columnspan=4, padx=self.BUTTONX, pady=self.PADY, sticky=tk.W, row=row.get())
 
         # Option to disabled Automatic Check For Updates whilst in-game
         ttk.Separator(config_frame, orient=tk.HORIZONTAL).grid(
@@ -588,7 +589,9 @@ class PreferencesDialog(tk.Toplevel):
             command=self.disable_autoappupdatecheckingame_changed
         )
 
-        self.disable_autoappupdatecheckingame_btn.grid(columnspan=4, padx=self.BUTTONX, sticky=tk.W, row=row.get())
+        self.disable_autoappupdatecheckingame_btn.grid(
+            columnspan=4, padx=self.BUTTONX, pady=self.PADY, sticky=tk.W, row=row.get()
+        )
 
         ttk.Separator(config_frame, orient=tk.HORIZONTAL).grid(
             columnspan=4, padx=self.PADX, pady=self.SEPY, sticky=tk.EW, row=row.get()
@@ -597,7 +600,7 @@ class PreferencesDialog(tk.Toplevel):
         # Settings prompt for preferred ship loadout, system and station info websites
         # LANG: Label for preferred shipyard, system and station 'providers'
         nb.Label(config_frame, text=_('Preferred websites')).grid(
-            columnspan=4, padx=self.PADX, sticky=tk.W, row=row.get()
+            columnspan=4, padx=self.PADX, pady=self.PADY, sticky=tk.W, row=row.get()
         )
 
         with row as cur_row:
@@ -607,13 +610,13 @@ class PreferencesDialog(tk.Toplevel):
             )
             # Setting to decide which ship outfitting website to link to - either E:D Shipyard or Coriolis
             # LANG: Label for Shipyard provider selection
-            nb.Label(config_frame, text=_('Shipyard')).grid(padx=self.PADX, pady=2*self.PADY, sticky=tk.W, row=cur_row)
+            nb.Label(config_frame, text=_('Shipyard')).grid(padx=self.PADX, pady=self.PADY, sticky=tk.W, row=cur_row)
             self.shipyard_button = nb.OptionMenu(
                 config_frame, self.shipyard_provider, self.shipyard_provider.get(), *plug.provides('shipyard_url')
             )
 
             self.shipyard_button.configure(width=15)
-            self.shipyard_button.grid(column=1, sticky=tk.W, row=cur_row)
+            self.shipyard_button.grid(column=1, pady=self.BOXY, sticky=tk.W, row=cur_row)
             # Option for alternate URL opening
             self.alt_shipyard_open = tk.IntVar(value=config.get_int('use_alt_shipyard_open'))
             self.alt_shipyard_open_btn = nb.Checkbutton(
@@ -624,7 +627,7 @@ class PreferencesDialog(tk.Toplevel):
                 command=self.alt_shipyard_open_changed,
             )
 
-            self.alt_shipyard_open_btn.grid(column=2, sticky=tk.W, row=cur_row)
+            self.alt_shipyard_open_btn.grid(column=2, padx=self.PADX, pady=self.PADY, sticky=tk.W, row=cur_row)
 
         with row as cur_row:
             system_provider = config.get_str('system_provider')
@@ -633,7 +636,7 @@ class PreferencesDialog(tk.Toplevel):
             )
 
             # LANG: Configuration - Label for selection of 'System' provider website
-            nb.Label(config_frame, text=_('System')).grid(padx=self.PADX, pady=2*self.PADY, sticky=tk.W, row=cur_row)
+            nb.Label(config_frame, text=_('System')).grid(padx=self.PADX, pady=self.PADY, sticky=tk.W, row=cur_row)
             self.system_button = nb.OptionMenu(
                 config_frame,
                 self.system_provider,
@@ -642,7 +645,7 @@ class PreferencesDialog(tk.Toplevel):
             )
 
             self.system_button.configure(width=15)
-            self.system_button.grid(column=1, sticky=tk.W, row=cur_row)
+            self.system_button.grid(column=1, pady=self.BOXY, sticky=tk.W, row=cur_row)
 
         with row as cur_row:
             station_provider = config.get_str('station_provider')
@@ -651,7 +654,7 @@ class PreferencesDialog(tk.Toplevel):
             )
 
             # LANG: Configuration - Label for selection of 'Station' provider website
-            nb.Label(config_frame, text=_('Station')).grid(padx=self.PADX, pady=2*self.PADY, sticky=tk.W, row=cur_row)
+            nb.Label(config_frame, text=_('Station')).grid(padx=self.PADX, pady=self.PADY, sticky=tk.W, row=cur_row)
             self.station_button = nb.OptionMenu(
                 config_frame,
                 self.station_provider,
@@ -660,7 +663,7 @@ class PreferencesDialog(tk.Toplevel):
             )
 
             self.station_button.configure(width=15)
-            self.station_button.grid(column=1, sticky=tk.W, row=cur_row)
+            self.station_button.grid(column=1, pady=self.BOXY, sticky=tk.W, row=cur_row)
 
         # Set loglevel
         ttk.Separator(config_frame, orient=tk.HORIZONTAL).grid(
@@ -673,7 +676,7 @@ class PreferencesDialog(tk.Toplevel):
                 config_frame,
                 # LANG: Configuration - Label for selection of Log Level
                 text=_('Log Level')
-            ).grid(padx=self.PADX, pady=2*self.PADY, sticky=tk.W, row=cur_row)
+            ).grid(padx=self.PADX, pady=self.PADY, sticky=tk.W, row=cur_row)
 
             current_loglevel = config.get_str('loglevel')
             if not current_loglevel:
@@ -694,14 +697,14 @@ class PreferencesDialog(tk.Toplevel):
             )
 
             self.loglevel_dropdown.configure(width=15)
-            self.loglevel_dropdown.grid(column=1, sticky=tk.W, row=cur_row)
+            self.loglevel_dropdown.grid(column=1, pady=self.BOXY, sticky=tk.W, row=cur_row)
 
             nb.Button(
                 config_frame,
                 # LANG: Label on button used to open a filesystem folder
                 text=_('Open Log Folder'),  # Button that opens a folder in Explorer/Finder
                 command=lambda: help_open_log_folder()
-            ).grid(column=2, padx=(0, self.PADX), sticky=tk.NSEW, row=cur_row)
+            ).grid(column=2, padx=self.PADX, pady=0, sticky=tk.NSEW, row=cur_row)
 
         # Big spacer
         nb.Label(config_frame).grid(sticky=tk.W, row=row.get())
@@ -717,15 +720,17 @@ class PreferencesDialog(tk.Toplevel):
 
         # LANG: UI elements privacy section header in privacy tab of preferences
         nb.Label(privacy_frame, text=_('Main UI privacy options')).grid(
-            row=row.get(), column=0, sticky=tk.W, padx=self.PADX
+            row=row.get(), column=0, sticky=tk.W, padx=self.PADX, pady=self.PADY
         )
 
         nb.Checkbutton(
-            privacy_frame, text=_('Hide private group name in UI'),  # LANG: Hide private group owner name from UI checkbox
+            # LANG: Hide private group owner name from UI checkbox
+            privacy_frame, text=_('Hide private group name in UI'),
             variable=self.hide_private_group
         ).grid(row=row.get(), column=0, padx=self.BUTTONX, pady=self.PADY, sticky=tk.W)
         nb.Checkbutton(
-            privacy_frame, text=_('Hide multi-crew captain name'),  # LANG: Hide multicrew captain name from main UI checkbox
+            # LANG: Hide multicrew captain name from main UI checkbox
+            privacy_frame, text=_('Hide multi-crew captain name'),
             variable=self.hide_multicrew_captain
         ).grid(row=row.get(), column=0, padx=self.BUTTONX, pady=self.PADY, sticky=tk.W)
 
@@ -753,30 +758,34 @@ class PreferencesDialog(tk.Toplevel):
         appearance_frame.columnconfigure(2, weight=1)
         with row as cur_row:
             # LANG: Appearance - Label for selection of application display language
-            nb.Label(appearance_frame, text=_('Language')).grid(padx=self.PADX, sticky=tk.W, row=cur_row)
+            nb.Label(appearance_frame, text=_('Language')).grid(
+                padx=self.PADX, pady=self.PADY, sticky=tk.W, row=cur_row
+            )
             self.lang_button = nb.OptionMenu(appearance_frame, self.lang, self.lang.get(), *self.languages.values())
-            self.lang_button.grid(column=1, columnspan=2, padx=(0, self.PADX), sticky=tk.W, row=cur_row)
+            self.lang_button.grid(column=1, columnspan=2, padx=0, pady=self.BOXY, sticky=tk.W, row=cur_row)
 
         ttk.Separator(appearance_frame, orient=tk.HORIZONTAL).grid(
-            columnspan=3, padx=self.PADX, pady=self.SEPY, sticky=tk.EW, row=row.get()
+            columnspan=4, padx=self.PADX, pady=self.SEPY, sticky=tk.EW, row=row.get()
         )
 
         # Appearance setting
         # LANG: Label for Settings > Appearance > Theme selection
-        nb.Label(appearance_frame, text=_('Theme')).grid(columnspan=3, padx=self.PADX, sticky=tk.W, row=row.get())
+        nb.Label(appearance_frame, text=_('Theme')).grid(
+            columnspan=3, padx=self.PADX, pady=self.PADY, sticky=tk.W, row=row.get()
+        )
 
         # Appearance theme and language setting
         nb.Radiobutton(
             # LANG: Label for 'Default' theme radio button
             appearance_frame, text=_('Default'), variable=self.theme,
             value=theme.THEME_DEFAULT, command=self.themevarchanged
-        ).grid(columnspan=3, padx=self.BUTTONX, sticky=tk.W, row=row.get())
+        ).grid(columnspan=3, padx=self.BUTTONX, pady=self.PADY, sticky=tk.W, row=row.get())
 
         # Appearance theme setting
         nb.Radiobutton(
             # LANG: Label for 'Dark' theme radio button
             appearance_frame, text=_('Dark'), variable=self.theme, value=theme.THEME_DARK, command=self.themevarchanged
-        ).grid(columnspan=3, padx=self.BUTTONX, sticky=tk.W, row=row.get())
+        ).grid(columnspan=3, padx=self.BUTTONX, pady=self.PADY, sticky=tk.W, row=row.get())
 
         if sys.platform == 'win32':
             nb.Radiobutton(
@@ -786,11 +795,11 @@ class PreferencesDialog(tk.Toplevel):
                 variable=self.theme,
                 value=theme.THEME_TRANSPARENT,
                 command=self.themevarchanged
-            ).grid(columnspan=3, padx=self.BUTTONX, sticky=tk.W, row=row.get())
+            ).grid(columnspan=3, padx=self.BUTTONX, pady=self.PADY, sticky=tk.W, row=row.get())
 
         with row as cur_row:
             self.theme_label_0 = nb.Label(appearance_frame, text=self.theme_prompts[0])
-            self.theme_label_0.grid(padx=self.PADX, sticky=tk.W, row=cur_row)
+            self.theme_label_0.grid(padx=self.PADX, pady=self.PADY, sticky=tk.W, row=cur_row)
 
             # Main window
             self.theme_button_0 = nb.ColoredButton(
@@ -801,11 +810,11 @@ class PreferencesDialog(tk.Toplevel):
                 command=lambda: self.themecolorbrowse(0)
             )
 
-            self.theme_button_0.grid(column=1, padx=0, pady=self.PADY, sticky=tk.NSEW, row=cur_row)
+            self.theme_button_0.grid(column=1, padx=0, pady=self.BOXY, sticky=tk.NSEW, row=cur_row)
 
         with row as cur_row:
             self.theme_label_1 = nb.Label(appearance_frame, text=self.theme_prompts[1])
-            self.theme_label_1.grid(padx=self.PADX, sticky=tk.W, row=cur_row)
+            self.theme_label_1.grid(padx=self.PADX, pady=self.PADY, sticky=tk.W, row=cur_row)
             self.theme_button_1 = nb.ColoredButton(
                 appearance_frame,
                 text='  Hutton Orbital  ',  # Do not translate
@@ -813,7 +822,7 @@ class PreferencesDialog(tk.Toplevel):
                 command=lambda: self.themecolorbrowse(1)
             )
 
-            self.theme_button_1.grid(column=1, padx=0, pady=self.PADY, sticky=tk.NSEW, row=cur_row)
+            self.theme_button_1.grid(column=1, padx=0, pady=self.BOXY, sticky=tk.NSEW, row=cur_row)
 
         # UI Scaling
         """
@@ -829,7 +838,7 @@ class PreferencesDialog(tk.Toplevel):
         with row as cur_row:
             # LANG: Appearance - Label for selection of UI scaling
             nb.Label(appearance_frame, text=_('UI Scale Percentage')).grid(
-                padx=self.PADX, pady=2*self.PADY, sticky=tk.W, row=cur_row
+                padx=self.PADX, pady=self.PADY, sticky=tk.W, row=cur_row
             )
 
             self.ui_scale = tk.IntVar()
@@ -845,12 +854,12 @@ class PreferencesDialog(tk.Toplevel):
                 resolution=10,
             )
 
-            self.uiscale_bar.grid(column=1, padx=0, sticky=tk.W, row=cur_row)
+            self.uiscale_bar.grid(column=1, padx=0, pady=self.BOXY, sticky=tk.W, row=cur_row)
             self.ui_scaling_defaultis = nb.Label(
                 appearance_frame,
                 # LANG: Appearance - Help/hint text for UI scaling selection
                 text=_('100 means Default{CR}Restart Required for{CR}changes to take effect!')
-            ).grid(column=3, padx=self.PADX, pady=2*self.PADY, sticky=tk.E, row=cur_row)
+            ).grid(column=3, padx=self.PADX, pady=self.PADY, sticky=tk.E, row=cur_row)
 
         # Transparency slider
         ttk.Separator(appearance_frame, orient=tk.HORIZONTAL).grid(
@@ -860,7 +869,7 @@ class PreferencesDialog(tk.Toplevel):
         with row as cur_row:
             # LANG: Appearance - Label for selection of main window transparency
             nb.Label(appearance_frame, text=_("Main window transparency")).grid(
-                padx=self.PADX, pady=self.PADY*2, sticky=tk.W, row=cur_row
+                padx=self.PADX, pady=self.PADY, sticky=tk.W, row=cur_row
             )
             self.transparency = tk.IntVar()
             self.transparency.set(config.get_int('ui_transparency') or 100)  # Default to 100 for users
@@ -886,12 +895,12 @@ class PreferencesDialog(tk.Toplevel):
             ).grid(
                 column=3,
                 padx=self.PADX,
-                pady=self.PADY*2,
+                pady=self.PADY,
                 sticky=tk.E,
                 row=cur_row
             )
 
-            self.transparency_bar.grid(column=1, padx=0, sticky=tk.W, row=cur_row)
+            self.transparency_bar.grid(column=1, padx=0, pady=self.BOXY, sticky=tk.W, row=cur_row)
 
         # Always on top
         ttk.Separator(appearance_frame, orient=tk.HORIZONTAL).grid(
@@ -905,7 +914,9 @@ class PreferencesDialog(tk.Toplevel):
             variable=self.always_ontop,
             command=self.themevarchanged
         )
-        self.ontop_button.grid(columnspan=3, padx=self.BUTTONX, sticky=tk.W, row=row.get())  # Appearance setting
+        self.ontop_button.grid(
+            columnspan=3, padx=self.BUTTONX, pady=self.PADY, sticky=tk.W, row=row.get()
+        )  # Appearance setting
 
         if sys.platform == 'win32':
             nb.Checkbutton(
@@ -914,7 +925,7 @@ class PreferencesDialog(tk.Toplevel):
                 text=_('Minimize to system tray'),
                 variable=self.minimize_system_tray,
                 command=self.themevarchanged
-            ).grid(columnspan=3, padx=self.BUTTONX, sticky=tk.W, row=row.get())  # Appearance setting
+            ).grid(columnspan=3, padx=self.BUTTONX, pady=self.PADY, sticky=tk.W, row=row.get())  # Appearance setting
 
         nb.Label(appearance_frame).grid(sticky=tk.W)  # big spacer
 
@@ -932,26 +943,27 @@ class PreferencesDialog(tk.Toplevel):
         # Section heading in settings
         # LANG: Label for location of third-party plugins folder
         nb.Label(plugins_frame, text=_('Plugins folder') + ':').grid(
-            padx=self.PADX, pady=(0, self.PADY), sticky=tk.W, row=row.get()
+            padx=self.PADX, pady=self.PADY, sticky=tk.W, row=row.get()
         )
 
         plugdirentry = nb.Entry(plugins_frame, justify=tk.LEFT)
         self.displaypath(plugdir, plugdirentry)
-        plugdirentry.grid(columnspan=2, padx=self.PADX, pady=(0, self.PADY), sticky=tk.EW, row=row.get())
+        plugdirentry.grid(columnspan=2, padx=self.PADX, pady=self.BOXY, sticky=tk.EW, row=row.get())
 
-        nb.Button(
-            plugins_frame,
-            # LANG: Label on button used to open a filesystem folder
-            text=_('Open'),  # Button that opens a folder in Explorer/Finder
-            command=lambda: webbrowser.open(f'file:///{config.plugin_dir_path}')
-        ).grid(column=1, padx=self.PADX, pady=self.PADY, sticky=tk.EW, row=row.get())
+        with row as cur_row:
+            nb.Label(
+                plugins_frame,
+                # Help text in settings
+                # LANG: Tip/label about how to disable plugins
+                text=_("Tip: You can disable a plugin by{CR}adding '{EXT}' to its folder name").format(EXT='.disabled')
+            ).grid(columnspan=2, padx=self.PADX, pady=self.PADY, sticky=tk.EW, row=cur_row)
 
-        nb.Label(
-            plugins_frame,
-            # Help text in settings
-            # LANG: Tip/label about how to disable plugins
-            text=_("Tip: You can disable a plugin by{CR}adding '{EXT}' to its folder name").format(EXT='.disabled')
-        ).grid(columnspan=2, padx=self.PADX, pady=self.PADY, sticky=tk.EW, row=row.get())
+            nb.Button(
+                plugins_frame,
+                # LANG: Label on button used to open a filesystem folder
+                text=_('Open'),  # Button that opens a folder in Explorer/Finder
+                command=lambda: webbrowser.open(f'file:///{config.plugin_dir_path}')
+            ).grid(column=1, padx=self.PADX, pady=self.PADY, sticky=tk.N, row=cur_row)
 
         enabled_plugins = list(filter(lambda x: x.folder and x.module, plug.PLUGINS))
         if len(enabled_plugins):
@@ -962,7 +974,7 @@ class PreferencesDialog(tk.Toplevel):
                 plugins_frame,
                 # LANG: Label on list of enabled plugins
                 text=_('Enabled Plugins')+':'  # List of plugins in settings
-            ).grid(padx=self.PADX, sticky=tk.W, row=row.get())
+            ).grid(padx=self.PADX, pady=self.PADY, sticky=tk.W, row=row.get())
 
             for plugin in enabled_plugins:
                 if plugin.name == plugin.folder:
@@ -971,7 +983,7 @@ class PreferencesDialog(tk.Toplevel):
                 else:
                     label = nb.Label(plugins_frame, text=f'{plugin.folder} ({plugin.name})')
 
-                label.grid(columnspan=2, padx=self.LISTX, sticky=tk.W, row=row.get())
+                label.grid(columnspan=2, padx=self.LISTX, pady=self.PADY, sticky=tk.W, row=row.get())
 
         ############################################################
         # Show which plugins don't have Python 3.x support
@@ -982,7 +994,7 @@ class PreferencesDialog(tk.Toplevel):
             )
             # LANG: Plugins - Label for list of 'enabled' plugins that don't work with Python 3.x
             nb.Label(plugins_frame, text=_('Plugins Without Python 3.x Support')+':').grid(
-                padx=self.PADX, sticky=tk.W, row=row.get()
+                padx=self.PADX, pady=self.PADY, sticky=tk.W, row=row.get()
             )
 
             HyperlinkLabel(
@@ -991,12 +1003,12 @@ class PreferencesDialog(tk.Toplevel):
                 background=nb.Label().cget('background'),
                 url='https://github.com/EDCD/EDMarketConnector/blob/main/PLUGINS.md#migration-from-python-27',
                 underline=True
-            ).grid(columnspan=2, padx=self.PADX, sticky=tk.W, row=row.get())
+            ).grid(columnspan=2, padx=self.PADX, pady=self.PADY, sticky=tk.W, row=row.get())
 
             for plugin in plug.PLUGINS_not_py3:
                 if plugin.folder:  # 'system' ones have this set to None to suppress listing in Plugins prefs tab
                     nb.Label(plugins_frame, text=plugin.name).grid(
-                        columnspan=2, padx=self.LISTX, sticky=tk.W, row=row.get()
+                        columnspan=2, padx=self.LISTX, pady=self.PADY, sticky=tk.W, row=row.get()
                     )
         ############################################################
         # Show disabled plugins
@@ -1004,17 +1016,17 @@ class PreferencesDialog(tk.Toplevel):
         disabled_plugins = list(filter(lambda x: x.folder and not x.module, plug.PLUGINS))
         if len(disabled_plugins):
             ttk.Separator(plugins_frame, orient=tk.HORIZONTAL).grid(
-                columnspan=3, padx=self.PADX*2, pady=self.SEPY, sticky=tk.EW, row=row.get()
+                columnspan=3, padx=self.PADX, pady=self.SEPY, sticky=tk.EW, row=row.get()
             )
             nb.Label(
                 plugins_frame,
                 # LANG: Label on list of user-disabled plugins
                 text=_('Disabled Plugins')+':'  # List of plugins in settings
-            ).grid(padx=self.PADX, sticky=tk.W, row=row.get())
+            ).grid(padx=self.PADX, pady=self.PADY, sticky=tk.W, row=row.get())
 
             for plugin in disabled_plugins:
                 nb.Label(plugins_frame, text=plugin.name).grid(
-                    columnspan=2, padx=self.LISTX, sticky=tk.W, row=row.get()
+                    columnspan=2, padx=self.LISTX, pady=self.PADY, sticky=tk.W, row=row.get()
                 )
 
         # LANG: Label on Settings > Plugins tab

--- a/prefs.py
+++ b/prefs.py
@@ -347,7 +347,7 @@ class PreferencesDialog(tk.Toplevel):
         else:
             output = config.get_int('output')
 
-        row = AutoInc(start=1)
+        row = AutoInc(start=0)
 
         # LANG: Settings > Output - choosing what data to save to files
         self.out_label = nb.Label(output_frame, text=_('Please choose what data to save'))
@@ -396,7 +396,7 @@ class PreferencesDialog(tk.Toplevel):
         # LANG: Settings > Output - Label for "where files are located"
         self.outdir_label = nb.Label(output_frame, text=_('File location')+':')  # Section heading in settings
         # Type ignored due to incorrect type annotation. a 2 tuple does padding for each side
-        self.outdir_label.grid(padx=self.PADX, pady=(5, 0), sticky=tk.W, row=row.get())  # type: ignore
+        self.outdir_label.grid(padx=self.PADX, pady=(0, self.PADY), sticky=tk.W, row=row.get())  # type: ignore
 
         self.outdir_entry = nb.Entry(output_frame, takefocus=False)
         self.outdir_entry.grid(columnspan=2, padx=self.PADX, pady=(0, self.PADY), sticky=tk.EW, row=row.get())
@@ -415,7 +415,7 @@ class PreferencesDialog(tk.Toplevel):
             # LANG: Settings > Output - Label for "where files are located"
             command=lambda: self.filebrowse(_('File location'), self.outdir)
         )
-        self.outbutton.grid(column=1, padx=self.PADX, pady=self.PADY, sticky=tk.NSEW, row=row.get())
+        self.outbutton.grid(column=1, padx=self.PADX, pady=self.PADY, sticky=tk.EW, row=row.get())
 
         nb.Frame(output_frame).grid(row=row.get())  # bottom spacer # TODO: does nothing?
 
@@ -431,7 +431,7 @@ class PreferencesDialog(tk.Toplevel):
     def __setup_config_tab(self, notebook: ttk.Notebook) -> None:  # noqa: CCR001
         config_frame = nb.Frame(notebook)
         config_frame.columnconfigure(1, weight=1)
-        row = AutoInc(start=1)
+        row = AutoInc(start=0)
 
         self.logdir = tk.StringVar()
         default = config.default_journal_dir if config.default_journal_dir_path is not None else ''
@@ -709,21 +709,21 @@ class PreferencesDialog(tk.Toplevel):
         frame = nb.Frame(notebook)
         self.hide_multicrew_captain = tk.BooleanVar(value=config.get_bool('hide_multicrew_captain', default=False))
         self.hide_private_group = tk.BooleanVar(value=config.get_bool('hide_private_group', default=False))
-        row = AutoInc()
+        row = AutoInc(start=0)
 
         # LANG: UI elements privacy section header in privacy tab of preferences
         nb.Label(frame, text=_('Main UI privacy options')).grid(
-            row=row.get(), column=0, sticky=tk.W, padx=self.PADX, pady=self.PADY
+            row=row.get(), column=0, sticky=tk.W, padx=self.PADX
         )
 
         nb.Checkbutton(
             frame, text=_('Hide private group name in UI'),  # LANG: Hide private group owner name from UI checkbox
             variable=self.hide_private_group
-        ).grid(row=row.get(), column=0, padx=self.PADX, pady=self.PADY)
+        ).grid(row=row.get(), column=0, padx=self.BUTTONX, pady=self.PADY, sticky=tk.W)
         nb.Checkbutton(
             frame, text=_('Hide multi-crew captain name'),  # LANG: Hide multicrew captain name from main UI checkbox
             variable=self.hide_multicrew_captain
-        ).grid(row=row.get(), column=0, padx=self.PADX, pady=self.PADY)
+        ).grid(row=row.get(), column=0, padx=self.BUTTONX, pady=self.PADY, sticky=tk.W)
 
         notebook.add(frame, text=_('Privacy'))  # LANG: Preferences privacy tab title
 
@@ -743,7 +743,7 @@ class PreferencesDialog(tk.Toplevel):
             _('Highlighted text'),  # Dark theme color setting
         ]
 
-        row = AutoInc(start=1)
+        row = AutoInc(start=0)
 
         appearance_frame = nb.Frame(notebook)
         appearance_frame.columnconfigure(2, weight=1)
@@ -923,30 +923,29 @@ class PreferencesDialog(tk.Toplevel):
         plugins_frame.columnconfigure(0, weight=1)
         plugdir = tk.StringVar()
         plugdir.set(config.plugin_dir)
-        row = AutoInc(1)
+        row = AutoInc(start=0)
+
+        # Section heading in settings
+        # LANG: Label for location of third-party plugins folder
+        nb.Label(plugins_frame, text=_('Plugins folder') + ':').grid(padx=self.PADX, pady=(0, self.PADY), sticky=tk.W, row=row.get())
 
         plugdirentry = nb.Entry(plugins_frame, justify=tk.LEFT)
         self.displaypath(plugdir, plugdirentry)
-        with row as cur_row:
-            # Section heading in settings
-            # LANG: Label for location of third-party plugins folder
-            nb.Label(plugins_frame, text=_('Plugins folder') + ':').grid(padx=self.PADX, sticky=tk.W, row=cur_row)
+        plugdirentry.grid(columnspan=2, padx=self.PADX, pady=(0, self.PADY), sticky=tk.EW, row=row.get())
 
-            plugdirentry.grid(padx=self.PADX, sticky=tk.EW, row=cur_row)
-
-            nb.Button(
-                plugins_frame,
-                # LANG: Label on button used to open a filesystem folder
-                text=_('Open'),  # Button that opens a folder in Explorer/Finder
-                command=lambda: webbrowser.open(f'file:///{config.plugin_dir_path}')
-            ).grid(column=1, padx=(0, self.PADX), sticky=tk.NSEW, row=cur_row)
+        nb.Button(
+            plugins_frame,
+            # LANG: Label on button used to open a filesystem folder
+            text=_('Open'),  # Button that opens a folder in Explorer/Finder
+            command=lambda: webbrowser.open(f'file:///{config.plugin_dir_path}')
+        ).grid(column=1, padx=self.PADX, pady=self.PADY, sticky=tk.EW, row=row.get())
 
         nb.Label(
             plugins_frame,
             # Help text in settings
             # LANG: Tip/label about how to disable plugins
             text=_("Tip: You can disable a plugin by{CR}adding '{EXT}' to its folder name").format(EXT='.disabled')
-        ).grid(columnspan=2, padx=self.PADX, pady=10, sticky=tk.NSEW, row=row.get())
+        ).grid(columnspan=2, padx=self.PADX, pady=10, sticky=tk.EW, row=row.get())
 
         enabled_plugins = list(filter(lambda x: x.folder and x.module, plug.PLUGINS))
         if len(enabled_plugins):

--- a/prefs.py
+++ b/prefs.py
@@ -288,7 +288,9 @@ class PreferencesDialog(tk.Toplevel):
 
         self.PADX = 10
         self.BUTTONX = 12  # indent Checkbuttons and Radiobuttons
+        self.LISTX = 25  # indent listed items
         self.PADY = 2  # close spacing
+        self.SEPY = 10 # seperator line spacing
 
         # Set up different tabs
         self.__setup_output_tab(notebook)
@@ -457,29 +459,30 @@ class PreferencesDialog(tk.Toplevel):
         else:
             text = (_('Browse...'))  # LANG: NOT-macOS Setting - files location selection button
 
-        self.logbutton = nb.Button(
-            config_frame,
-            text=text,
-            # LANG: Settings > Configuration - Label for Journal files location
-            command=lambda: self.filebrowse(_('E:D journal file location'), self.logdir)
-        )
-        self.logbutton.grid(column=3, padx=self.PADX, pady=self.PADY, sticky=tk.EW, row=row.get())
-
-        if config.default_journal_dir_path:
-            # Appearance theme and language setting
-            nb.Button(
+        with row as cur_row:
+            self.logbutton = nb.Button(
                 config_frame,
-                # LANG: Settings > Configuration - Label on 'reset journal files location to default' button
-                text=_('Default'),
-                command=self.logdir_reset,
-                state=tk.NORMAL if config.get_str('journaldir') else tk.DISABLED
-            ).grid(column=2, pady=self.PADY, sticky=tk.EW, row=row.get())
+                text=text,
+                # LANG: Settings > Configuration - Label for Journal files location
+                command=lambda: self.filebrowse(_('E:D journal file location'), self.logdir)
+            )
+            self.logbutton.grid(column=3, padx=self.PADX, pady=self.PADY, sticky=tk.EW, row=cur_row)
+
+            if config.default_journal_dir_path:
+                # Appearance theme and language setting
+                nb.Button(
+                    config_frame,
+                    # LANG: Settings > Configuration - Label on 'reset journal files location to default' button
+                    text=_('Default'),
+                    command=self.logdir_reset,
+                    state=tk.NORMAL if config.get_str('journaldir') else tk.DISABLED
+                ).grid(column=2, padx=self.PADX, pady=self.PADY, sticky=tk.EW, row=cur_row)
 
         # CAPI settings
         self.capi_fleetcarrier = tk.BooleanVar(value=config.get_bool('capi_fleetcarrier'))
 
         ttk.Separator(config_frame, orient=tk.HORIZONTAL).grid(
-                columnspan=4, padx=self.PADX, pady=self.PADY*4, sticky=tk.EW, row=row.get()
+                columnspan=4, padx=self.PADX, pady=self.SEPY, sticky=tk.EW, row=row.get()
             )
 
         nb.Label(
@@ -492,62 +495,63 @@ class PreferencesDialog(tk.Toplevel):
                 # LANG: Configuration - Enable or disable the Fleet Carrier CAPI calls
                 text=_('Enable Fleetcarrier CAPI Queries'),
                 variable=self.capi_fleetcarrier
-            ).grid(columnspan=4, padx=self.PADX, pady=(5, 0), sticky=tk.W, row=row.get())
+            ).grid(columnspan=4, padx=self.BUTTONX, pady=(5, 0), sticky=tk.W, row=row.get())
 
         if sys.platform in ('darwin', 'win32'):
             ttk.Separator(config_frame, orient=tk.HORIZONTAL).grid(
-                columnspan=4, padx=self.PADX, pady=self.PADY*4, sticky=tk.EW, row=row.get()
+                columnspan=4, padx=self.PADX, pady=self.SEPY, sticky=tk.EW, row=row.get()
             )
 
             self.hotkey_code = config.get_int('hotkey_code')
             self.hotkey_mods = config.get_int('hotkey_mods')
             self.hotkey_only = tk.IntVar(value=not config.get_int('hotkey_always'))
             self.hotkey_play = tk.IntVar(value=not config.get_int('hotkey_mute'))
-            nb.Label(
-                config_frame,
-                text=_('Keyboard shortcut') if  # LANG: Hotkey/Shortcut settings prompt on OSX
-                sys.platform == 'darwin' else
-                _('Hotkey')  # LANG: Hotkey/Shortcut settings prompt on Windows
-            ).grid(padx=self.PADX, sticky=tk.W, row=row.get())
+            with row as cur_row:
+                nb.Label(
+                    config_frame,
+                    text=_('Keyboard shortcut') if  # LANG: Hotkey/Shortcut settings prompt on OSX
+                    sys.platform == 'darwin' else
+                    _('Hotkey')  # LANG: Hotkey/Shortcut settings prompt on Windows
+                ).grid(padx=self.PADX, sticky=tk.W, row=cur_row)
 
-            if sys.platform == 'darwin' and not was_accessible_at_launch:
-                if AXIsProcessTrusted():
-                    # Shortcut settings prompt on OSX
-                    nb.Label(
-                        config_frame,
-                        # LANG: macOS Preferences > Configuration - restart the app message
-                        text=_('Re-start {APP} to use shortcuts').format(APP=applongname),
-                        foreground='firebrick'
-                    ).grid(padx=self.PADX, sticky=tk.W, row=row.get())
+                if sys.platform == 'darwin' and not was_accessible_at_launch:
+                    if AXIsProcessTrusted():
+                        # Shortcut settings prompt on OSX
+                        nb.Label(
+                            config_frame,
+                            # LANG: macOS Preferences > Configuration - restart the app message
+                            text=_('Re-start {APP} to use shortcuts').format(APP=applongname),
+                            foreground='firebrick'
+                        ).grid(padx=self.PADX, sticky=tk.W, row=cur_row)
+
+                    else:
+                        # Shortcut settings prompt on OSX
+                        nb.Label(
+                            config_frame,
+                            # LANG: macOS - Configuration - need to grant the app permission for keyboard shortcuts
+                            text=_('{APP} needs permission to use shortcuts').format(APP=applongname),
+                            foreground='firebrick'
+                        ).grid(columnspan=4, padx=self.PADX, sticky=tk.W, row=cur_row)
+
+                        # LANG: Shortcut settings button on OSX
+                        nb.Button(config_frame, text=_('Open System Preferences'), command=self.enableshortcuts).grid(
+                            padx=self.PADX, sticky=tk.E, row=cur_row
+                        )
 
                 else:
-                    # Shortcut settings prompt on OSX
-                    nb.Label(
-                        config_frame,
-                        # LANG: macOS - Configuration - need to grant the app permission for keyboard shortcuts
-                        text=_('{APP} needs permission to use shortcuts').format(APP=applongname),
-                        foreground='firebrick'
-                    ).grid(columnspan=4, padx=self.PADX, sticky=tk.W, row=row.get())
-
-                    # LANG: Shortcut settings button on OSX
-                    nb.Button(config_frame, text=_('Open System Preferences'), command=self.enableshortcuts).grid(
-                        padx=self.PADX, sticky=tk.E, row=row.get()
+                    self.hotkey_text = nb.Entry(config_frame, width=(
+                        20 if sys.platform == 'darwin' else 30), justify=tk.CENTER)
+                    self.hotkey_text.insert(
+                        0,
+                        # No hotkey/shortcut currently defined
+                        # TODO: display Only shows up on darwin or windows
+                        # LANG: No hotkey/shortcut set
+                        hotkeymgr.display(self.hotkey_code, self.hotkey_mods) if self.hotkey_code else _('None')
                     )
 
-            else:
-                self.hotkey_text = nb.Entry(config_frame, width=(
-                    20 if sys.platform == 'darwin' else 30), justify=tk.CENTER)
-                self.hotkey_text.insert(
-                    0,
-                    # No hotkey/shortcut currently defined
-                    # TODO: display Only shows up on darwin or windows
-                    # LANG: No hotkey/shortcut set
-                    hotkeymgr.display(self.hotkey_code, self.hotkey_mods) if self.hotkey_code else _('None')
-                )
-
-                self.hotkey_text.bind('<FocusIn>', self.hotkeystart)
-                self.hotkey_text.bind('<FocusOut>', self.hotkeyend)
-                self.hotkey_text.grid(column=1, columnspan=2, pady=(5, 0), sticky=tk.W, row=row.get())
+                    self.hotkey_text.bind('<FocusIn>', self.hotkeystart)
+                    self.hotkey_text.bind('<FocusOut>', self.hotkeyend)
+                    self.hotkey_text.grid(column=1, columnspan=2, pady=(5, 0), sticky=tk.W, row=cur_row)
 
                 # Hotkey/Shortcut setting
                 self.hotkey_only_btn = nb.Checkbutton(
@@ -558,7 +562,7 @@ class PreferencesDialog(tk.Toplevel):
                     state=tk.NORMAL if self.hotkey_code else tk.DISABLED
                 )
 
-                self.hotkey_only_btn.grid(columnspan=4, padx=self.PADX, pady=(5, 0), sticky=tk.W, row=row.get())
+                self.hotkey_only_btn.grid(columnspan=4, padx=self.BUTTONX, pady=(5, 0), sticky=tk.W, row=row.get())
 
                 # Hotkey/Shortcut setting
                 self.hotkey_play_btn = nb.Checkbutton(
@@ -569,11 +573,11 @@ class PreferencesDialog(tk.Toplevel):
                     state=tk.NORMAL if self.hotkey_code else tk.DISABLED
                 )
 
-                self.hotkey_play_btn.grid(columnspan=4, padx=self.PADX, sticky=tk.W, row=row.get())
+                self.hotkey_play_btn.grid(columnspan=4, padx=self.BUTTONX, sticky=tk.W, row=row.get())
 
         # Option to disabled Automatic Check For Updates whilst in-game
         ttk.Separator(config_frame, orient=tk.HORIZONTAL).grid(
-            columnspan=4, padx=self.PADX, pady=self.PADY*4, sticky=tk.EW, row=row.get()
+            columnspan=4, padx=self.PADX, pady=self.SEPY, sticky=tk.EW, row=row.get()
         )
         self.disable_autoappupdatecheckingame = tk.IntVar(value=config.get_int('disable_autoappupdatecheckingame'))
         self.disable_autoappupdatecheckingame_btn = nb.Checkbutton(
@@ -584,10 +588,10 @@ class PreferencesDialog(tk.Toplevel):
             command=self.disable_autoappupdatecheckingame_changed
         )
 
-        self.disable_autoappupdatecheckingame_btn.grid(columnspan=4, padx=self.PADX, sticky=tk.W, row=row.get())
+        self.disable_autoappupdatecheckingame_btn.grid(columnspan=4, padx=self.BUTTONX, sticky=tk.W, row=row.get())
 
         ttk.Separator(config_frame, orient=tk.HORIZONTAL).grid(
-            columnspan=4, padx=self.PADX, pady=self.PADY*4, sticky=tk.EW, row=row.get()
+            columnspan=4, padx=self.PADX, pady=self.SEPY, sticky=tk.EW, row=row.get()
         )
 
         # Settings prompt for preferred ship loadout, system and station info websites
@@ -660,7 +664,7 @@ class PreferencesDialog(tk.Toplevel):
 
         # Set loglevel
         ttk.Separator(config_frame, orient=tk.HORIZONTAL).grid(
-            columnspan=4, padx=self.PADX, pady=self.PADY*4, sticky=tk.EW, row=row.get()
+            columnspan=4, padx=self.PADX, pady=self.SEPY, sticky=tk.EW, row=row.get()
         )
 
         with row as cur_row:
@@ -706,26 +710,26 @@ class PreferencesDialog(tk.Toplevel):
         notebook.add(config_frame, text=_('Configuration'))
 
     def __setup_privacy_tab(self, notebook: ttk.Notebook) -> None:
-        frame = nb.Frame(notebook)
+        privacy_frame = nb.Frame(notebook)
         self.hide_multicrew_captain = tk.BooleanVar(value=config.get_bool('hide_multicrew_captain', default=False))
         self.hide_private_group = tk.BooleanVar(value=config.get_bool('hide_private_group', default=False))
         row = AutoInc(start=0)
 
         # LANG: UI elements privacy section header in privacy tab of preferences
-        nb.Label(frame, text=_('Main UI privacy options')).grid(
+        nb.Label(privacy_frame, text=_('Main UI privacy options')).grid(
             row=row.get(), column=0, sticky=tk.W, padx=self.PADX
         )
 
         nb.Checkbutton(
-            frame, text=_('Hide private group name in UI'),  # LANG: Hide private group owner name from UI checkbox
+            privacy_frame, text=_('Hide private group name in UI'),  # LANG: Hide private group owner name from UI checkbox
             variable=self.hide_private_group
         ).grid(row=row.get(), column=0, padx=self.BUTTONX, pady=self.PADY, sticky=tk.W)
         nb.Checkbutton(
-            frame, text=_('Hide multi-crew captain name'),  # LANG: Hide multicrew captain name from main UI checkbox
+            privacy_frame, text=_('Hide multi-crew captain name'),  # LANG: Hide multicrew captain name from main UI checkbox
             variable=self.hide_multicrew_captain
         ).grid(row=row.get(), column=0, padx=self.BUTTONX, pady=self.PADY, sticky=tk.W)
 
-        notebook.add(frame, text=_('Privacy'))  # LANG: Preferences privacy tab title
+        notebook.add(privacy_frame, text=_('Privacy'))  # LANG: Preferences privacy tab title
 
     def __setup_appearance_tab(self, notebook: ttk.Notebook) -> None:
         self.languages = Translations.available_names()
@@ -751,10 +755,10 @@ class PreferencesDialog(tk.Toplevel):
             # LANG: Appearance - Label for selection of application display language
             nb.Label(appearance_frame, text=_('Language')).grid(padx=self.PADX, sticky=tk.W, row=cur_row)
             self.lang_button = nb.OptionMenu(appearance_frame, self.lang, self.lang.get(), *self.languages.values())
-            self.lang_button.grid(column=1, columnspan=2, padx=self.PADX, sticky=tk.W, row=cur_row)
+            self.lang_button.grid(column=1, columnspan=2, padx=(0, self.PADX), sticky=tk.W, row=cur_row)
 
         ttk.Separator(appearance_frame, orient=tk.HORIZONTAL).grid(
-            columnspan=3, padx=self.PADX, pady=self.PADY*4, sticky=tk.EW, row=row.get()
+            columnspan=3, padx=self.PADX, pady=self.SEPY, sticky=tk.EW, row=row.get()
         )
 
         # Appearance setting
@@ -797,7 +801,7 @@ class PreferencesDialog(tk.Toplevel):
                 command=lambda: self.themecolorbrowse(0)
             )
 
-            self.theme_button_0.grid(column=1, padx=self.PADX, pady=self.PADY, sticky=tk.NSEW, row=cur_row)
+            self.theme_button_0.grid(column=1, padx=0, pady=self.PADY, sticky=tk.NSEW, row=cur_row)
 
         with row as cur_row:
             self.theme_label_1 = nb.Label(appearance_frame, text=self.theme_prompts[1])
@@ -809,7 +813,7 @@ class PreferencesDialog(tk.Toplevel):
                 command=lambda: self.themecolorbrowse(1)
             )
 
-            self.theme_button_1.grid(column=1, padx=self.PADX, pady=self.PADY, sticky=tk.NSEW, row=cur_row)
+            self.theme_button_1.grid(column=1, padx=0, pady=self.PADY, sticky=tk.NSEW, row=cur_row)
 
         # UI Scaling
         """
@@ -820,7 +824,7 @@ class PreferencesDialog(tk.Toplevel):
         of 200 we'll end up setting 2.66 as the tk-scaling value.
         """
         ttk.Separator(appearance_frame, orient=tk.HORIZONTAL).grid(
-            columnspan=4, padx=self.PADX, pady=self.PADY*4, sticky=tk.EW, row=row.get()
+            columnspan=4, padx=self.PADX, pady=self.SEPY, sticky=tk.EW, row=row.get()
         )
         with row as cur_row:
             # LANG: Appearance - Label for selection of UI scaling
@@ -841,7 +845,7 @@ class PreferencesDialog(tk.Toplevel):
                 resolution=10,
             )
 
-            self.uiscale_bar.grid(column=1, sticky=tk.W, row=cur_row)
+            self.uiscale_bar.grid(column=1, padx=0, sticky=tk.W, row=cur_row)
             self.ui_scaling_defaultis = nb.Label(
                 appearance_frame,
                 # LANG: Appearance - Help/hint text for UI scaling selection
@@ -850,7 +854,7 @@ class PreferencesDialog(tk.Toplevel):
 
         # Transparency slider
         ttk.Separator(appearance_frame, orient=tk.HORIZONTAL).grid(
-            columnspan=4, padx=self.PADX, pady=self.PADY*4, sticky=tk.EW, row=row.get()
+            columnspan=4, padx=self.PADX, pady=self.SEPY, sticky=tk.EW, row=row.get()
         )
 
         with row as cur_row:
@@ -887,11 +891,11 @@ class PreferencesDialog(tk.Toplevel):
                 row=cur_row
             )
 
-            self.transparency_bar.grid(column=1, sticky=tk.W, row=cur_row)
+            self.transparency_bar.grid(column=1, padx=0, sticky=tk.W, row=cur_row)
 
         # Always on top
         ttk.Separator(appearance_frame, orient=tk.HORIZONTAL).grid(
-            columnspan=4, padx=self.PADX, pady=self.PADY*4, sticky=tk.EW, row=row.get()
+            columnspan=4, padx=self.PADX, pady=self.SEPY, sticky=tk.EW, row=row.get()
         )
 
         self.ontop_button = nb.Checkbutton(
@@ -947,12 +951,12 @@ class PreferencesDialog(tk.Toplevel):
             # Help text in settings
             # LANG: Tip/label about how to disable plugins
             text=_("Tip: You can disable a plugin by{CR}adding '{EXT}' to its folder name").format(EXT='.disabled')
-        ).grid(columnspan=2, padx=self.PADX, pady=10, sticky=tk.EW, row=row.get())
+        ).grid(columnspan=2, padx=self.PADX, pady=self.PADY, sticky=tk.EW, row=row.get())
 
         enabled_plugins = list(filter(lambda x: x.folder and x.module, plug.PLUGINS))
         if len(enabled_plugins):
             ttk.Separator(plugins_frame, orient=tk.HORIZONTAL).grid(
-                columnspan=3, padx=self.PADX, pady=self.PADY * 8, sticky=tk.EW
+                columnspan=3, padx=self.PADX, pady=self.SEPY, sticky=tk.EW, row=row.get()
             )
             nb.Label(
                 plugins_frame,
@@ -967,21 +971,19 @@ class PreferencesDialog(tk.Toplevel):
                 else:
                     label = nb.Label(plugins_frame, text=f'{plugin.folder} ({plugin.name})')
 
-                label.grid(columnspan=2, padx=self.PADX*2, sticky=tk.W, row=row.get())
+                label.grid(columnspan=2, padx=self.LISTX, sticky=tk.W, row=row.get())
 
         ############################################################
         # Show which plugins don't have Python 3.x support
         ############################################################
         if len(plug.PLUGINS_not_py3):
             ttk.Separator(plugins_frame, orient=tk.HORIZONTAL).grid(
-                columnspan=3, padx=self.PADX, pady=self.PADY * 8, sticky=tk.EW, row=row.get()
+                columnspan=3, padx=self.PADX, pady=self.SEPY, sticky=tk.EW, row=row.get()
             )
             # LANG: Plugins - Label for list of 'enabled' plugins that don't work with Python 3.x
-            nb.Label(plugins_frame, text=_('Plugins Without Python 3.x Support:')+':').grid(padx=self.PADX, sticky=tk.W)
-
-            for plugin in plug.PLUGINS_not_py3:
-                if plugin.folder:  # 'system' ones have this set to None to suppress listing in Plugins prefs tab
-                    nb.Label(plugins_frame, text=plugin.name).grid(columnspan=2, padx=self.PADX*2, sticky=tk.W)
+            nb.Label(plugins_frame, text=_('Plugins Without Python 3.x Support')+':').grid(
+                padx=self.PADX, sticky=tk.W, row=row.get()
+            )
 
             HyperlinkLabel(
                 # LANG: Plugins - Label on URL to documentation about migrating plugins from Python 2.7
@@ -989,23 +991,30 @@ class PreferencesDialog(tk.Toplevel):
                 background=nb.Label().cget('background'),
                 url='https://github.com/EDCD/EDMarketConnector/blob/main/PLUGINS.md#migration-from-python-27',
                 underline=True
-            ).grid(columnspan=2, padx=self.PADX, sticky=tk.W)
-        ############################################################
+            ).grid(columnspan=2, padx=self.PADX, sticky=tk.W, row=row.get())
 
+            for plugin in plug.PLUGINS_not_py3:
+                if plugin.folder:  # 'system' ones have this set to None to suppress listing in Plugins prefs tab
+                    nb.Label(plugins_frame, text=plugin.name).grid(
+                        columnspan=2, padx=self.LISTX, sticky=tk.W, row=row.get()
+                    )
+        ############################################################
+        # Show disabled plugins
+        ############################################################
         disabled_plugins = list(filter(lambda x: x.folder and not x.module, plug.PLUGINS))
         if len(disabled_plugins):
             ttk.Separator(plugins_frame, orient=tk.HORIZONTAL).grid(
-                columnspan=3, padx=self.PADX, pady=self.PADY * 8, sticky=tk.EW, row=row.get()
+                columnspan=3, padx=self.PADX*2, pady=self.SEPY, sticky=tk.EW, row=row.get()
             )
             nb.Label(
                 plugins_frame,
-                # LANG: Lable on list of user-disabled plugins
+                # LANG: Label on list of user-disabled plugins
                 text=_('Disabled Plugins')+':'  # List of plugins in settings
             ).grid(padx=self.PADX, sticky=tk.W, row=row.get())
 
             for plugin in disabled_plugins:
                 nb.Label(plugins_frame, text=plugin.name).grid(
-                    columnspan=2, padx=self.PADX*2, sticky=tk.W, row=row.get()
+                    columnspan=2, padx=self.LISTX, sticky=tk.W, row=row.get()
                 )
 
         # LANG: Label on Settings > Plugins tab

--- a/prefs.py
+++ b/prefs.py
@@ -927,7 +927,9 @@ class PreferencesDialog(tk.Toplevel):
 
         # Section heading in settings
         # LANG: Label for location of third-party plugins folder
-        nb.Label(plugins_frame, text=_('Plugins folder') + ':').grid(padx=self.PADX, pady=(0, self.PADY), sticky=tk.W, row=row.get())
+        nb.Label(plugins_frame, text=_('Plugins folder') + ':').grid(
+            padx=self.PADX, pady=(0, self.PADY), sticky=tk.W, row=row.get()
+        )
 
         plugdirentry = nb.Entry(plugins_frame, justify=tk.LEFT)
         self.displaypath(plugdir, plugdirentry)


### PR DESCRIPTION
# Description
The UI in the settings panels is currently not standardized. The Paddings used vary wildly with signs of a pattern that's not used everywhere though. This creates a standard for the settings UI and applies it to the panels. This standard can also be used as a reference for future updates and be given to Plugin developers to achieve a uniform look.

Closes #2088, #2089, #2095

## Type of change
- Fixes indentation on non-English languages with varying character spacing
- Fixes a number of issues with labels overwriting the content they are displaying on
- Implementation of settings UI standard

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- Multiple install runs, clean installs, and others made to confirm functionality, including under a variety of existing pre-install situations. 
- All PyTest tests pass