### PR TITLE
[1843] Update URL Parameter Encoding

### DIFF
--- a/companion.py
+++ b/companion.py
@@ -395,7 +395,7 @@ class Auth:
         webbrowser.open(
             f'{FRONTIER_AUTH_SERVER}{self.FRONTIER_AUTH_PATH_AUTH}?response_type=code'
             f'&audience=frontier,steam,epic'
-            f'&scope=auth capi'
+            f'&scope=auth%20capi'
             f'&client_id={self.CLIENT_ID}'
             f'&code_challenge={challenge}'
             f'&code_challenge_method=S256'


### PR DESCRIPTION
# Description
In rare edge cases, how the API authentication key is called can be sent to the web browser incorrectly, meaning that the request fails on the API scope query. This endeavors to remove the ambiguous space, given the evidence and logs provided in #1843. 

## Type of change
- Minor Bug Fix

# How Has This Been Tested?
- Tests of installation, operation, and building on the developer's machine
- All PyTest tests pass

Closes #1843 