### PR TITLE
[555] Move Default Registry Creation

### DIFF
--- a/build.py
+++ b/build.py
@@ -19,12 +19,16 @@ from config import (
     copyright,
     git_shorthash_from_head,
     _static_appversion,
+    update_interval
 )
 
 
 def iss_build(template_path: str, output_file: str) -> None:
     """Build the .iss file needed for building the installer EXE."""
-    sub_vals = {"appver": _static_appversion}
+    sub_vals = {
+        "appver": _static_appversion,
+        "update_time": str(update_interval),
+        }
     with open(template_path, encoding="UTF8") as template_file:
         src = Template(template_file.read())
         newfile = src.substitute(sub_vals)

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -60,7 +60,7 @@ _cached_version: semantic_version.Version | None = None
 copyright = '© 2015-2019 Jonathan Harris, 2020-2023 EDCD'
 
 update_feed = 'https://raw.githubusercontent.com/EDCD/EDMarketConnector/releases/edmarketconnector.xml'
-update_interval = 8*60*60
+update_interval = 8*60*60  # 8 Hours
 # Providers marked to be in debug mode. Generally this is expected to switch to sending data to a log file
 debug_senders: list[str] = []
 # TRACE logging code that should actually be used.  Means not spamming it

--- a/docs/Translations.md
+++ b/docs/Translations.md
@@ -34,8 +34,7 @@ _('stuff')
 
 #### Edit `L10n/en.template` to add the phrase
 
-##### Hint: It is strongly recommended to use the find_localized_strings.py script to help automate this process!
-
+##### Hint: It is strongly recommended to use the `find_localized_strings.py` script to help automate this process!
 	/* <use of this phrase> [<file it was first added in>] */
 	"<text as it appears in the code>" = "<English version of the text>";
 e.g.

--- a/resources/EDMC_Installer_Config_template.txt
+++ b/resources/EDMC_Installer_Config_template.txt
@@ -1,6 +1,7 @@
 #define MyAppName "EDMarketConnector"
 #define MyAppLongName "Elite Dangerous Market Connector"
 #define MyAppVersion "$appver"
+#define MyAppUpdateTime "$update_time"
 #define MyAppPublisher "EDCD"
 #define MyAppURL "https://edcd.github.io/"
 #define SuppURL "https://github.com/EDCD/EDMarketConnector/"
@@ -34,6 +35,7 @@ AlwaysShowDirOnReadyPage=yes
 UninstallDisplayIcon={app}\{#MyAppExeName}
 MinVersion=6.2
 ChangesAssociations = yes
+UsedUserAreasWarning = no
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -113,6 +115,11 @@ Root: HKCR; Subkey: "edmc\shell\open"; Flags: uninsdeletekey
 Root: HKCR; Subkey: "edmc\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\EDMarketConnector.exe"" ""%1"""; Flags: uninsdeletekey
 ; Create the "ddeexec" subkey under the "open" subkey
 Root: HKCR; Subkey: "edmc\shell\open\ddeexec"; ValueType: string; ValueName: ""; ValueData: "Open(""%1"")"; Flags: uninsdeletekey
+; Create WinSparkle related keys for update values
+Root: HKCU; Subkey: "Software\EDCD\EDMarketConnector"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\EDCD\EDMarketConnector\WinSparkle"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\EDCD\EDMarketConnector\WinSparkle"; ValueType: string; ValueName: "UpdateInterval"; ValueData: "{#MyAppUpdateTime}"; Flags: createvalueifdoesntexist
+Root: HKCU; Subkey: "Software\EDCD\EDMarketConnector\WinSparkle"; ValueType: string; ValueName: "CheckForUpdates"; ValueData: "1"; Flags: createvalueifdoesntexist
 
 [InstallDelete]
 Type: filesandordirs; Name: "{app}"


### PR DESCRIPTION
# Description
Attempts to move the WinSparkle key creation from the Windows config itself to the InnoSetup INI file. This is done in such a way as to try and reduce some overhead as well as create these values if and only if they don't already exist. 

## Type of change
- Feature Enhancement

# How Has This Been Tested?
- Tests of installation, operation, and building on the developer's machine
- All PyTest tests pass
- Manual edits of registry values to test survivability

Closes #555