### PR TITLE
[2051] Convert Pickle to Json

### DIFF
--- a/build.py
+++ b/build.py
@@ -73,8 +73,10 @@ def generate_data_files(
                 "ChangeLog.md",
                 "snd_good.wav",
                 "snd_bad.wav",
-                "modules.p",
-                "ships.p",
+                "modules.p",  # TODO: Remove in 6.0
+                "resources/modules.json",
+                "resources/ships.json",
+                "ships.p",  # TODO: Remove in 6.0
                 f"{app_name}.VisualElementsManifest.xml",
                 f"{app_name}.ico",
                 "EDMarketConnector - TRACE.bat",

--- a/coriolis-update-files.py
+++ b/coriolis-update-files.py
@@ -1,16 +1,18 @@
-#!/usr/bin/env python3
 """
-Build ship and module databases from https://github.com/EDCD/coriolis-data/ .
+coriolis-update-files.py - Build ship and module databases from https://github.com/EDCD/coriolis-data/.
 
-This script also utilise the file outfitting.csv.   Due to how collate.py
-both reads and writes to this file a local copy is used, in the root of the
-project structure, is used for this purpose.  If you want to utilise the
+Copyright (c) EDCD, All Rights Reserved
+Licensed under the GNU General Public License.
+See LICENSE file.
+
+This script also utilizes the file outfitting.csv. Due to how collate.py
+both reads and writes to this file, a local copy in the root of the
+project structure is used for this purpose. If you want to utilize the
 FDevIDs/ version of the file, copy it over the local one.
 """
 
 
 import json
-import pickle
 import subprocess
 import sys
 from collections import OrderedDict
@@ -29,7 +31,9 @@ if __name__ == "__main__":
     # Regenerate coriolis-data distribution
     subprocess.check_call('npm install', cwd='coriolis-data', shell=True, stdout=sys.stdout, stderr=sys.stderr)
 
-    data = json.load(open('coriolis-data/dist/index.json'))
+    file_path = 'coriolis-data/dist/index.json'
+    with open(file_path) as file:
+        data = json.load(file)
 
     # Symbolic name from in-game name
     reverse_ship_map = {v: k for k, v in list(ship_name_map.items())}
@@ -44,11 +48,12 @@ if __name__ == "__main__":
         name = coriolis_ship_map.get(m['properties']['name'], str(m['properties']['name']))
         assert name in reverse_ship_map, name
         ships[name] = {'hullMass': m['properties']['hullMass']}
-        for i in range(len(bulkheads)):
-            modules['_'.join([reverse_ship_map[name], 'armour', bulkheads[i]])] = {'mass': m['bulkheads'][i]['mass']}
+        for i, bulkhead in enumerate(bulkheads):
+            modules['_'.join([reverse_ship_map[name], 'armour', bulkhead])] = {'mass': m['bulkheads'][i]['mass']}
 
     ships = OrderedDict([(k, ships[k]) for k in sorted(ships)])  # sort for easier diffing
-    pickle.dump(ships, open('ships.p', 'wb'))
+    with open("resources/ships.json", "w") as ships_file:
+        json.dump(ships, ships_file, indent=4)
 
     # Module masses
     for cat in list(data['Modules'].values()):
@@ -82,4 +87,5 @@ if __name__ == "__main__":
     add(modules, 'hpt_multicannon_fixed_medium_advanced',         {'mass': 4})
 
     modules = OrderedDict([(k, modules[k]) for k in sorted(modules)])  # sort for easier diffing
-    pickle.dump(modules, open('modules.p', 'wb'))
+    with open("resources/modules.json", "w") as modules_file:
+        json.dump(modules, modules_file, indent=4)

--- a/docs/Releasing.md
+++ b/docs/Releasing.md
@@ -156,7 +156,7 @@ Before you create a new install each time you should:
    1. `cd coriolis-data`
    2. `git pull`
    3. `npm install` - to check it's worked.
-3. Run `coriolis-update-files.py` to update `modules.p` and `ships.p`. **NB:
+3. Run `coriolis-update-files.py` to update `modules.json` and `ships.json`. **NB:
     The submodule might have been updated by a GitHub workflow/PR/merge, so
     be sure to perform this step for every build.**
 4. XXX: Test ?

--- a/edshipyard.py
+++ b/edshipyard.py
@@ -1,12 +1,13 @@
 """Export ship loadout in ED Shipyard plain text format."""
+from __future__ import annotations
 
+import json
 import os
 import pathlib
-import pickle
 import re
 import time
 from collections import defaultdict
-from typing import Dict, List, Union
+from typing import Union
 
 import outfitting
 import util_ships
@@ -17,14 +18,15 @@ from EDMCLogging import get_main_logger
 
 logger = get_main_logger()
 
-__Module = Dict[str, Union[str, List[str]]]
+__Module = dict[str, Union[str, list[str]]]  # Have to keep old-style here for compatibility
 
 # Map API ship names to ED Shipyard names
 ship_map = ship_name_map.copy()
 
 # Ship masses
-# TODO: prefer something other than pickle for this storage (dev readability, security)
-ships = pickle.load(open(pathlib.Path(config.respath_path) / 'ships.p', 'rb'))
+ships_file = config.respath_path / "resources" / "ships.json"
+with open(ships_file, encoding="utf-8") as ships_file_handle:
+    ships = json.load(ships_file_handle)
 
 
 def export(data, filename=None) -> None:  # noqa: C901, CCR001
@@ -75,7 +77,6 @@ def export(data, filename=None) -> None:  # noqa: C901, CCR001
     jumpboost = 0
 
     for slot in sorted(data['ship']['modules']):
-
         v = data['ship']['modules'][slot]
         try:
             if not v:
@@ -116,15 +117,14 @@ def export(data, filename=None) -> None:  # noqa: C901, CCR001
 
             jumpboost += module.get('jumpboost', 0)  # type: ignore
 
-            for s in slot_map:
-                if slot.lower().startswith(s):
-                    loadout[slot_map[s]].append(cr + name)
+            for slot_prefix, index in slot_map.items():
+                if slot.lower().startswith(slot_prefix):
+                    loadout[index].append(cr + name)
                     break
 
             else:
                 if slot.lower().startswith('slot'):
                     loadout[slot[-1]].append(cr + name)
-
                 elif not slot.lower().startswith('planetaryapproachsuite'):
                     logger.debug(f'EDShipyard: Unknown slot {slot}')
 
@@ -138,7 +138,6 @@ def export(data, filename=None) -> None:  # noqa: C901, CCR001
 
     # Construct description
     ship = ship_map.get(data['ship']['name'].lower(), data['ship']['name'])
-
     if data['ship'].get('shipName') is not None:
         _ships = f'{ship}, {data["ship"]["shipName"]}'
 
@@ -185,7 +184,6 @@ def export(data, filename=None) -> None:  # noqa: C901, CCR001
     if filename:
         with open(filename, 'wt') as h:
             h.write(string)
-
         return
 
     # Look for last ship of this type
@@ -193,7 +191,7 @@ def export(data, filename=None) -> None:  # noqa: C901, CCR001
     regexp = re.compile(re.escape(ship) + r'\.\d{4}-\d\d-\d\dT\d\d\.\d\d\.\d\d\.txt')
     oldfiles = sorted([x for x in os.listdir(config.get_str('outdir')) if regexp.match(x)])
     if oldfiles:
-        with (pathlib.Path(config.get_str('outdir')) / oldfiles[-1]).open('r') as h:
+        with (pathlib.Path(config.get_str('outdir')) / oldfiles[-1]).open() as h:
             if h.read() == string:
                 return  # same as last time - don't write
 

--- a/outfitting.py
+++ b/outfitting.py
@@ -1,30 +1,37 @@
-"""Code dealing with ship outfitting."""
+"""
+outfitting.py - Code dealing with ship outfitting.
 
-import pickle
+Copyright (c) EDCD, All Rights Reserved
+Licensed under the GNU General Public License.
+See LICENSE file.
+"""
+from __future__ import annotations
+
+import json
 from collections import OrderedDict
-from os.path import join
-from typing import Optional
 from typing import OrderedDict as OrderedDictT
 
 from config import config
-from edmc_data import outfitting_armour_map as armour_map
-from edmc_data import outfitting_cabin_map as cabin_map
-from edmc_data import outfitting_corrosion_rating_map as corrosion_rating_map
-from edmc_data import outfitting_countermeasure_map as countermeasure_map
-from edmc_data import outfitting_fighter_rating_map as fighter_rating_map
-from edmc_data import outfitting_internal_map as internal_map
-from edmc_data import outfitting_misc_internal_map as misc_internal_map
-from edmc_data import outfitting_missiletype_map as missiletype_map
-from edmc_data import outfitting_planet_rating_map as planet_rating_map
-from edmc_data import outfitting_rating_map as rating_map
-from edmc_data import outfitting_standard_map as standard_map
-from edmc_data import outfitting_utility_map as utility_map
-from edmc_data import outfitting_weapon_map as weapon_map
-from edmc_data import outfitting_weaponclass_map as weaponclass_map
-from edmc_data import outfitting_weaponmount_map as weaponmount_map
-from edmc_data import outfitting_weaponoldvariant_map as weaponoldvariant_map
-from edmc_data import outfitting_weaponrating_map as weaponrating_map
-from edmc_data import ship_name_map
+from edmc_data import (
+    outfitting_armour_map as armour_map,
+    outfitting_cabin_map as cabin_map,
+    outfitting_corrosion_rating_map as corrosion_rating_map,
+    outfitting_countermeasure_map as countermeasure_map,
+    outfitting_fighter_rating_map as fighter_rating_map,
+    outfitting_internal_map as internal_map,
+    outfitting_misc_internal_map as misc_internal_map,
+    outfitting_missiletype_map as missiletype_map,
+    outfitting_planet_rating_map as planet_rating_map,
+    outfitting_rating_map as rating_map,
+    outfitting_standard_map as standard_map,
+    outfitting_utility_map as utility_map,
+    outfitting_weapon_map as weapon_map,
+    outfitting_weaponclass_map as weaponclass_map,
+    outfitting_weaponmount_map as weaponmount_map,
+    outfitting_weaponoldvariant_map as weaponoldvariant_map,
+    outfitting_weaponrating_map as weaponrating_map,
+    ship_name_map,
+)
 from EDMCLogging import get_main_logger
 
 logger = get_main_logger()
@@ -33,7 +40,7 @@ logger = get_main_logger()
 moduledata: OrderedDictT = OrderedDict()
 
 
-def lookup(module, ship_map, entitled=False) -> Optional[dict]:  # noqa: C901, CCR001
+def lookup(module, ship_map, entitled=False) -> dict | None:  # noqa: C901, CCR001
     """
     Produce a standard dict description of the given module.
 
@@ -51,7 +58,8 @@ def lookup(module, ship_map, entitled=False) -> Optional[dict]:  # noqa: C901, C
     """
     # Lazily populate
     if not moduledata:
-        moduledata.update(pickle.load(open(join(config.respath_path, 'modules.p'),  'rb')))
+        modules_path = config.respath_path / "resources" / "modules.json"
+        moduledata.update(json.loads(modules_path.read_text()))
 
     if not module.get('name'):
         raise AssertionError(f'{module["id"]}')
@@ -61,10 +69,13 @@ def lookup(module, ship_map, entitled=False) -> Optional[dict]:  # noqa: C901, C
 
     # Armour - e.g. Federation_Dropship_Armour_Grade2
     if name[-2] == 'armour':
-        name = module['name'].lower().rsplit('_', 2)  # Armour is ship-specific, and ship names can have underscores
+        # Armour is ship-specific, and ship names can have underscores
+        ship_name, armour_grade = module["name"].lower().rsplit("_", 2)[0:2]
+        if ship_name not in ship_map:
+            raise AssertionError(f"Unknown ship: {ship_name}")
         new['category'] = 'standard'
-        new['name'] = armour_map[name[2]]
-        new['ship'] = ship_map[name[0]]  # Generate error on unknown ship
+        new["name"] = armour_map[armour_grade]
+        new["ship"] = ship_map[ship_name]
         new['class'] = '1'
         new['rating'] = 'I'
 
@@ -219,10 +230,7 @@ def lookup(module, ship_map, entitled=False) -> Optional[dict]:  # noqa: C901, C
         new['enabled'], new['priority'] = module['on'], module['priority']  # priority is zero-based
 
     # Entitlements
-    if not module.get('sku'):
-        pass
-
-    else:
+    if module.get('sku'):
         new['entitlement'] = module['sku']
 
     # Extra module data
@@ -245,10 +253,11 @@ def lookup(module, ship_map, entitled=False) -> Optional[dict]:  # noqa: C901, C
 
     new.update(moduledata.get(module['name'].lower(), {}))
 
-    # check we've filled out mandatory fields
-    for thing in ['id', 'symbol', 'category', 'name', 'class', 'rating']:  # Don't consider mass etc as mandatory
-        if not new.get(thing):
-            raise AssertionError(f'{module["id"]}: failed to set {thing}')
+    # Check we've filled out mandatory fields
+    mandatory_fields = ["id", "symbol", "category", "name", "class", "rating"]
+    for field in mandatory_fields:
+        if not new.get(field):
+            raise AssertionError(f'{module["id"]}: failed to set {field}')
 
     if new['category'] == 'hardpoint' and not new.get('mount'):
         raise AssertionError(f'{module["id"]}: failed to set mount')
@@ -263,15 +272,15 @@ def export(data, filename) -> None:
     :param data: CAPI data to export.
     :param filename: Filename to export into.
     """
-    assert data['lastSystem'].get('name')
-    assert data['lastStarport'].get('name')
+    assert "name" in data["lastSystem"]
+    assert "name" in data["lastStarport"]
 
     header = 'System,Station,Category,Name,Mount,Guidance,Ship,Class,Rating,FDevID,Date\n'
     rowheader = f'{data["lastSystem"]["name"]},{data["lastStarport"]["name"]}'
 
     with open(filename, 'wt') as h:
         h.write(header)
-        for v in list(data['lastStarport'].get('modules', {}).values()):
+        for v in data["lastStarport"].get("modules", {}).values():
             try:
                 m = lookup(v, ship_name_map)
                 if m:

--- a/resources/modules.json
+++ b/resources/modules.json
@@ -1,0 +1,3306 @@
+{
+    "adder_armour_grade1": {
+        "mass": 0
+    },
+    "adder_armour_grade2": {
+        "mass": 3
+    },
+    "adder_armour_grade3": {
+        "mass": 5
+    },
+    "adder_armour_mirrored": {
+        "mass": 5
+    },
+    "adder_armour_reactive": {
+        "mass": 5
+    },
+    "anaconda_armour_grade1": {
+        "mass": 0
+    },
+    "anaconda_armour_grade2": {
+        "mass": 30
+    },
+    "anaconda_armour_grade3": {
+        "mass": 60
+    },
+    "anaconda_armour_mirrored": {
+        "mass": 60
+    },
+    "anaconda_armour_reactive": {
+        "mass": 60
+    },
+    "asp_armour_grade1": {
+        "mass": 0
+    },
+    "asp_armour_grade2": {
+        "mass": 21
+    },
+    "asp_armour_grade3": {
+        "mass": 42
+    },
+    "asp_armour_mirrored": {
+        "mass": 42
+    },
+    "asp_armour_reactive": {
+        "mass": 42
+    },
+    "asp_scout_armour_grade1": {
+        "mass": 0
+    },
+    "asp_scout_armour_grade2": {
+        "mass": 21
+    },
+    "asp_scout_armour_grade3": {
+        "mass": 42
+    },
+    "asp_scout_armour_mirrored": {
+        "mass": 42
+    },
+    "asp_scout_armour_reactive": {
+        "mass": 42
+    },
+    "belugaliner_armour_grade1": {
+        "mass": 0
+    },
+    "belugaliner_armour_grade2": {
+        "mass": 83
+    },
+    "belugaliner_armour_grade3": {
+        "mass": 165
+    },
+    "belugaliner_armour_mirrored": {
+        "mass": 165
+    },
+    "belugaliner_armour_reactive": {
+        "mass": 165
+    },
+    "cobramkiii_armour_grade1": {
+        "mass": 0
+    },
+    "cobramkiii_armour_grade2": {
+        "mass": 14
+    },
+    "cobramkiii_armour_grade3": {
+        "mass": 27
+    },
+    "cobramkiii_armour_mirrored": {
+        "mass": 27
+    },
+    "cobramkiii_armour_reactive": {
+        "mass": 27
+    },
+    "cobramkiv_armour_grade1": {
+        "mass": 0
+    },
+    "cobramkiv_armour_grade2": {
+        "mass": 14
+    },
+    "cobramkiv_armour_grade3": {
+        "mass": 27
+    },
+    "cobramkiv_armour_mirrored": {
+        "mass": 27
+    },
+    "cobramkiv_armour_reactive": {
+        "mass": 27
+    },
+    "cutter_armour_grade1": {
+        "mass": 0
+    },
+    "cutter_armour_grade2": {
+        "mass": 30
+    },
+    "cutter_armour_grade3": {
+        "mass": 60
+    },
+    "cutter_armour_mirrored": {
+        "mass": 60
+    },
+    "cutter_armour_reactive": {
+        "mass": 60
+    },
+    "diamondback_armour_grade1": {
+        "mass": 0
+    },
+    "diamondback_armour_grade2": {
+        "mass": 13
+    },
+    "diamondback_armour_grade3": {
+        "mass": 26
+    },
+    "diamondback_armour_mirrored": {
+        "mass": 26
+    },
+    "diamondback_armour_reactive": {
+        "mass": 26
+    },
+    "diamondbackxl_armour_grade1": {
+        "mass": 0
+    },
+    "diamondbackxl_armour_grade2": {
+        "mass": 23
+    },
+    "diamondbackxl_armour_grade3": {
+        "mass": 47
+    },
+    "diamondbackxl_armour_mirrored": {
+        "mass": 26
+    },
+    "diamondbackxl_armour_reactive": {
+        "mass": 47
+    },
+    "dolphin_armour_grade1": {
+        "mass": 0
+    },
+    "dolphin_armour_grade2": {
+        "mass": 32
+    },
+    "dolphin_armour_grade3": {
+        "mass": 63
+    },
+    "dolphin_armour_mirrored": {
+        "mass": 63
+    },
+    "dolphin_armour_reactive": {
+        "mass": 63
+    },
+    "eagle_armour_grade1": {
+        "mass": 0
+    },
+    "eagle_armour_grade2": {
+        "mass": 4
+    },
+    "eagle_armour_grade3": {
+        "mass": 8
+    },
+    "eagle_armour_mirrored": {
+        "mass": 8
+    },
+    "eagle_armour_reactive": {
+        "mass": 8
+    },
+    "empire_courier_armour_grade1": {
+        "mass": 0
+    },
+    "empire_courier_armour_grade2": {
+        "mass": 4
+    },
+    "empire_courier_armour_grade3": {
+        "mass": 8
+    },
+    "empire_courier_armour_mirrored": {
+        "mass": 8
+    },
+    "empire_courier_armour_reactive": {
+        "mass": 8
+    },
+    "empire_eagle_armour_grade1": {
+        "mass": 0
+    },
+    "empire_eagle_armour_grade2": {
+        "mass": 4
+    },
+    "empire_eagle_armour_grade3": {
+        "mass": 8
+    },
+    "empire_eagle_armour_mirrored": {
+        "mass": 8
+    },
+    "empire_eagle_armour_reactive": {
+        "mass": 8
+    },
+    "empire_trader_armour_grade1": {
+        "mass": 0
+    },
+    "empire_trader_armour_grade2": {
+        "mass": 30
+    },
+    "empire_trader_armour_grade3": {
+        "mass": 60
+    },
+    "empire_trader_armour_mirrored": {
+        "mass": 60
+    },
+    "empire_trader_armour_reactive": {
+        "mass": 60
+    },
+    "federation_corvette_armour_grade1": {
+        "mass": 0
+    },
+    "federation_corvette_armour_grade2": {
+        "mass": 30
+    },
+    "federation_corvette_armour_grade3": {
+        "mass": 60
+    },
+    "federation_corvette_armour_mirrored": {
+        "mass": 60
+    },
+    "federation_corvette_armour_reactive": {
+        "mass": 60
+    },
+    "federation_dropship_armour_grade1": {
+        "mass": 0
+    },
+    "federation_dropship_armour_grade2": {
+        "mass": 44
+    },
+    "federation_dropship_armour_grade3": {
+        "mass": 87
+    },
+    "federation_dropship_armour_mirrored": {
+        "mass": 87
+    },
+    "federation_dropship_armour_reactive": {
+        "mass": 87
+    },
+    "federation_dropship_mkii_armour_grade1": {
+        "mass": 0
+    },
+    "federation_dropship_mkii_armour_grade2": {
+        "mass": 44
+    },
+    "federation_dropship_mkii_armour_grade3": {
+        "mass": 87
+    },
+    "federation_dropship_mkii_armour_mirrored": {
+        "mass": 87
+    },
+    "federation_dropship_mkii_armour_reactive": {
+        "mass": 87
+    },
+    "federation_gunship_armour_grade1": {
+        "mass": 0
+    },
+    "federation_gunship_armour_grade2": {
+        "mass": 44
+    },
+    "federation_gunship_armour_grade3": {
+        "mass": 87
+    },
+    "federation_gunship_armour_mirrored": {
+        "mass": 87
+    },
+    "federation_gunship_armour_reactive": {
+        "mass": 87
+    },
+    "ferdelance_armour_grade1": {
+        "mass": 0
+    },
+    "ferdelance_armour_grade2": {
+        "mass": 19
+    },
+    "ferdelance_armour_grade3": {
+        "mass": 38
+    },
+    "ferdelance_armour_mirrored": {
+        "mass": 38
+    },
+    "ferdelance_armour_reactive": {
+        "mass": 38
+    },
+    "hauler_armour_grade1": {
+        "mass": 0
+    },
+    "hauler_armour_grade2": {
+        "mass": 1
+    },
+    "hauler_armour_grade3": {
+        "mass": 2
+    },
+    "hauler_armour_mirrored": {
+        "mass": 2
+    },
+    "hauler_armour_reactive": {
+        "mass": 2
+    },
+    "hpt_advancedtorppylon_fixed_large": {
+        "mass": 8
+    },
+    "hpt_advancedtorppylon_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_advancedtorppylon_fixed_small": {
+        "mass": 2
+    },
+    "hpt_antiunknownshutdown_tiny": {
+        "mass": 1.3
+    },
+    "hpt_atdumbfiremissile_fixed_large": {
+        "mass": 8
+    },
+    "hpt_atdumbfiremissile_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_atdumbfiremissile_turret_large": {
+        "mass": 8
+    },
+    "hpt_atdumbfiremissile_turret_medium": {
+        "mass": 4
+    },
+    "hpt_atmulticannon_fixed_large": {
+        "mass": 8
+    },
+    "hpt_atmulticannon_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_atmulticannon_turret_large": {
+        "mass": 8
+    },
+    "hpt_atmulticannon_turret_medium": {
+        "mass": 4
+    },
+    "hpt_basicmissilerack_fixed_large": {
+        "mass": 8
+    },
+    "hpt_basicmissilerack_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_basicmissilerack_fixed_small": {
+        "mass": 2
+    },
+    "hpt_beamlaser_fixed_huge": {
+        "mass": 16
+    },
+    "hpt_beamlaser_fixed_large": {
+        "mass": 8
+    },
+    "hpt_beamlaser_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_beamlaser_fixed_small": {
+        "mass": 2
+    },
+    "hpt_beamlaser_fixed_small_heat": {
+        "mass": 2
+    },
+    "hpt_beamlaser_gimbal_huge": {
+        "mass": 16
+    },
+    "hpt_beamlaser_gimbal_large": {
+        "mass": 8
+    },
+    "hpt_beamlaser_gimbal_medium": {
+        "mass": 4
+    },
+    "hpt_beamlaser_gimbal_small": {
+        "mass": 2
+    },
+    "hpt_beamlaser_turret_large": {
+        "mass": 8
+    },
+    "hpt_beamlaser_turret_medium": {
+        "mass": 4
+    },
+    "hpt_beamlaser_turret_small": {
+        "mass": 2
+    },
+    "hpt_cannon_fixed_huge": {
+        "mass": 16
+    },
+    "hpt_cannon_fixed_large": {
+        "mass": 8
+    },
+    "hpt_cannon_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_cannon_fixed_small": {
+        "mass": 2
+    },
+    "hpt_cannon_gimbal_huge": {
+        "mass": 16
+    },
+    "hpt_cannon_gimbal_large": {
+        "mass": 8
+    },
+    "hpt_cannon_gimbal_medium": {
+        "mass": 4
+    },
+    "hpt_cannon_gimbal_small": {
+        "mass": 2
+    },
+    "hpt_cannon_turret_large": {
+        "mass": 8
+    },
+    "hpt_cannon_turret_medium": {
+        "mass": 4
+    },
+    "hpt_cannon_turret_small": {
+        "mass": 2
+    },
+    "hpt_cargoscanner_size0_class1": {
+        "mass": 1.3
+    },
+    "hpt_cargoscanner_size0_class2": {
+        "mass": 1.3
+    },
+    "hpt_cargoscanner_size0_class3": {
+        "mass": 1.3
+    },
+    "hpt_cargoscanner_size0_class4": {
+        "mass": 1.3
+    },
+    "hpt_cargoscanner_size0_class5": {
+        "mass": 1.3
+    },
+    "hpt_causticmissile_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_chafflauncher_tiny": {
+        "mass": 1.3
+    },
+    "hpt_cloudscanner_size0_class1": {
+        "mass": 1.3
+    },
+    "hpt_cloudscanner_size0_class2": {
+        "mass": 1.3
+    },
+    "hpt_cloudscanner_size0_class3": {
+        "mass": 1.3
+    },
+    "hpt_cloudscanner_size0_class4": {
+        "mass": 1.3
+    },
+    "hpt_cloudscanner_size0_class5": {
+        "mass": 1.3
+    },
+    "hpt_crimescanner_size0_class1": {
+        "mass": 1.3
+    },
+    "hpt_crimescanner_size0_class2": {
+        "mass": 1.3
+    },
+    "hpt_crimescanner_size0_class3": {
+        "mass": 1.3
+    },
+    "hpt_crimescanner_size0_class4": {
+        "mass": 1.3
+    },
+    "hpt_crimescanner_size0_class5": {
+        "mass": 1.3
+    },
+    "hpt_drunkmissilerack_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_dumbfiremissilerack_fixed_large": {
+        "mass": 8
+    },
+    "hpt_dumbfiremissilerack_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_dumbfiremissilerack_fixed_medium_advanced": {
+        "mass": 4
+    },
+    "hpt_dumbfiremissilerack_fixed_medium_lasso": {
+        "mass": 4
+    },
+    "hpt_dumbfiremissilerack_fixed_small": {
+        "mass": 2
+    },
+    "hpt_dumbfiremissilerack_fixed_small_advanced": {
+        "mass": 2
+    },
+    "hpt_electroniccountermeasure_tiny": {
+        "mass": 1.3
+    },
+    "hpt_flakmortar_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_flakmortar_turret_medium": {
+        "mass": 4
+    },
+    "hpt_flechettelauncher_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_flechettelauncher_turret_medium": {
+        "mass": 4
+    },
+    "hpt_guardian_gausscannon_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_guardian_gausscannon_fixed_small": {
+        "mass": 2
+    },
+    "hpt_guardian_plasmalauncher_fixed_large": {
+        "mass": 8
+    },
+    "hpt_guardian_plasmalauncher_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_guardian_plasmalauncher_fixed_small": {
+        "mass": 2
+    },
+    "hpt_guardian_plasmalauncher_turret_large": {
+        "mass": 8
+    },
+    "hpt_guardian_plasmalauncher_turret_medium": {
+        "mass": 4
+    },
+    "hpt_guardian_plasmalauncher_turret_small": {
+        "mass": 2
+    },
+    "hpt_guardian_shardcannon_fixed_large": {
+        "mass": 8
+    },
+    "hpt_guardian_shardcannon_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_guardian_shardcannon_fixed_small": {
+        "mass": 2
+    },
+    "hpt_guardian_shardcannon_turret_large": {
+        "mass": 8
+    },
+    "hpt_guardian_shardcannon_turret_medium": {
+        "mass": 4
+    },
+    "hpt_guardian_shardcannon_turret_small": {
+        "mass": 2
+    },
+    "hpt_heatsinklauncher_turret_tiny": {
+        "mass": 1.3
+    },
+    "hpt_minelauncher_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_minelauncher_fixed_small": {
+        "mass": 2
+    },
+    "hpt_minelauncher_fixed_small_impulse": {
+        "mass": 2
+    },
+    "hpt_mining_abrblstr_fixed_small": {
+        "mass": 2
+    },
+    "hpt_mining_abrblstr_turret_small": {
+        "mass": 2
+    },
+    "hpt_mining_seismchrgwarhd_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_mining_seismchrgwarhd_turret_medium": {
+        "mass": 4
+    },
+    "hpt_mining_subsurfdispmisle_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_mining_subsurfdispmisle_fixed_small": {
+        "mass": 2
+    },
+    "hpt_mining_subsurfdispmisle_turret_medium": {
+        "mass": 4
+    },
+    "hpt_mining_subsurfdispmisle_turret_small": {
+        "mass": 2
+    },
+    "hpt_mininglaser_fixed_medium": {
+        "mass": 2
+    },
+    "hpt_mininglaser_fixed_small": {
+        "mass": 2
+    },
+    "hpt_mininglaser_fixed_small_advanced": {
+        "mass": 2
+    },
+    "hpt_mininglaser_turret_medium": {
+        "mass": 2
+    },
+    "hpt_mininglaser_turret_small": {
+        "mass": 2
+    },
+    "hpt_mrascanner_size0_class1": {
+        "mass": 1.3
+    },
+    "hpt_mrascanner_size0_class2": {
+        "mass": 1.3
+    },
+    "hpt_mrascanner_size0_class3": {
+        "mass": 1.3
+    },
+    "hpt_mrascanner_size0_class4": {
+        "mass": 1.3
+    },
+    "hpt_mrascanner_size0_class5": {
+        "mass": 1.3
+    },
+    "hpt_multicannon_fixed_huge": {
+        "mass": 16
+    },
+    "hpt_multicannon_fixed_large": {
+        "mass": 8
+    },
+    "hpt_multicannon_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_multicannon_fixed_medium_advanced": {
+        "mass": 4
+    },
+    "hpt_multicannon_fixed_small": {
+        "mass": 2
+    },
+    "hpt_multicannon_fixed_small_advanced": {
+        "mass": 2
+    },
+    "hpt_multicannon_fixed_small_strong": {
+        "mass": 2
+    },
+    "hpt_multicannon_gimbal_huge": {
+        "mass": 16
+    },
+    "hpt_multicannon_gimbal_large": {
+        "mass": 8
+    },
+    "hpt_multicannon_gimbal_medium": {
+        "mass": 4
+    },
+    "hpt_multicannon_gimbal_small": {
+        "mass": 2
+    },
+    "hpt_multicannon_turret_large": {
+        "mass": 8
+    },
+    "hpt_multicannon_turret_medium": {
+        "mass": 4
+    },
+    "hpt_multicannon_turret_small": {
+        "mass": 2
+    },
+    "hpt_plasmaaccelerator_fixed_huge": {
+        "mass": 16
+    },
+    "hpt_plasmaaccelerator_fixed_large": {
+        "mass": 8
+    },
+    "hpt_plasmaaccelerator_fixed_large_advanced": {
+        "mass": 8
+    },
+    "hpt_plasmaaccelerator_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_plasmapointdefence_turret_tiny": {
+        "mass": 0.5
+    },
+    "hpt_plasmashockcannon_fixed_large": {
+        "mass": 8
+    },
+    "hpt_plasmashockcannon_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_plasmashockcannon_fixed_small": {
+        "mass": 2
+    },
+    "hpt_plasmashockcannon_gimbal_large": {
+        "mass": 8
+    },
+    "hpt_plasmashockcannon_gimbal_medium": {
+        "mass": 4
+    },
+    "hpt_plasmashockcannon_gimbal_small": {
+        "mass": 2
+    },
+    "hpt_plasmashockcannon_turret_large": {
+        "mass": 8
+    },
+    "hpt_plasmashockcannon_turret_medium": {
+        "mass": 4
+    },
+    "hpt_plasmashockcannon_turret_small": {
+        "mass": 2
+    },
+    "hpt_pulselaser_fixed_huge": {
+        "mass": 16
+    },
+    "hpt_pulselaser_fixed_large": {
+        "mass": 8
+    },
+    "hpt_pulselaser_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_pulselaser_fixed_medium_disruptor": {
+        "mass": 4
+    },
+    "hpt_pulselaser_fixed_small": {
+        "mass": 2
+    },
+    "hpt_pulselaser_gimbal_huge": {
+        "mass": 16
+    },
+    "hpt_pulselaser_gimbal_large": {
+        "mass": 8
+    },
+    "hpt_pulselaser_gimbal_medium": {
+        "mass": 4
+    },
+    "hpt_pulselaser_gimbal_small": {
+        "mass": 2
+    },
+    "hpt_pulselaser_turret_large": {
+        "mass": 8
+    },
+    "hpt_pulselaser_turret_medium": {
+        "mass": 4
+    },
+    "hpt_pulselaser_turret_small": {
+        "mass": 2
+    },
+    "hpt_pulselaserburst_fixed_huge": {
+        "mass": 16
+    },
+    "hpt_pulselaserburst_fixed_large": {
+        "mass": 8
+    },
+    "hpt_pulselaserburst_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_pulselaserburst_fixed_small": {
+        "mass": 2
+    },
+    "hpt_pulselaserburst_fixed_small_scatter": {
+        "mass": 2
+    },
+    "hpt_pulselaserburst_gimbal_huge": {
+        "mass": 16
+    },
+    "hpt_pulselaserburst_gimbal_large": {
+        "mass": 8
+    },
+    "hpt_pulselaserburst_gimbal_medium": {
+        "mass": 4
+    },
+    "hpt_pulselaserburst_gimbal_small": {
+        "mass": 2
+    },
+    "hpt_pulselaserburst_turret_large": {
+        "mass": 8
+    },
+    "hpt_pulselaserburst_turret_medium": {
+        "mass": 4
+    },
+    "hpt_pulselaserburst_turret_small": {
+        "mass": 2
+    },
+    "hpt_railgun_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_railgun_fixed_medium_burst": {
+        "mass": 4
+    },
+    "hpt_railgun_fixed_small": {
+        "mass": 2
+    },
+    "hpt_shieldbooster_size0_class1": {
+        "mass": 0.5
+    },
+    "hpt_shieldbooster_size0_class2": {
+        "mass": 1
+    },
+    "hpt_shieldbooster_size0_class3": {
+        "mass": 2
+    },
+    "hpt_shieldbooster_size0_class4": {
+        "mass": 3
+    },
+    "hpt_shieldbooster_size0_class5": {
+        "mass": 3.5
+    },
+    "hpt_slugshot_fixed_large": {
+        "mass": 8
+    },
+    "hpt_slugshot_fixed_large_range": {
+        "mass": 8
+    },
+    "hpt_slugshot_fixed_medium": {
+        "mass": 4
+    },
+    "hpt_slugshot_fixed_small": {
+        "mass": 2
+    },
+    "hpt_slugshot_gimbal_large": {
+        "mass": 8
+    },
+    "hpt_slugshot_gimbal_medium": {
+        "mass": 4
+    },
+    "hpt_slugshot_gimbal_small": {
+        "mass": 2
+    },
+    "hpt_slugshot_turret_large": {
+        "mass": 8
+    },
+    "hpt_slugshot_turret_medium": {
+        "mass": 4
+    },
+    "hpt_slugshot_turret_small": {
+        "mass": 2
+    },
+    "hpt_xenoscanner_basic_tiny": {
+        "mass": 1.3
+    },
+    "hpt_xenoscannermk2_basic_tiny": {
+        "mass": 1.3
+    },
+    "independant_trader_armour_grade1": {
+        "mass": 0
+    },
+    "independant_trader_armour_grade2": {
+        "mass": 12
+    },
+    "independant_trader_armour_grade3": {
+        "mass": 23
+    },
+    "independant_trader_armour_mirrored": {
+        "mass": 23
+    },
+    "independant_trader_armour_reactive": {
+        "mass": 23
+    },
+    "int_buggybay_size2_class1": {
+        "mass": 12
+    },
+    "int_buggybay_size2_class2": {
+        "mass": 6
+    },
+    "int_buggybay_size4_class1": {
+        "mass": 20
+    },
+    "int_buggybay_size4_class2": {
+        "mass": 10
+    },
+    "int_buggybay_size6_class1": {
+        "mass": 34
+    },
+    "int_buggybay_size6_class2": {
+        "mass": 17
+    },
+    "int_cargorack_size1_class1": {
+        "mass": 0
+    },
+    "int_cargorack_size2_class1": {
+        "mass": 0
+    },
+    "int_cargorack_size3_class1": {
+        "mass": 0
+    },
+    "int_cargorack_size4_class1": {
+        "mass": 0
+    },
+    "int_cargorack_size5_class1": {
+        "mass": 0
+    },
+    "int_cargorack_size6_class1": {
+        "mass": 0
+    },
+    "int_cargorack_size7_class1": {
+        "mass": 0
+    },
+    "int_cargorack_size8_class1": {
+        "mass": 0
+    },
+    "int_corrosionproofcargorack_size1_class1": {
+        "mass": 0
+    },
+    "int_corrosionproofcargorack_size1_class2": {
+        "mass": 0
+    },
+    "int_corrosionproofcargorack_size4_class1": {
+        "mass": 0
+    },
+    "int_detailedsurfacescanner_tiny": {
+        "mass": 0
+    },
+    "int_dockingcomputer_advanced": {
+        "mass": 0
+    },
+    "int_dockingcomputer_standard": {
+        "mass": 0
+    },
+    "int_dronecontrol_collection_size1_class1": {
+        "mass": 0.5
+    },
+    "int_dronecontrol_collection_size1_class2": {
+        "mass": 0.5
+    },
+    "int_dronecontrol_collection_size1_class3": {
+        "mass": 1.3
+    },
+    "int_dronecontrol_collection_size1_class4": {
+        "mass": 2
+    },
+    "int_dronecontrol_collection_size1_class5": {
+        "mass": 2
+    },
+    "int_dronecontrol_collection_size3_class1": {
+        "mass": 2
+    },
+    "int_dronecontrol_collection_size3_class2": {
+        "mass": 2
+    },
+    "int_dronecontrol_collection_size3_class3": {
+        "mass": 5
+    },
+    "int_dronecontrol_collection_size3_class4": {
+        "mass": 8
+    },
+    "int_dronecontrol_collection_size3_class5": {
+        "mass": 8
+    },
+    "int_dronecontrol_collection_size5_class1": {
+        "mass": 8
+    },
+    "int_dronecontrol_collection_size5_class2": {
+        "mass": 8
+    },
+    "int_dronecontrol_collection_size5_class3": {
+        "mass": 20
+    },
+    "int_dronecontrol_collection_size5_class4": {
+        "mass": 32
+    },
+    "int_dronecontrol_collection_size5_class5": {
+        "mass": 32
+    },
+    "int_dronecontrol_collection_size7_class1": {
+        "mass": 32
+    },
+    "int_dronecontrol_collection_size7_class2": {
+        "mass": 32
+    },
+    "int_dronecontrol_collection_size7_class3": {
+        "mass": 80
+    },
+    "int_dronecontrol_collection_size7_class4": {
+        "mass": 128
+    },
+    "int_dronecontrol_collection_size7_class5": {
+        "mass": 128
+    },
+    "int_dronecontrol_decontamination_size1_class1": {
+        "mass": 1.3
+    },
+    "int_dronecontrol_decontamination_size3_class1": {
+        "mass": 2
+    },
+    "int_dronecontrol_decontamination_size5_class1": {
+        "mass": 20
+    },
+    "int_dronecontrol_decontamination_size7_class1": {
+        "mass": 128
+    },
+    "int_dronecontrol_fueltransfer_size1_class1": {
+        "mass": 1.3
+    },
+    "int_dronecontrol_fueltransfer_size1_class2": {
+        "mass": 0.5
+    },
+    "int_dronecontrol_fueltransfer_size1_class3": {
+        "mass": 1.3
+    },
+    "int_dronecontrol_fueltransfer_size1_class4": {
+        "mass": 2
+    },
+    "int_dronecontrol_fueltransfer_size1_class5": {
+        "mass": 1.3
+    },
+    "int_dronecontrol_fueltransfer_size3_class1": {
+        "mass": 5
+    },
+    "int_dronecontrol_fueltransfer_size3_class2": {
+        "mass": 2
+    },
+    "int_dronecontrol_fueltransfer_size3_class3": {
+        "mass": 5
+    },
+    "int_dronecontrol_fueltransfer_size3_class4": {
+        "mass": 8
+    },
+    "int_dronecontrol_fueltransfer_size3_class5": {
+        "mass": 5
+    },
+    "int_dronecontrol_fueltransfer_size5_class1": {
+        "mass": 20
+    },
+    "int_dronecontrol_fueltransfer_size5_class2": {
+        "mass": 8
+    },
+    "int_dronecontrol_fueltransfer_size5_class3": {
+        "mass": 20
+    },
+    "int_dronecontrol_fueltransfer_size5_class4": {
+        "mass": 32
+    },
+    "int_dronecontrol_fueltransfer_size5_class5": {
+        "mass": 20
+    },
+    "int_dronecontrol_fueltransfer_size7_class1": {
+        "mass": 80
+    },
+    "int_dronecontrol_fueltransfer_size7_class2": {
+        "mass": 32
+    },
+    "int_dronecontrol_fueltransfer_size7_class3": {
+        "mass": 80
+    },
+    "int_dronecontrol_fueltransfer_size7_class4": {
+        "mass": 128
+    },
+    "int_dronecontrol_fueltransfer_size7_class5": {
+        "mass": 80
+    },
+    "int_dronecontrol_prospector_size1_class1": {
+        "mass": 1.3
+    },
+    "int_dronecontrol_prospector_size1_class2": {
+        "mass": 0.5
+    },
+    "int_dronecontrol_prospector_size1_class3": {
+        "mass": 1.3
+    },
+    "int_dronecontrol_prospector_size1_class4": {
+        "mass": 2
+    },
+    "int_dronecontrol_prospector_size1_class5": {
+        "mass": 1.3
+    },
+    "int_dronecontrol_prospector_size3_class1": {
+        "mass": 5
+    },
+    "int_dronecontrol_prospector_size3_class2": {
+        "mass": 2
+    },
+    "int_dronecontrol_prospector_size3_class3": {
+        "mass": 5
+    },
+    "int_dronecontrol_prospector_size3_class4": {
+        "mass": 8
+    },
+    "int_dronecontrol_prospector_size3_class5": {
+        "mass": 5
+    },
+    "int_dronecontrol_prospector_size5_class1": {
+        "mass": 20
+    },
+    "int_dronecontrol_prospector_size5_class2": {
+        "mass": 8
+    },
+    "int_dronecontrol_prospector_size5_class3": {
+        "mass": 20
+    },
+    "int_dronecontrol_prospector_size5_class4": {
+        "mass": 32
+    },
+    "int_dronecontrol_prospector_size5_class5": {
+        "mass": 20
+    },
+    "int_dronecontrol_prospector_size7_class1": {
+        "mass": 80
+    },
+    "int_dronecontrol_prospector_size7_class2": {
+        "mass": 32
+    },
+    "int_dronecontrol_prospector_size7_class3": {
+        "mass": 80
+    },
+    "int_dronecontrol_prospector_size7_class4": {
+        "mass": 128
+    },
+    "int_dronecontrol_prospector_size7_class5": {
+        "mass": 80
+    },
+    "int_dronecontrol_recon_size1_class1": {
+        "mass": 1.3
+    },
+    "int_dronecontrol_recon_size3_class1": {
+        "mass": 2
+    },
+    "int_dronecontrol_recon_size5_class1": {
+        "mass": 20
+    },
+    "int_dronecontrol_recon_size7_class1": {
+        "mass": 128
+    },
+    "int_dronecontrol_repair_size1_class1": {
+        "mass": 1.3
+    },
+    "int_dronecontrol_repair_size1_class2": {
+        "mass": 0.5
+    },
+    "int_dronecontrol_repair_size1_class3": {
+        "mass": 1.3
+    },
+    "int_dronecontrol_repair_size1_class4": {
+        "mass": 2
+    },
+    "int_dronecontrol_repair_size1_class5": {
+        "mass": 1.3
+    },
+    "int_dronecontrol_repair_size3_class1": {
+        "mass": 5
+    },
+    "int_dronecontrol_repair_size3_class2": {
+        "mass": 2
+    },
+    "int_dronecontrol_repair_size3_class3": {
+        "mass": 5
+    },
+    "int_dronecontrol_repair_size3_class4": {
+        "mass": 8
+    },
+    "int_dronecontrol_repair_size3_class5": {
+        "mass": 5
+    },
+    "int_dronecontrol_repair_size5_class1": {
+        "mass": 20
+    },
+    "int_dronecontrol_repair_size5_class2": {
+        "mass": 8
+    },
+    "int_dronecontrol_repair_size5_class3": {
+        "mass": 20
+    },
+    "int_dronecontrol_repair_size5_class4": {
+        "mass": 32
+    },
+    "int_dronecontrol_repair_size5_class5": {
+        "mass": 20
+    },
+    "int_dronecontrol_repair_size7_class1": {
+        "mass": 80
+    },
+    "int_dronecontrol_repair_size7_class2": {
+        "mass": 32
+    },
+    "int_dronecontrol_repair_size7_class3": {
+        "mass": 80
+    },
+    "int_dronecontrol_repair_size7_class4": {
+        "mass": 128
+    },
+    "int_dronecontrol_repair_size7_class5": {
+        "mass": 80
+    },
+    "int_dronecontrol_resourcesiphon_size1_class1": {
+        "mass": 1.3
+    },
+    "int_dronecontrol_resourcesiphon_size1_class2": {
+        "mass": 0.5
+    },
+    "int_dronecontrol_resourcesiphon_size1_class3": {
+        "mass": 1.3
+    },
+    "int_dronecontrol_resourcesiphon_size1_class4": {
+        "mass": 2
+    },
+    "int_dronecontrol_resourcesiphon_size1_class5": {
+        "mass": 1.3
+    },
+    "int_dronecontrol_resourcesiphon_size3_class1": {
+        "mass": 5
+    },
+    "int_dronecontrol_resourcesiphon_size3_class2": {
+        "mass": 2
+    },
+    "int_dronecontrol_resourcesiphon_size3_class3": {
+        "mass": 5
+    },
+    "int_dronecontrol_resourcesiphon_size3_class4": {
+        "mass": 8
+    },
+    "int_dronecontrol_resourcesiphon_size3_class5": {
+        "mass": 5
+    },
+    "int_dronecontrol_resourcesiphon_size5_class1": {
+        "mass": 20
+    },
+    "int_dronecontrol_resourcesiphon_size5_class2": {
+        "mass": 8
+    },
+    "int_dronecontrol_resourcesiphon_size5_class3": {
+        "mass": 20
+    },
+    "int_dronecontrol_resourcesiphon_size5_class4": {
+        "mass": 32
+    },
+    "int_dronecontrol_resourcesiphon_size5_class5": {
+        "mass": 20
+    },
+    "int_dronecontrol_resourcesiphon_size7_class1": {
+        "mass": 80
+    },
+    "int_dronecontrol_resourcesiphon_size7_class2": {
+        "mass": 32
+    },
+    "int_dronecontrol_resourcesiphon_size7_class3": {
+        "mass": 80
+    },
+    "int_dronecontrol_resourcesiphon_size7_class4": {
+        "mass": 128
+    },
+    "int_dronecontrol_resourcesiphon_size7_class5": {
+        "mass": 80
+    },
+    "int_dronecontrol_unkvesselresearch": {
+        "mass": 1.3
+    },
+    "int_engine_size2_class1": {
+        "mass": 2.5
+    },
+    "int_engine_size2_class2": {
+        "mass": 1
+    },
+    "int_engine_size2_class3": {
+        "mass": 2.5
+    },
+    "int_engine_size2_class4": {
+        "mass": 4
+    },
+    "int_engine_size2_class5": {
+        "mass": 2.5
+    },
+    "int_engine_size2_class5_fast": {
+        "mass": 2.5
+    },
+    "int_engine_size3_class1": {
+        "mass": 5
+    },
+    "int_engine_size3_class2": {
+        "mass": 2
+    },
+    "int_engine_size3_class3": {
+        "mass": 5
+    },
+    "int_engine_size3_class4": {
+        "mass": 8
+    },
+    "int_engine_size3_class5": {
+        "mass": 5
+    },
+    "int_engine_size3_class5_fast": {
+        "mass": 5
+    },
+    "int_engine_size4_class1": {
+        "mass": 10
+    },
+    "int_engine_size4_class2": {
+        "mass": 4
+    },
+    "int_engine_size4_class3": {
+        "mass": 10
+    },
+    "int_engine_size4_class4": {
+        "mass": 16
+    },
+    "int_engine_size4_class5": {
+        "mass": 10
+    },
+    "int_engine_size5_class1": {
+        "mass": 20
+    },
+    "int_engine_size5_class2": {
+        "mass": 8
+    },
+    "int_engine_size5_class3": {
+        "mass": 20
+    },
+    "int_engine_size5_class4": {
+        "mass": 32
+    },
+    "int_engine_size5_class5": {
+        "mass": 20
+    },
+    "int_engine_size6_class1": {
+        "mass": 40
+    },
+    "int_engine_size6_class2": {
+        "mass": 16
+    },
+    "int_engine_size6_class3": {
+        "mass": 40
+    },
+    "int_engine_size6_class4": {
+        "mass": 64
+    },
+    "int_engine_size6_class5": {
+        "mass": 40
+    },
+    "int_engine_size7_class1": {
+        "mass": 80
+    },
+    "int_engine_size7_class2": {
+        "mass": 32
+    },
+    "int_engine_size7_class3": {
+        "mass": 80
+    },
+    "int_engine_size7_class4": {
+        "mass": 128
+    },
+    "int_engine_size7_class5": {
+        "mass": 80
+    },
+    "int_engine_size8_class1": {
+        "mass": 160
+    },
+    "int_engine_size8_class2": {
+        "mass": 64
+    },
+    "int_engine_size8_class3": {
+        "mass": 160
+    },
+    "int_engine_size8_class4": {
+        "mass": 256
+    },
+    "int_engine_size8_class5": {
+        "mass": 160
+    },
+    "int_fighterbay_size5_class1": {
+        "mass": 20
+    },
+    "int_fighterbay_size6_class1": {
+        "mass": 40
+    },
+    "int_fighterbay_size7_class1": {
+        "mass": 60
+    },
+    "int_fsdinterdictor_size1_class1": {
+        "mass": 1.3
+    },
+    "int_fsdinterdictor_size1_class2": {
+        "mass": 0.5
+    },
+    "int_fsdinterdictor_size1_class3": {
+        "mass": 1.3
+    },
+    "int_fsdinterdictor_size1_class4": {
+        "mass": 2
+    },
+    "int_fsdinterdictor_size1_class5": {
+        "mass": 1.3
+    },
+    "int_fsdinterdictor_size2_class1": {
+        "mass": 2.5
+    },
+    "int_fsdinterdictor_size2_class2": {
+        "mass": 1
+    },
+    "int_fsdinterdictor_size2_class3": {
+        "mass": 2.5
+    },
+    "int_fsdinterdictor_size2_class4": {
+        "mass": 4
+    },
+    "int_fsdinterdictor_size2_class5": {
+        "mass": 2.5
+    },
+    "int_fsdinterdictor_size3_class1": {
+        "mass": 5
+    },
+    "int_fsdinterdictor_size3_class2": {
+        "mass": 2
+    },
+    "int_fsdinterdictor_size3_class3": {
+        "mass": 5
+    },
+    "int_fsdinterdictor_size3_class4": {
+        "mass": 8
+    },
+    "int_fsdinterdictor_size3_class5": {
+        "mass": 5
+    },
+    "int_fsdinterdictor_size4_class1": {
+        "mass": 10
+    },
+    "int_fsdinterdictor_size4_class2": {
+        "mass": 4
+    },
+    "int_fsdinterdictor_size4_class3": {
+        "mass": 10
+    },
+    "int_fsdinterdictor_size4_class4": {
+        "mass": 16
+    },
+    "int_fsdinterdictor_size4_class5": {
+        "mass": 10
+    },
+    "int_fuelscoop_size1_class1": {
+        "mass": 0
+    },
+    "int_fuelscoop_size1_class2": {
+        "mass": 0
+    },
+    "int_fuelscoop_size1_class3": {
+        "mass": 0
+    },
+    "int_fuelscoop_size1_class4": {
+        "mass": 0
+    },
+    "int_fuelscoop_size1_class5": {
+        "mass": 0
+    },
+    "int_fuelscoop_size2_class1": {
+        "mass": 0
+    },
+    "int_fuelscoop_size2_class2": {
+        "mass": 0
+    },
+    "int_fuelscoop_size2_class3": {
+        "mass": 0
+    },
+    "int_fuelscoop_size2_class4": {
+        "mass": 0
+    },
+    "int_fuelscoop_size2_class5": {
+        "mass": 0
+    },
+    "int_fuelscoop_size3_class1": {
+        "mass": 0
+    },
+    "int_fuelscoop_size3_class2": {
+        "mass": 0
+    },
+    "int_fuelscoop_size3_class3": {
+        "mass": 0
+    },
+    "int_fuelscoop_size3_class4": {
+        "mass": 0
+    },
+    "int_fuelscoop_size3_class5": {
+        "mass": 0
+    },
+    "int_fuelscoop_size4_class1": {
+        "mass": 0
+    },
+    "int_fuelscoop_size4_class2": {
+        "mass": 0
+    },
+    "int_fuelscoop_size4_class3": {
+        "mass": 0
+    },
+    "int_fuelscoop_size4_class4": {
+        "mass": 0
+    },
+    "int_fuelscoop_size4_class5": {
+        "mass": 0
+    },
+    "int_fuelscoop_size5_class1": {
+        "mass": 0
+    },
+    "int_fuelscoop_size5_class2": {
+        "mass": 0
+    },
+    "int_fuelscoop_size5_class3": {
+        "mass": 0
+    },
+    "int_fuelscoop_size5_class4": {
+        "mass": 0
+    },
+    "int_fuelscoop_size5_class5": {
+        "mass": 0
+    },
+    "int_fuelscoop_size6_class1": {
+        "mass": 0
+    },
+    "int_fuelscoop_size6_class2": {
+        "mass": 0
+    },
+    "int_fuelscoop_size6_class3": {
+        "mass": 0
+    },
+    "int_fuelscoop_size6_class4": {
+        "mass": 0
+    },
+    "int_fuelscoop_size6_class5": {
+        "mass": 0
+    },
+    "int_fuelscoop_size7_class1": {
+        "mass": 0
+    },
+    "int_fuelscoop_size7_class2": {
+        "mass": 0
+    },
+    "int_fuelscoop_size7_class3": {
+        "mass": 0
+    },
+    "int_fuelscoop_size7_class4": {
+        "mass": 0
+    },
+    "int_fuelscoop_size7_class5": {
+        "mass": 0
+    },
+    "int_fuelscoop_size8_class1": {
+        "mass": 0
+    },
+    "int_fuelscoop_size8_class2": {
+        "mass": 0
+    },
+    "int_fuelscoop_size8_class3": {
+        "mass": 0
+    },
+    "int_fuelscoop_size8_class4": {
+        "mass": 0
+    },
+    "int_fuelscoop_size8_class5": {
+        "mass": 0
+    },
+    "int_fueltank_size1_class3": {
+        "mass": 0
+    },
+    "int_fueltank_size2_class3": {
+        "mass": 0
+    },
+    "int_fueltank_size3_class3": {
+        "mass": 0
+    },
+    "int_fueltank_size4_class3": {
+        "mass": 0
+    },
+    "int_fueltank_size5_class3": {
+        "mass": 0
+    },
+    "int_fueltank_size6_class3": {
+        "mass": 0
+    },
+    "int_fueltank_size7_class3": {
+        "mass": 0
+    },
+    "int_fueltank_size8_class3": {
+        "mass": 0
+    },
+    "int_guardianfsdbooster_size1": {
+        "mass": 1.3,
+        "jumpboost": 4
+    },
+    "int_guardianfsdbooster_size2": {
+        "mass": 1.3,
+        "jumpboost": 6
+    },
+    "int_guardianfsdbooster_size3": {
+        "mass": 1.3,
+        "jumpboost": 7.75
+    },
+    "int_guardianfsdbooster_size4": {
+        "mass": 1.3,
+        "jumpboost": 9.25
+    },
+    "int_guardianfsdbooster_size5": {
+        "mass": 1.3,
+        "jumpboost": 10.5
+    },
+    "int_guardianhullreinforcement_size1_class1": {
+        "mass": 2
+    },
+    "int_guardianhullreinforcement_size1_class2": {
+        "mass": 1
+    },
+    "int_guardianhullreinforcement_size2_class1": {
+        "mass": 4
+    },
+    "int_guardianhullreinforcement_size2_class2": {
+        "mass": 2
+    },
+    "int_guardianhullreinforcement_size3_class1": {
+        "mass": 8
+    },
+    "int_guardianhullreinforcement_size3_class2": {
+        "mass": 4
+    },
+    "int_guardianhullreinforcement_size4_class1": {
+        "mass": 16
+    },
+    "int_guardianhullreinforcement_size4_class2": {
+        "mass": 8
+    },
+    "int_guardianhullreinforcement_size5_class1": {
+        "mass": 32
+    },
+    "int_guardianhullreinforcement_size5_class2": {
+        "mass": 16
+    },
+    "int_guardianmodulereinforcement_size1_class1": {
+        "mass": 2
+    },
+    "int_guardianmodulereinforcement_size1_class2": {
+        "mass": 1
+    },
+    "int_guardianmodulereinforcement_size2_class1": {
+        "mass": 4
+    },
+    "int_guardianmodulereinforcement_size2_class2": {
+        "mass": 2
+    },
+    "int_guardianmodulereinforcement_size3_class1": {
+        "mass": 8
+    },
+    "int_guardianmodulereinforcement_size3_class2": {
+        "mass": 4
+    },
+    "int_guardianmodulereinforcement_size4_class1": {
+        "mass": 16
+    },
+    "int_guardianmodulereinforcement_size4_class2": {
+        "mass": 8
+    },
+    "int_guardianmodulereinforcement_size5_class1": {
+        "mass": 32
+    },
+    "int_guardianmodulereinforcement_size5_class2": {
+        "mass": 16
+    },
+    "int_guardianpowerdistributor_size1": {
+        "mass": 1.4
+    },
+    "int_guardianpowerdistributor_size2": {
+        "mass": 2.6
+    },
+    "int_guardianpowerdistributor_size3": {
+        "mass": 5.25
+    },
+    "int_guardianpowerdistributor_size4": {
+        "mass": 10.5
+    },
+    "int_guardianpowerdistributor_size5": {
+        "mass": 21
+    },
+    "int_guardianpowerdistributor_size6": {
+        "mass": 42
+    },
+    "int_guardianpowerdistributor_size7": {
+        "mass": 84
+    },
+    "int_guardianpowerdistributor_size8": {
+        "mass": 168
+    },
+    "int_guardianpowerplant_size2": {
+        "mass": 1.5
+    },
+    "int_guardianpowerplant_size3": {
+        "mass": 2.9
+    },
+    "int_guardianpowerplant_size4": {
+        "mass": 5.9
+    },
+    "int_guardianpowerplant_size5": {
+        "mass": 11.7
+    },
+    "int_guardianpowerplant_size6": {
+        "mass": 23.4
+    },
+    "int_guardianpowerplant_size7": {
+        "mass": 46.8
+    },
+    "int_guardianpowerplant_size8": {
+        "mass": 93.6
+    },
+    "int_guardianshieldreinforcement_size1_class1": {
+        "mass": 2
+    },
+    "int_guardianshieldreinforcement_size1_class2": {
+        "mass": 1
+    },
+    "int_guardianshieldreinforcement_size2_class1": {
+        "mass": 4
+    },
+    "int_guardianshieldreinforcement_size2_class2": {
+        "mass": 2
+    },
+    "int_guardianshieldreinforcement_size3_class1": {
+        "mass": 8
+    },
+    "int_guardianshieldreinforcement_size3_class2": {
+        "mass": 4
+    },
+    "int_guardianshieldreinforcement_size4_class1": {
+        "mass": 16
+    },
+    "int_guardianshieldreinforcement_size4_class2": {
+        "mass": 8
+    },
+    "int_guardianshieldreinforcement_size5_class1": {
+        "mass": 32
+    },
+    "int_guardianshieldreinforcement_size5_class2": {
+        "mass": 16
+    },
+    "int_hullreinforcement_size1_class1": {
+        "mass": 2
+    },
+    "int_hullreinforcement_size1_class2": {
+        "mass": 1
+    },
+    "int_hullreinforcement_size2_class1": {
+        "mass": 4
+    },
+    "int_hullreinforcement_size2_class2": {
+        "mass": 2
+    },
+    "int_hullreinforcement_size3_class1": {
+        "mass": 8
+    },
+    "int_hullreinforcement_size3_class2": {
+        "mass": 4
+    },
+    "int_hullreinforcement_size4_class1": {
+        "mass": 16
+    },
+    "int_hullreinforcement_size4_class2": {
+        "mass": 8
+    },
+    "int_hullreinforcement_size5_class1": {
+        "mass": 32
+    },
+    "int_hullreinforcement_size5_class2": {
+        "mass": 16
+    },
+    "int_hyperdrive_size2_class1": {
+        "mass": 2.5,
+        "optmass": 48,
+        "maxfuel": 0.6,
+        "fuelmul": 0.011,
+        "fuelpower": 2
+    },
+    "int_hyperdrive_size2_class2": {
+        "mass": 1,
+        "optmass": 54,
+        "maxfuel": 0.6,
+        "fuelmul": 0.01,
+        "fuelpower": 2
+    },
+    "int_hyperdrive_size2_class3": {
+        "mass": 2.5,
+        "optmass": 60,
+        "maxfuel": 0.6,
+        "fuelmul": 0.008,
+        "fuelpower": 2
+    },
+    "int_hyperdrive_size2_class4": {
+        "mass": 4,
+        "optmass": 75,
+        "maxfuel": 0.8,
+        "fuelmul": 0.01,
+        "fuelpower": 2
+    },
+    "int_hyperdrive_size2_class5": {
+        "mass": 2.5,
+        "optmass": 90,
+        "maxfuel": 0.9,
+        "fuelmul": 0.012,
+        "fuelpower": 2
+    },
+    "int_hyperdrive_size3_class1": {
+        "mass": 5,
+        "optmass": 80,
+        "maxfuel": 1.2,
+        "fuelmul": 0.011,
+        "fuelpower": 2.15
+    },
+    "int_hyperdrive_size3_class2": {
+        "mass": 2,
+        "optmass": 90,
+        "maxfuel": 1.2,
+        "fuelmul": 0.01,
+        "fuelpower": 2.15
+    },
+    "int_hyperdrive_size3_class3": {
+        "mass": 5,
+        "optmass": 100,
+        "maxfuel": 1.2,
+        "fuelmul": 0.008,
+        "fuelpower": 2.15
+    },
+    "int_hyperdrive_size3_class4": {
+        "mass": 8,
+        "optmass": 125,
+        "maxfuel": 1.5,
+        "fuelmul": 0.01,
+        "fuelpower": 2.15
+    },
+    "int_hyperdrive_size3_class5": {
+        "mass": 5,
+        "optmass": 150,
+        "maxfuel": 1.8,
+        "fuelmul": 0.012,
+        "fuelpower": 2.15
+    },
+    "int_hyperdrive_size4_class1": {
+        "mass": 10,
+        "optmass": 280,
+        "maxfuel": 2,
+        "fuelmul": 0.011,
+        "fuelpower": 2.3
+    },
+    "int_hyperdrive_size4_class2": {
+        "mass": 4,
+        "optmass": 315,
+        "maxfuel": 2,
+        "fuelmul": 0.01,
+        "fuelpower": 2.3
+    },
+    "int_hyperdrive_size4_class3": {
+        "mass": 10,
+        "optmass": 350,
+        "maxfuel": 2,
+        "fuelmul": 0.008,
+        "fuelpower": 2.3
+    },
+    "int_hyperdrive_size4_class4": {
+        "mass": 16,
+        "optmass": 437.5,
+        "maxfuel": 2.5,
+        "fuelmul": 0.01,
+        "fuelpower": 2.3
+    },
+    "int_hyperdrive_size4_class5": {
+        "mass": 10,
+        "optmass": 525,
+        "maxfuel": 3,
+        "fuelmul": 0.012,
+        "fuelpower": 2.3
+    },
+    "int_hyperdrive_size5_class1": {
+        "mass": 20,
+        "optmass": 560,
+        "maxfuel": 3.3,
+        "fuelmul": 0.011,
+        "fuelpower": 2.45
+    },
+    "int_hyperdrive_size5_class2": {
+        "mass": 8,
+        "optmass": 630,
+        "maxfuel": 3.3,
+        "fuelmul": 0.01,
+        "fuelpower": 2.45
+    },
+    "int_hyperdrive_size5_class3": {
+        "mass": 20,
+        "optmass": 700,
+        "maxfuel": 3.3,
+        "fuelmul": 0.008,
+        "fuelpower": 2.45
+    },
+    "int_hyperdrive_size5_class4": {
+        "mass": 32,
+        "optmass": 875,
+        "maxfuel": 4.1,
+        "fuelmul": 0.01,
+        "fuelpower": 2.45
+    },
+    "int_hyperdrive_size5_class5": {
+        "mass": 20,
+        "optmass": 1050,
+        "maxfuel": 5,
+        "fuelmul": 0.012,
+        "fuelpower": 2.45
+    },
+    "int_hyperdrive_size6_class1": {
+        "mass": 40,
+        "optmass": 960,
+        "maxfuel": 5.3,
+        "fuelmul": 0.011,
+        "fuelpower": 2.6
+    },
+    "int_hyperdrive_size6_class2": {
+        "mass": 16,
+        "optmass": 1080,
+        "maxfuel": 5.3,
+        "fuelmul": 0.01,
+        "fuelpower": 2.6
+    },
+    "int_hyperdrive_size6_class3": {
+        "mass": 40,
+        "optmass": 1200,
+        "maxfuel": 5.3,
+        "fuelmul": 0.008,
+        "fuelpower": 2.6
+    },
+    "int_hyperdrive_size6_class4": {
+        "mass": 64,
+        "optmass": 1500,
+        "maxfuel": 6.6,
+        "fuelmul": 0.01,
+        "fuelpower": 2.6
+    },
+    "int_hyperdrive_size6_class5": {
+        "mass": 40,
+        "optmass": 1800,
+        "maxfuel": 8,
+        "fuelmul": 0.012,
+        "fuelpower": 2.6
+    },
+    "int_hyperdrive_size7_class1": {
+        "mass": 80,
+        "optmass": 1440,
+        "maxfuel": 8.5,
+        "fuelmul": 0.011,
+        "fuelpower": 2.75
+    },
+    "int_hyperdrive_size7_class2": {
+        "mass": 32,
+        "optmass": 1620,
+        "maxfuel": 8.5,
+        "fuelmul": 0.01,
+        "fuelpower": 2.75
+    },
+    "int_hyperdrive_size7_class3": {
+        "mass": 80,
+        "optmass": 1800,
+        "maxfuel": 8.5,
+        "fuelmul": 0.008,
+        "fuelpower": 2.75
+    },
+    "int_hyperdrive_size7_class4": {
+        "mass": 128,
+        "optmass": 2250,
+        "maxfuel": 10.6,
+        "fuelmul": 0.01,
+        "fuelpower": 2.75
+    },
+    "int_hyperdrive_size7_class5": {
+        "mass": 80,
+        "optmass": 2700,
+        "maxfuel": 12.8,
+        "fuelmul": 0.012,
+        "fuelpower": 2.75
+    },
+    "int_hyperdrive_size8_class1": {
+        "mass": 160,
+        "optmass": 0,
+        "maxfuel": 0,
+        "fuelmul": 0.011,
+        "fuelpower": 2.9
+    },
+    "int_hyperdrive_size8_class2": {
+        "mass": 64,
+        "optmass": 0,
+        "maxfuel": 0,
+        "fuelmul": 0.01,
+        "fuelpower": 2.9
+    },
+    "int_hyperdrive_size8_class3": {
+        "mass": 160,
+        "optmass": 0,
+        "maxfuel": 0,
+        "fuelmul": 0.008,
+        "fuelpower": 2.9
+    },
+    "int_hyperdrive_size8_class4": {
+        "mass": 256,
+        "optmass": 0,
+        "maxfuel": 0,
+        "fuelmul": 0.01,
+        "fuelpower": 2.9
+    },
+    "int_hyperdrive_size8_class5": {
+        "mass": 160,
+        "optmass": 0,
+        "maxfuel": 0,
+        "fuelmul": 0.012,
+        "fuelpower": 2.9
+    },
+    "int_lifesupport_size1_class1": {
+        "mass": 1.3
+    },
+    "int_lifesupport_size1_class2": {
+        "mass": 0.5
+    },
+    "int_lifesupport_size1_class3": {
+        "mass": 1.3
+    },
+    "int_lifesupport_size1_class4": {
+        "mass": 2
+    },
+    "int_lifesupport_size1_class5": {
+        "mass": 1.3
+    },
+    "int_lifesupport_size2_class1": {
+        "mass": 2.5
+    },
+    "int_lifesupport_size2_class2": {
+        "mass": 1
+    },
+    "int_lifesupport_size2_class3": {
+        "mass": 2.5
+    },
+    "int_lifesupport_size2_class4": {
+        "mass": 4
+    },
+    "int_lifesupport_size2_class5": {
+        "mass": 2.5
+    },
+    "int_lifesupport_size3_class1": {
+        "mass": 5
+    },
+    "int_lifesupport_size3_class2": {
+        "mass": 2
+    },
+    "int_lifesupport_size3_class3": {
+        "mass": 5
+    },
+    "int_lifesupport_size3_class4": {
+        "mass": 8
+    },
+    "int_lifesupport_size3_class5": {
+        "mass": 5
+    },
+    "int_lifesupport_size4_class1": {
+        "mass": 10
+    },
+    "int_lifesupport_size4_class2": {
+        "mass": 4
+    },
+    "int_lifesupport_size4_class3": {
+        "mass": 10
+    },
+    "int_lifesupport_size4_class4": {
+        "mass": 16
+    },
+    "int_lifesupport_size4_class5": {
+        "mass": 10
+    },
+    "int_lifesupport_size5_class1": {
+        "mass": 20
+    },
+    "int_lifesupport_size5_class2": {
+        "mass": 8
+    },
+    "int_lifesupport_size5_class3": {
+        "mass": 20
+    },
+    "int_lifesupport_size5_class4": {
+        "mass": 32
+    },
+    "int_lifesupport_size5_class5": {
+        "mass": 20
+    },
+    "int_lifesupport_size6_class1": {
+        "mass": 40
+    },
+    "int_lifesupport_size6_class2": {
+        "mass": 16
+    },
+    "int_lifesupport_size6_class3": {
+        "mass": 40
+    },
+    "int_lifesupport_size6_class4": {
+        "mass": 64
+    },
+    "int_lifesupport_size6_class5": {
+        "mass": 40
+    },
+    "int_lifesupport_size7_class1": {
+        "mass": 80
+    },
+    "int_lifesupport_size7_class2": {
+        "mass": 32
+    },
+    "int_lifesupport_size7_class3": {
+        "mass": 80
+    },
+    "int_lifesupport_size7_class4": {
+        "mass": 128
+    },
+    "int_lifesupport_size7_class5": {
+        "mass": 80
+    },
+    "int_lifesupport_size8_class1": {
+        "mass": 160
+    },
+    "int_lifesupport_size8_class2": {
+        "mass": 64
+    },
+    "int_lifesupport_size8_class3": {
+        "mass": 160
+    },
+    "int_lifesupport_size8_class4": {
+        "mass": 256
+    },
+    "int_lifesupport_size8_class5": {
+        "mass": 160
+    },
+    "int_metaalloyhullreinforcement_size1_class1": {
+        "mass": 2
+    },
+    "int_metaalloyhullreinforcement_size1_class2": {
+        "mass": 2
+    },
+    "int_metaalloyhullreinforcement_size2_class1": {
+        "mass": 4
+    },
+    "int_metaalloyhullreinforcement_size2_class2": {
+        "mass": 2
+    },
+    "int_metaalloyhullreinforcement_size3_class1": {
+        "mass": 8
+    },
+    "int_metaalloyhullreinforcement_size3_class2": {
+        "mass": 4
+    },
+    "int_metaalloyhullreinforcement_size4_class1": {
+        "mass": 16
+    },
+    "int_metaalloyhullreinforcement_size4_class2": {
+        "mass": 8
+    },
+    "int_metaalloyhullreinforcement_size5_class1": {
+        "mass": 32
+    },
+    "int_metaalloyhullreinforcement_size5_class2": {
+        "mass": 16
+    },
+    "int_modulereinforcement_size1_class1": {
+        "mass": 2
+    },
+    "int_modulereinforcement_size1_class2": {
+        "mass": 1
+    },
+    "int_modulereinforcement_size2_class1": {
+        "mass": 4
+    },
+    "int_modulereinforcement_size2_class2": {
+        "mass": 2
+    },
+    "int_modulereinforcement_size3_class1": {
+        "mass": 8
+    },
+    "int_modulereinforcement_size3_class2": {
+        "mass": 4
+    },
+    "int_modulereinforcement_size4_class1": {
+        "mass": 16
+    },
+    "int_modulereinforcement_size4_class2": {
+        "mass": 8
+    },
+    "int_modulereinforcement_size5_class1": {
+        "mass": 32
+    },
+    "int_modulereinforcement_size5_class2": {
+        "mass": 16
+    },
+    "int_multidronecontrol_mining_size3_class1": {
+        "mass": 12
+    },
+    "int_multidronecontrol_mining_size3_class3": {
+        "mass": 10
+    },
+    "int_multidronecontrol_operations_size3_class3": {
+        "mass": 10
+    },
+    "int_multidronecontrol_operations_size3_class4": {
+        "mass": 15
+    },
+    "int_multidronecontrol_rescue_size3_class2": {
+        "mass": 8
+    },
+    "int_multidronecontrol_rescue_size3_class3": {
+        "mass": 10
+    },
+    "int_multidronecontrol_universal_size7_class3": {
+        "mass": 125
+    },
+    "int_multidronecontrol_universal_size7_class5": {
+        "mass": 140
+    },
+    "int_multidronecontrol_xeno_size3_class3": {
+        "mass": 10
+    },
+    "int_multidronecontrol_xeno_size3_class4": {
+        "mass": 15
+    },
+    "int_passengercabin_size2_class1": {
+        "mass": 2.5
+    },
+    "int_passengercabin_size3_class1": {
+        "mass": 5
+    },
+    "int_passengercabin_size3_class2": {
+        "mass": 5
+    },
+    "int_passengercabin_size4_class1": {
+        "mass": 10
+    },
+    "int_passengercabin_size4_class2": {
+        "mass": 10
+    },
+    "int_passengercabin_size4_class3": {
+        "mass": 10
+    },
+    "int_passengercabin_size5_class1": {
+        "mass": 20
+    },
+    "int_passengercabin_size5_class2": {
+        "mass": 20
+    },
+    "int_passengercabin_size5_class3": {
+        "mass": 20
+    },
+    "int_passengercabin_size5_class4": {
+        "mass": 20
+    },
+    "int_passengercabin_size6_class1": {
+        "mass": 40
+    },
+    "int_passengercabin_size6_class2": {
+        "mass": 40
+    },
+    "int_passengercabin_size6_class3": {
+        "mass": 40
+    },
+    "int_passengercabin_size6_class4": {
+        "mass": 40
+    },
+    "int_planetapproachsuite": {
+        "mass": 0
+    },
+    "int_powerdistributor_size1_class1": {
+        "mass": 1.3
+    },
+    "int_powerdistributor_size1_class2": {
+        "mass": 0.5
+    },
+    "int_powerdistributor_size1_class3": {
+        "mass": 1.3
+    },
+    "int_powerdistributor_size1_class4": {
+        "mass": 2
+    },
+    "int_powerdistributor_size1_class5": {
+        "mass": 1.3
+    },
+    "int_powerdistributor_size2_class1": {
+        "mass": 2.5
+    },
+    "int_powerdistributor_size2_class2": {
+        "mass": 1
+    },
+    "int_powerdistributor_size2_class3": {
+        "mass": 2.5
+    },
+    "int_powerdistributor_size2_class4": {
+        "mass": 4
+    },
+    "int_powerdistributor_size2_class5": {
+        "mass": 2.5
+    },
+    "int_powerdistributor_size3_class1": {
+        "mass": 5
+    },
+    "int_powerdistributor_size3_class2": {
+        "mass": 2
+    },
+    "int_powerdistributor_size3_class3": {
+        "mass": 5
+    },
+    "int_powerdistributor_size3_class4": {
+        "mass": 8
+    },
+    "int_powerdistributor_size3_class5": {
+        "mass": 5
+    },
+    "int_powerdistributor_size4_class1": {
+        "mass": 10
+    },
+    "int_powerdistributor_size4_class2": {
+        "mass": 4
+    },
+    "int_powerdistributor_size4_class3": {
+        "mass": 10
+    },
+    "int_powerdistributor_size4_class4": {
+        "mass": 16
+    },
+    "int_powerdistributor_size4_class5": {
+        "mass": 10
+    },
+    "int_powerdistributor_size5_class1": {
+        "mass": 20
+    },
+    "int_powerdistributor_size5_class2": {
+        "mass": 8
+    },
+    "int_powerdistributor_size5_class3": {
+        "mass": 20
+    },
+    "int_powerdistributor_size5_class4": {
+        "mass": 32
+    },
+    "int_powerdistributor_size5_class5": {
+        "mass": 20
+    },
+    "int_powerdistributor_size6_class1": {
+        "mass": 40
+    },
+    "int_powerdistributor_size6_class2": {
+        "mass": 16
+    },
+    "int_powerdistributor_size6_class3": {
+        "mass": 40
+    },
+    "int_powerdistributor_size6_class4": {
+        "mass": 64
+    },
+    "int_powerdistributor_size6_class5": {
+        "mass": 40
+    },
+    "int_powerdistributor_size7_class1": {
+        "mass": 80
+    },
+    "int_powerdistributor_size7_class2": {
+        "mass": 32
+    },
+    "int_powerdistributor_size7_class3": {
+        "mass": 80
+    },
+    "int_powerdistributor_size7_class4": {
+        "mass": 128
+    },
+    "int_powerdistributor_size7_class5": {
+        "mass": 80
+    },
+    "int_powerdistributor_size8_class1": {
+        "mass": 160
+    },
+    "int_powerdistributor_size8_class2": {
+        "mass": 64
+    },
+    "int_powerdistributor_size8_class3": {
+        "mass": 160
+    },
+    "int_powerdistributor_size8_class4": {
+        "mass": 256
+    },
+    "int_powerdistributor_size8_class5": {
+        "mass": 160
+    },
+    "int_powerplant_size2_class1": {
+        "mass": 2.5
+    },
+    "int_powerplant_size2_class2": {
+        "mass": 1
+    },
+    "int_powerplant_size2_class3": {
+        "mass": 1.3
+    },
+    "int_powerplant_size2_class4": {
+        "mass": 2
+    },
+    "int_powerplant_size2_class5": {
+        "mass": 1.3
+    },
+    "int_powerplant_size3_class1": {
+        "mass": 5
+    },
+    "int_powerplant_size3_class2": {
+        "mass": 2
+    },
+    "int_powerplant_size3_class3": {
+        "mass": 2.5
+    },
+    "int_powerplant_size3_class4": {
+        "mass": 4
+    },
+    "int_powerplant_size3_class5": {
+        "mass": 2.5
+    },
+    "int_powerplant_size4_class1": {
+        "mass": 10
+    },
+    "int_powerplant_size4_class2": {
+        "mass": 4
+    },
+    "int_powerplant_size4_class3": {
+        "mass": 5
+    },
+    "int_powerplant_size4_class4": {
+        "mass": 8
+    },
+    "int_powerplant_size4_class5": {
+        "mass": 5
+    },
+    "int_powerplant_size5_class1": {
+        "mass": 20
+    },
+    "int_powerplant_size5_class2": {
+        "mass": 8
+    },
+    "int_powerplant_size5_class3": {
+        "mass": 10
+    },
+    "int_powerplant_size5_class4": {
+        "mass": 16
+    },
+    "int_powerplant_size5_class5": {
+        "mass": 10
+    },
+    "int_powerplant_size6_class1": {
+        "mass": 40
+    },
+    "int_powerplant_size6_class2": {
+        "mass": 16
+    },
+    "int_powerplant_size6_class3": {
+        "mass": 20
+    },
+    "int_powerplant_size6_class4": {
+        "mass": 32
+    },
+    "int_powerplant_size6_class5": {
+        "mass": 20
+    },
+    "int_powerplant_size7_class1": {
+        "mass": 80
+    },
+    "int_powerplant_size7_class2": {
+        "mass": 32
+    },
+    "int_powerplant_size7_class3": {
+        "mass": 40
+    },
+    "int_powerplant_size7_class4": {
+        "mass": 64
+    },
+    "int_powerplant_size7_class5": {
+        "mass": 40
+    },
+    "int_powerplant_size8_class1": {
+        "mass": 160
+    },
+    "int_powerplant_size8_class2": {
+        "mass": 64
+    },
+    "int_powerplant_size8_class3": {
+        "mass": 80
+    },
+    "int_powerplant_size8_class4": {
+        "mass": 128
+    },
+    "int_powerplant_size8_class5": {
+        "mass": 80
+    },
+    "int_refinery_size1_class1": {
+        "mass": 0
+    },
+    "int_refinery_size1_class2": {
+        "mass": 0
+    },
+    "int_refinery_size1_class3": {
+        "mass": 0
+    },
+    "int_refinery_size1_class4": {
+        "mass": 0
+    },
+    "int_refinery_size1_class5": {
+        "mass": 0
+    },
+    "int_refinery_size2_class1": {
+        "mass": 0
+    },
+    "int_refinery_size2_class2": {
+        "mass": 0
+    },
+    "int_refinery_size2_class3": {
+        "mass": 0
+    },
+    "int_refinery_size2_class4": {
+        "mass": 0
+    },
+    "int_refinery_size2_class5": {
+        "mass": 0
+    },
+    "int_refinery_size3_class1": {
+        "mass": 0
+    },
+    "int_refinery_size3_class2": {
+        "mass": 0
+    },
+    "int_refinery_size3_class3": {
+        "mass": 0
+    },
+    "int_refinery_size3_class4": {
+        "mass": 0
+    },
+    "int_refinery_size3_class5": {
+        "mass": 0
+    },
+    "int_refinery_size4_class1": {
+        "mass": 0
+    },
+    "int_refinery_size4_class2": {
+        "mass": 0
+    },
+    "int_refinery_size4_class3": {
+        "mass": 0
+    },
+    "int_refinery_size4_class4": {
+        "mass": 0
+    },
+    "int_refinery_size4_class5": {
+        "mass": 0
+    },
+    "int_repairer_size1_class1": {
+        "mass": 0
+    },
+    "int_repairer_size1_class2": {
+        "mass": 0
+    },
+    "int_repairer_size1_class3": {
+        "mass": 0
+    },
+    "int_repairer_size1_class4": {
+        "mass": 0
+    },
+    "int_repairer_size1_class5": {
+        "mass": 0
+    },
+    "int_repairer_size2_class1": {
+        "mass": 0
+    },
+    "int_repairer_size2_class2": {
+        "mass": 0
+    },
+    "int_repairer_size2_class3": {
+        "mass": 0
+    },
+    "int_repairer_size2_class4": {
+        "mass": 0
+    },
+    "int_repairer_size2_class5": {
+        "mass": 0
+    },
+    "int_repairer_size3_class1": {
+        "mass": 0
+    },
+    "int_repairer_size3_class2": {
+        "mass": 0
+    },
+    "int_repairer_size3_class3": {
+        "mass": 0
+    },
+    "int_repairer_size3_class4": {
+        "mass": 0
+    },
+    "int_repairer_size3_class5": {
+        "mass": 0
+    },
+    "int_repairer_size4_class1": {
+        "mass": 0
+    },
+    "int_repairer_size4_class2": {
+        "mass": 0
+    },
+    "int_repairer_size4_class3": {
+        "mass": 0
+    },
+    "int_repairer_size4_class4": {
+        "mass": 0
+    },
+    "int_repairer_size4_class5": {
+        "mass": 0
+    },
+    "int_repairer_size5_class1": {
+        "mass": 0
+    },
+    "int_repairer_size5_class2": {
+        "mass": 0
+    },
+    "int_repairer_size5_class3": {
+        "mass": 0
+    },
+    "int_repairer_size5_class4": {
+        "mass": 0
+    },
+    "int_repairer_size5_class5": {
+        "mass": 0
+    },
+    "int_repairer_size6_class1": {
+        "mass": 0
+    },
+    "int_repairer_size6_class2": {
+        "mass": 0
+    },
+    "int_repairer_size6_class3": {
+        "mass": 0
+    },
+    "int_repairer_size6_class4": {
+        "mass": 0
+    },
+    "int_repairer_size6_class5": {
+        "mass": 0
+    },
+    "int_repairer_size7_class1": {
+        "mass": 0
+    },
+    "int_repairer_size7_class2": {
+        "mass": 0
+    },
+    "int_repairer_size7_class3": {
+        "mass": 0
+    },
+    "int_repairer_size7_class4": {
+        "mass": 0
+    },
+    "int_repairer_size7_class5": {
+        "mass": 0
+    },
+    "int_repairer_size8_class1": {
+        "mass": 0
+    },
+    "int_repairer_size8_class2": {
+        "mass": 0
+    },
+    "int_repairer_size8_class3": {
+        "mass": 0
+    },
+    "int_repairer_size8_class4": {
+        "mass": 0
+    },
+    "int_repairer_size8_class5": {
+        "mass": 0
+    },
+    "int_sensors_size1_class1": {
+        "mass": 1.3
+    },
+    "int_sensors_size1_class2": {
+        "mass": 0.5
+    },
+    "int_sensors_size1_class3": {
+        "mass": 1.3
+    },
+    "int_sensors_size1_class4": {
+        "mass": 2
+    },
+    "int_sensors_size1_class5": {
+        "mass": 1.3
+    },
+    "int_sensors_size2_class1": {
+        "mass": 2.5
+    },
+    "int_sensors_size2_class2": {
+        "mass": 1
+    },
+    "int_sensors_size2_class3": {
+        "mass": 2.5
+    },
+    "int_sensors_size2_class4": {
+        "mass": 4
+    },
+    "int_sensors_size2_class5": {
+        "mass": 2.5
+    },
+    "int_sensors_size3_class1": {
+        "mass": 5
+    },
+    "int_sensors_size3_class2": {
+        "mass": 2
+    },
+    "int_sensors_size3_class3": {
+        "mass": 5
+    },
+    "int_sensors_size3_class4": {
+        "mass": 8
+    },
+    "int_sensors_size3_class5": {
+        "mass": 5
+    },
+    "int_sensors_size4_class1": {
+        "mass": 10
+    },
+    "int_sensors_size4_class2": {
+        "mass": 4
+    },
+    "int_sensors_size4_class3": {
+        "mass": 10
+    },
+    "int_sensors_size4_class4": {
+        "mass": 16
+    },
+    "int_sensors_size4_class5": {
+        "mass": 10
+    },
+    "int_sensors_size5_class1": {
+        "mass": 20
+    },
+    "int_sensors_size5_class2": {
+        "mass": 8
+    },
+    "int_sensors_size5_class3": {
+        "mass": 20
+    },
+    "int_sensors_size5_class4": {
+        "mass": 32
+    },
+    "int_sensors_size5_class5": {
+        "mass": 20
+    },
+    "int_sensors_size6_class1": {
+        "mass": 40
+    },
+    "int_sensors_size6_class2": {
+        "mass": 16
+    },
+    "int_sensors_size6_class3": {
+        "mass": 40
+    },
+    "int_sensors_size6_class4": {
+        "mass": 64
+    },
+    "int_sensors_size6_class5": {
+        "mass": 40
+    },
+    "int_sensors_size7_class1": {
+        "mass": 80
+    },
+    "int_sensors_size7_class2": {
+        "mass": 32
+    },
+    "int_sensors_size7_class3": {
+        "mass": 80
+    },
+    "int_sensors_size7_class4": {
+        "mass": 128
+    },
+    "int_sensors_size7_class5": {
+        "mass": 80
+    },
+    "int_sensors_size8_class1": {
+        "mass": 160
+    },
+    "int_sensors_size8_class2": {
+        "mass": 64
+    },
+    "int_sensors_size8_class3": {
+        "mass": 160
+    },
+    "int_sensors_size8_class4": {
+        "mass": 256
+    },
+    "int_sensors_size8_class5": {
+        "mass": 160
+    },
+    "int_shieldcellbank_size1_class1": {
+        "mass": 1.3
+    },
+    "int_shieldcellbank_size1_class2": {
+        "mass": 0.5
+    },
+    "int_shieldcellbank_size1_class3": {
+        "mass": 1.3
+    },
+    "int_shieldcellbank_size1_class4": {
+        "mass": 2
+    },
+    "int_shieldcellbank_size1_class5": {
+        "mass": 1.3
+    },
+    "int_shieldcellbank_size2_class1": {
+        "mass": 2.5
+    },
+    "int_shieldcellbank_size2_class2": {
+        "mass": 1
+    },
+    "int_shieldcellbank_size2_class3": {
+        "mass": 2.5
+    },
+    "int_shieldcellbank_size2_class4": {
+        "mass": 4
+    },
+    "int_shieldcellbank_size2_class5": {
+        "mass": 2.5
+    },
+    "int_shieldcellbank_size3_class1": {
+        "mass": 5
+    },
+    "int_shieldcellbank_size3_class2": {
+        "mass": 2
+    },
+    "int_shieldcellbank_size3_class3": {
+        "mass": 5
+    },
+    "int_shieldcellbank_size3_class4": {
+        "mass": 8
+    },
+    "int_shieldcellbank_size3_class5": {
+        "mass": 5
+    },
+    "int_shieldcellbank_size4_class1": {
+        "mass": 10
+    },
+    "int_shieldcellbank_size4_class2": {
+        "mass": 4
+    },
+    "int_shieldcellbank_size4_class3": {
+        "mass": 10
+    },
+    "int_shieldcellbank_size4_class4": {
+        "mass": 16
+    },
+    "int_shieldcellbank_size4_class5": {
+        "mass": 10
+    },
+    "int_shieldcellbank_size5_class1": {
+        "mass": 20
+    },
+    "int_shieldcellbank_size5_class2": {
+        "mass": 8
+    },
+    "int_shieldcellbank_size5_class3": {
+        "mass": 20
+    },
+    "int_shieldcellbank_size5_class4": {
+        "mass": 32
+    },
+    "int_shieldcellbank_size5_class5": {
+        "mass": 20
+    },
+    "int_shieldcellbank_size6_class1": {
+        "mass": 40
+    },
+    "int_shieldcellbank_size6_class2": {
+        "mass": 16
+    },
+    "int_shieldcellbank_size6_class3": {
+        "mass": 40
+    },
+    "int_shieldcellbank_size6_class4": {
+        "mass": 64
+    },
+    "int_shieldcellbank_size6_class5": {
+        "mass": 40
+    },
+    "int_shieldcellbank_size7_class1": {
+        "mass": 80
+    },
+    "int_shieldcellbank_size7_class2": {
+        "mass": 32
+    },
+    "int_shieldcellbank_size7_class3": {
+        "mass": 80
+    },
+    "int_shieldcellbank_size7_class4": {
+        "mass": 128
+    },
+    "int_shieldcellbank_size7_class5": {
+        "mass": 80
+    },
+    "int_shieldcellbank_size8_class1": {
+        "mass": 160
+    },
+    "int_shieldcellbank_size8_class2": {
+        "mass": 64
+    },
+    "int_shieldcellbank_size8_class3": {
+        "mass": 160
+    },
+    "int_shieldcellbank_size8_class4": {
+        "mass": 256
+    },
+    "int_shieldcellbank_size8_class5": {
+        "mass": 160
+    },
+    "int_shieldgenerator_size1_class3_fast": {
+        "mass": 1.3
+    },
+    "int_shieldgenerator_size1_class5": {
+        "mass": 1.3
+    },
+    "int_shieldgenerator_size1_class5_strong": {
+        "mass": 2.5
+    },
+    "int_shieldgenerator_size2_class1": {
+        "mass": 2.5
+    },
+    "int_shieldgenerator_size2_class2": {
+        "mass": 1
+    },
+    "int_shieldgenerator_size2_class3": {
+        "mass": 2.5
+    },
+    "int_shieldgenerator_size2_class3_fast": {
+        "mass": 2.5
+    },
+    "int_shieldgenerator_size2_class4": {
+        "mass": 4
+    },
+    "int_shieldgenerator_size2_class5": {
+        "mass": 2.5
+    },
+    "int_shieldgenerator_size2_class5_strong": {
+        "mass": 5
+    },
+    "int_shieldgenerator_size3_class1": {
+        "mass": 5
+    },
+    "int_shieldgenerator_size3_class2": {
+        "mass": 2
+    },
+    "int_shieldgenerator_size3_class3": {
+        "mass": 5
+    },
+    "int_shieldgenerator_size3_class3_fast": {
+        "mass": 5
+    },
+    "int_shieldgenerator_size3_class4": {
+        "mass": 8
+    },
+    "int_shieldgenerator_size3_class5": {
+        "mass": 5
+    },
+    "int_shieldgenerator_size3_class5_strong": {
+        "mass": 10
+    },
+    "int_shieldgenerator_size4_class1": {
+        "mass": 10
+    },
+    "int_shieldgenerator_size4_class2": {
+        "mass": 4
+    },
+    "int_shieldgenerator_size4_class3": {
+        "mass": 10
+    },
+    "int_shieldgenerator_size4_class3_fast": {
+        "mass": 10
+    },
+    "int_shieldgenerator_size4_class4": {
+        "mass": 16
+    },
+    "int_shieldgenerator_size4_class5": {
+        "mass": 10
+    },
+    "int_shieldgenerator_size4_class5_strong": {
+        "mass": 20
+    },
+    "int_shieldgenerator_size5_class1": {
+        "mass": 20
+    },
+    "int_shieldgenerator_size5_class2": {
+        "mass": 8
+    },
+    "int_shieldgenerator_size5_class3": {
+        "mass": 20
+    },
+    "int_shieldgenerator_size5_class3_fast": {
+        "mass": 20
+    },
+    "int_shieldgenerator_size5_class4": {
+        "mass": 32
+    },
+    "int_shieldgenerator_size5_class5": {
+        "mass": 20
+    },
+    "int_shieldgenerator_size5_class5_strong": {
+        "mass": 40
+    },
+    "int_shieldgenerator_size6_class1": {
+        "mass": 40
+    },
+    "int_shieldgenerator_size6_class2": {
+        "mass": 16
+    },
+    "int_shieldgenerator_size6_class3": {
+        "mass": 40
+    },
+    "int_shieldgenerator_size6_class3_fast": {
+        "mass": 40
+    },
+    "int_shieldgenerator_size6_class4": {
+        "mass": 64
+    },
+    "int_shieldgenerator_size6_class5": {
+        "mass": 40
+    },
+    "int_shieldgenerator_size6_class5_strong": {
+        "mass": 80
+    },
+    "int_shieldgenerator_size7_class1": {
+        "mass": 80
+    },
+    "int_shieldgenerator_size7_class2": {
+        "mass": 32
+    },
+    "int_shieldgenerator_size7_class3": {
+        "mass": 80
+    },
+    "int_shieldgenerator_size7_class3_fast": {
+        "mass": 80
+    },
+    "int_shieldgenerator_size7_class4": {
+        "mass": 128
+    },
+    "int_shieldgenerator_size7_class5": {
+        "mass": 80
+    },
+    "int_shieldgenerator_size7_class5_strong": {
+        "mass": 160
+    },
+    "int_shieldgenerator_size8_class1": {
+        "mass": 160
+    },
+    "int_shieldgenerator_size8_class2": {
+        "mass": 64
+    },
+    "int_shieldgenerator_size8_class3": {
+        "mass": 160
+    },
+    "int_shieldgenerator_size8_class3_fast": {
+        "mass": 160
+    },
+    "int_shieldgenerator_size8_class4": {
+        "mass": 256
+    },
+    "int_shieldgenerator_size8_class5": {
+        "mass": 160
+    },
+    "int_shieldgenerator_size8_class5_strong": {
+        "mass": 320
+    },
+    "int_stellarbodydiscoveryscanner_advanced": {
+        "mass": 2
+    },
+    "int_stellarbodydiscoveryscanner_intermediate": {
+        "mass": 2
+    },
+    "int_stellarbodydiscoveryscanner_standard": {
+        "mass": 2
+    },
+    "int_supercruiseassist": {
+        "mass": 0
+    },
+    "krait_light_armour_grade1": {
+        "mass": 0
+    },
+    "krait_light_armour_grade2": {
+        "mass": 26
+    },
+    "krait_light_armour_grade3": {
+        "mass": 53
+    },
+    "krait_light_armour_mirrored": {
+        "mass": 53
+    },
+    "krait_light_armour_reactive": {
+        "mass": 53
+    },
+    "krait_mkii_armour_grade1": {
+        "mass": 0
+    },
+    "krait_mkii_armour_grade2": {
+        "mass": 36
+    },
+    "krait_mkii_armour_grade3": {
+        "mass": 67
+    },
+    "krait_mkii_armour_mirrored": {
+        "mass": 67
+    },
+    "krait_mkii_armour_reactive": {
+        "mass": 67
+    },
+    "mamba_armour_grade1": {
+        "mass": 0
+    },
+    "mamba_armour_grade2": {
+        "mass": 19
+    },
+    "mamba_armour_grade3": {
+        "mass": 38
+    },
+    "mamba_armour_mirrored": {
+        "mass": 38
+    },
+    "mamba_armour_reactive": {
+        "mass": 38
+    },
+    "orca_armour_grade1": {
+        "mass": 0
+    },
+    "orca_armour_grade2": {
+        "mass": 21
+    },
+    "orca_armour_grade3": {
+        "mass": 87
+    },
+    "orca_armour_mirrored": {
+        "mass": 87
+    },
+    "orca_armour_reactive": {
+        "mass": 87
+    },
+    "python_armour_grade1": {
+        "mass": 0
+    },
+    "python_armour_grade2": {
+        "mass": 26
+    },
+    "python_armour_grade3": {
+        "mass": 53
+    },
+    "python_armour_mirrored": {
+        "mass": 53
+    },
+    "python_armour_reactive": {
+        "mass": 53
+    },
+    "sidewinder_armour_grade1": {
+        "mass": 0
+    },
+    "sidewinder_armour_grade2": {
+        "mass": 2
+    },
+    "sidewinder_armour_grade3": {
+        "mass": 4
+    },
+    "sidewinder_armour_mirrored": {
+        "mass": 4
+    },
+    "sidewinder_armour_reactive": {
+        "mass": 4
+    },
+    "type6_armour_grade1": {
+        "mass": 0
+    },
+    "type6_armour_grade2": {
+        "mass": 12
+    },
+    "type6_armour_grade3": {
+        "mass": 23
+    },
+    "type6_armour_mirrored": {
+        "mass": 23
+    },
+    "type6_armour_reactive": {
+        "mass": 23
+    },
+    "type7_armour_grade1": {
+        "mass": 0
+    },
+    "type7_armour_grade2": {
+        "mass": 32
+    },
+    "type7_armour_grade3": {
+        "mass": 63
+    },
+    "type7_armour_mirrored": {
+        "mass": 63
+    },
+    "type7_armour_reactive": {
+        "mass": 63
+    },
+    "type9_armour_grade1": {
+        "mass": 0
+    },
+    "type9_armour_grade2": {
+        "mass": 75
+    },
+    "type9_armour_grade3": {
+        "mass": 150
+    },
+    "type9_armour_mirrored": {
+        "mass": 150
+    },
+    "type9_armour_reactive": {
+        "mass": 150
+    },
+    "type9_military_armour_grade1": {
+        "mass": 0
+    },
+    "type9_military_armour_grade2": {
+        "mass": 75
+    },
+    "type9_military_armour_grade3": {
+        "mass": 150
+    },
+    "type9_military_armour_mirrored": {
+        "mass": 150
+    },
+    "type9_military_armour_reactive": {
+        "mass": 150
+    },
+    "typex_2_armour_grade1": {
+        "mass": 0
+    },
+    "typex_2_armour_grade2": {
+        "mass": 40
+    },
+    "typex_2_armour_grade3": {
+        "mass": 78
+    },
+    "typex_2_armour_mirrored": {
+        "mass": 78
+    },
+    "typex_2_armour_reactive": {
+        "mass": 78
+    },
+    "typex_3_armour_grade1": {
+        "mass": 0
+    },
+    "typex_3_armour_grade2": {
+        "mass": 40
+    },
+    "typex_3_armour_grade3": {
+        "mass": 78
+    },
+    "typex_3_armour_mirrored": {
+        "mass": 78
+    },
+    "typex_3_armour_reactive": {
+        "mass": 78
+    },
+    "typex_armour_grade1": {
+        "mass": 0
+    },
+    "typex_armour_grade2": {
+        "mass": 40
+    },
+    "typex_armour_grade3": {
+        "mass": 78
+    },
+    "typex_armour_mirrored": {
+        "mass": 78
+    },
+    "typex_armour_reactive": {
+        "mass": 78
+    },
+    "viper_armour_grade1": {
+        "mass": 0
+    },
+    "viper_armour_grade2": {
+        "mass": 5
+    },
+    "viper_armour_grade3": {
+        "mass": 9
+    },
+    "viper_armour_mirrored": {
+        "mass": 9
+    },
+    "viper_armour_reactive": {
+        "mass": 9
+    },
+    "viper_mkiv_armour_grade1": {
+        "mass": 0
+    },
+    "viper_mkiv_armour_grade2": {
+        "mass": 5
+    },
+    "viper_mkiv_armour_grade3": {
+        "mass": 9
+    },
+    "viper_mkiv_armour_mirrored": {
+        "mass": 9
+    },
+    "viper_mkiv_armour_reactive": {
+        "mass": 9
+    },
+    "vulture_armour_grade1": {
+        "mass": 0
+    },
+    "vulture_armour_grade2": {
+        "mass": 17
+    },
+    "vulture_armour_grade3": {
+        "mass": 35
+    },
+    "vulture_armour_mirrored": {
+        "mass": 35
+    },
+    "vulture_armour_reactive": {
+        "mass": 35
+    }
+}

--- a/resources/ships.json
+++ b/resources/ships.json
@@ -1,0 +1,116 @@
+{
+    "Adder": {
+        "hullMass": 35
+    },
+    "Alliance Challenger": {
+        "hullMass": 450
+    },
+    "Alliance Chieftain": {
+        "hullMass": 400
+    },
+    "Alliance Crusader": {
+        "hullMass": 500
+    },
+    "Anaconda": {
+        "hullMass": 400
+    },
+    "Asp Explorer": {
+        "hullMass": 280
+    },
+    "Asp Scout": {
+        "hullMass": 150
+    },
+    "Beluga Liner": {
+        "hullMass": 950
+    },
+    "Cobra MkIII": {
+        "hullMass": 180
+    },
+    "Cobra MkIV": {
+        "hullMass": 210
+    },
+    "Diamondback Explorer": {
+        "hullMass": 260
+    },
+    "Diamondback Scout": {
+        "hullMass": 170
+    },
+    "Dolphin": {
+        "hullMass": 140
+    },
+    "Eagle": {
+        "hullMass": 50
+    },
+    "Federal Assault Ship": {
+        "hullMass": 480
+    },
+    "Federal Corvette": {
+        "hullMass": 900
+    },
+    "Federal Dropship": {
+        "hullMass": 580
+    },
+    "Federal Gunship": {
+        "hullMass": 580
+    },
+    "Fer-de-Lance": {
+        "hullMass": 250
+    },
+    "Hauler": {
+        "hullMass": 14
+    },
+    "Imperial Clipper": {
+        "hullMass": 400
+    },
+    "Imperial Courier": {
+        "hullMass": 35
+    },
+    "Imperial Cutter": {
+        "hullMass": 1100
+    },
+    "Imperial Eagle": {
+        "hullMass": 50
+    },
+    "Keelback": {
+        "hullMass": 180
+    },
+    "Krait MkII": {
+        "hullMass": 320
+    },
+    "Krait Phantom": {
+        "hullMass": 270
+    },
+    "Mamba": {
+        "hullMass": 250
+    },
+    "Orca": {
+        "hullMass": 290
+    },
+    "Python": {
+        "hullMass": 350
+    },
+    "Sidewinder": {
+        "hullMass": 25
+    },
+    "Type-10 Defender": {
+        "hullMass": 1200
+    },
+    "Type-6 Transporter": {
+        "hullMass": 155
+    },
+    "Type-7 Transporter": {
+        "hullMass": 350
+    },
+    "Type-9 Heavy": {
+        "hullMass": 850
+    },
+    "Viper MkIII": {
+        "hullMass": 50
+    },
+    "Viper MkIV": {
+        "hullMass": 190
+    },
+    "Vulture": {
+        "hullMass": 230
+    }
+}


### PR DESCRIPTION
# Description
Updates a few more of the supporting core EDMC files. The biggest change here is removing the usage of ships.p and modules.p, and replacing them with json equivalent files. This is a security and readability update, as Pickle has a number of serious concerns about it's existence. 

Due to API requirements, we can't just remove it here. However, these files are officially deprecated and should be removed in 6.0.

Additionally, makes a few enhancements and logic flow improvements to existing code.

Derived from #2068 

## Type of change
- Rewrite of Existing Code
- Deprecation of Old Methods

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- Tests of installation, operation, and building on developer machine
- All PyTest tests pass