### PR TITLE
Broken Plugins Popup

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -2325,6 +2325,7 @@ sys.path: {sys.path}'''
 
     root.wm_attributes('-alpha', ui_transparency / 100)
     # Display message box about plugins without Python 3.x support
+    # Display message box about plugins that failed to load
     root.after(0, messagebox_broken_plugins)
     # Display message box about plugins without Python 3.x support
     root.after(1, messagebox_not_py3)

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -2262,11 +2262,11 @@ sys.path: {sys.path}'''
     def messagebox_broken_plugins():
         """Display message about plugins not updated for Python 3.x."""
         if plug.PLUGINS_broken:
-            # LANG: Popup-text about 'broken' plugins that failoed to load
+            # LANG: Popup-text about 'broken' plugins that failed to load
             popup_text = _(
                 "One or more of your enabled plugins failed to load. Please see the list on the '{PLUGINS}' "
                 "tab of '{FILE}' > '{SETTINGS}'. This could be caused by a wrong folder structure. The load.py "
-                "file should be located under plugins/PLUGIN_NAME/load.py.\r\n\r\nYou can disable a plugin by "
+                r"file should be located under plugins/PLUGIN_NAME/load.py.\r\n\r\nYou can disable a plugin by "
                 "renaming its folder to have '{DISABLED}' on the end of the name."
             )
 
@@ -2282,7 +2282,7 @@ sys.path: {sys.path}'''
             popup_text = popup_text.replace('\\r', '\r')
 
             tk.messagebox.showinfo(
-                # LANG: Popup window title for list of 'broken' plugins that failoed to load
+                # LANG: Popup window title for list of 'broken' plugins that failed to load
                 _('EDMC: Broken Plugins'),
                 popup_text
             )

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -2259,6 +2259,34 @@ sys.path: {sys.path}'''
 
     app = AppWindow(root)
 
+    def messagebox_broken_plugins():
+        """Display message about plugins not updated for Python 3.x."""
+        if plug.PLUGINS_broken:
+            # LANG: Popup-text about 'broken' plugins that failoed to load
+            popup_text = _(
+                "One or more of your enabled plugins failed to load. Please see the list on the '{PLUGINS}' "
+                "tab of '{FILE}' > '{SETTINGS}'. This could be caused by a wrong folder structure. The load.py "
+                "file should be located under plugins/PLUGIN_NAME/load.py.\r\n\r\nYou can disable a plugin by "
+                "renaming its folder to have '{DISABLED}' on the end of the name."
+            )
+
+            # Substitute in the other words.
+            popup_text = popup_text.format(
+                PLUGINS=_('Plugins'),  # LANG: Settings > Plugins tab
+                FILE=_('File'),  # LANG: 'File' menu
+                SETTINGS=_('Settings'),  # LANG: File > Settings
+                DISABLED='.disabled'
+            )
+            # And now we do need these to be actual \r\n
+            popup_text = popup_text.replace('\\n', '\n')
+            popup_text = popup_text.replace('\\r', '\r')
+
+            tk.messagebox.showinfo(
+                # LANG: Popup window title for list of 'broken' plugins that failoed to load
+                _('EDMC: Broken Plugins'),
+                popup_text
+            )
+
     def messagebox_not_py3():
         """Display message about plugins not updated for Python 3.x."""
         plugins_not_py3_last = config.get_int('plugins_not_py3_last', default=0)
@@ -2297,9 +2325,11 @@ sys.path: {sys.path}'''
 
     root.wm_attributes('-alpha', ui_transparency / 100)
     # Display message box about plugins without Python 3.x support
-    root.after(0, messagebox_not_py3)
+    root.after(0, messagebox_broken_plugins)
+    # Display message box about plugins without Python 3.x support
+    root.after(1, messagebox_not_py3)
     # Show warning popup for killswitches matching current version
-    root.after(1, show_killswitch_poppup, root)
+    root.after(2, show_killswitch_poppup, root)
     # Start the main event loop
     root.mainloop()
 

--- a/L10n/en.template
+++ b/L10n/en.template
@@ -213,11 +213,17 @@
 /* EDMarketConnector.py: Popup-text about 'active' plugins without Python 3.x support; In files: EDMarketConnector.py:2253:2259; */
 "One or more of your enabled plugins do not yet have support for Python 3.x. Please see the list on the '{PLUGINS}' tab of '{FILE}' > '{SETTINGS}'. You should check if there is an updated version available, else alert the developer that they need to update the code for Python 3.x.\r\n\r\nYou can disable a plugin by renaming its folder to have '{DISABLED}' on the end of the name." = "One or more of your enabled plugins do not yet have support for Python 3.x. Please see the list on the '{PLUGINS}' tab of '{FILE}' > '{SETTINGS}'. You should check if there is an updated version available, else alert the developer that they need to update the code for Python 3.x.\r\n\r\nYou can disable a plugin by renaming its folder to have '{DISABLED}' on the end of the name.";
 
+/* EDMarketConnector.py: Popup-text about 'broken' plugins without Python 3.x support; In files: EDMarketConnector.py:2266:2271; */
+"One or more of your enabled plugins failed to load. Please see the list on the '{PLUGINS}' tab of '{FILE}' > '{SETTINGS}'. This could be caused by a wrong folder structure. The load.py file should be located under plugins/PLUGIN_NAME/load.py.\r\n\r\nYou can disable a plugin by renaming its folder to have '{DISABLED}' on the end of the name." = "One or more of your enabled plugins failed to load. Please see the list on the '{PLUGINS}' tab of '{FILE}' > '{SETTINGS}'. This could be caused by a wrong folder structure. The load.py file should be located under plugins/PLUGIN_NAME/load.py.\r\n\r\nYou can disable a plugin by renaming its folder to have '{DISABLED}' on the end of the name.";
+
 /* EDMarketConnector.py: Settings > Plugins tab; prefs.py: Label on Settings > Plugins tab; In files: EDMarketConnector.py:2263; prefs.py:986; */
 "Plugins" = "Plugins";
 
 /* EDMarketConnector.py: Popup window title for list of 'enabled' plugins that don't work with Python 3.x; In files: EDMarketConnector.py:2274; */
 "EDMC: Plugins Without Python 3.x Support" = "EDMC: Plugins Without Python 3.x Support";
+
+/* EDMarketConnector.py: Popup window title for list of 'broken' plugins that failoed to load; In files: EDMarketConnector.py:2285; */
+"EDMC: Broken Plugins" = "EDMC: Broken Plugins";
 
 /* journal_lock.py: Title text on popup when Journal directory already locked; In files: journal_lock.py:208; */
 "Journal directory already locked" = "Journal directory already locked";
@@ -471,11 +477,14 @@
 /* prefs.py: Label on list of enabled plugins; In files: prefs.py:934; */
 "Enabled Plugins" = "Enabled Plugins";
 
-
 /* prefs.py: Plugins - Label for list of 'enabled' plugins that don't work with Python 3.x; In files: prefs.py:954; */
 "Plugins Without Python 3.x Support:" = "Plugins Without Python 3.x Support:";
+
 /* prefs.py: Plugins - Label on URL to documentation about migrating plugins from Python 2.7; In files: prefs.py:962; */
 "Information on migrating plugins" = "Information on migrating plugins";
+
+/* prefs.py: Plugins - Label for list of 'broken' plugins that failed to load; In files: prefs.py:1039; */
+"Broken Plugins" = "Broken Plugins";
 
 /* prefs.py: Lable on list of user-disabled plugins; In files: prefs.py:977; */
 "Disabled Plugins" = "Disabled Plugins";

--- a/L10n/en.template
+++ b/L10n/en.template
@@ -213,17 +213,17 @@
 /* EDMarketConnector.py: Popup-text about 'active' plugins without Python 3.x support; In files: EDMarketConnector.py:2253:2259; */
 "One or more of your enabled plugins do not yet have support for Python 3.x. Please see the list on the '{PLUGINS}' tab of '{FILE}' > '{SETTINGS}'. You should check if there is an updated version available, else alert the developer that they need to update the code for Python 3.x.\r\n\r\nYou can disable a plugin by renaming its folder to have '{DISABLED}' on the end of the name." = "One or more of your enabled plugins do not yet have support for Python 3.x. Please see the list on the '{PLUGINS}' tab of '{FILE}' > '{SETTINGS}'. You should check if there is an updated version available, else alert the developer that they need to update the code for Python 3.x.\r\n\r\nYou can disable a plugin by renaming its folder to have '{DISABLED}' on the end of the name.";
 
-/* EDMarketConnector.py: Popup-text about 'broken' plugins without Python 3.x support; In files: EDMarketConnector.py:2266:2271; */
-"One or more of your enabled plugins failed to load. Please see the list on the '{PLUGINS}' tab of '{FILE}' > '{SETTINGS}'. This could be caused by a wrong folder structure. The load.py file should be located under plugins/PLUGIN_NAME/load.py.\r\n\r\nYou can disable a plugin by renaming its folder to have '{DISABLED}' on the end of the name." = "One or more of your enabled plugins failed to load. Please see the list on the '{PLUGINS}' tab of '{FILE}' > '{SETTINGS}'. This could be caused by a wrong folder structure. The load.py file should be located under plugins/PLUGIN_NAME/load.py.\r\n\r\nYou can disable a plugin by renaming its folder to have '{DISABLED}' on the end of the name.";
-
 /* EDMarketConnector.py: Settings > Plugins tab; prefs.py: Label on Settings > Plugins tab; In files: EDMarketConnector.py:2263; prefs.py:986; */
 "Plugins" = "Plugins";
 
 /* EDMarketConnector.py: Popup window title for list of 'enabled' plugins that don't work with Python 3.x; In files: EDMarketConnector.py:2274; */
 "EDMC: Plugins Without Python 3.x Support" = "EDMC: Plugins Without Python 3.x Support";
 
-/* EDMarketConnector.py: Popup window title for list of 'broken' plugins that failoed to load; In files: EDMarketConnector.py:2285; */
+/* EDMarketConnector.py: Popup window title for list of 'broken' plugins that failed to load; In files: EDMarketConnector.py:2285; */
 "EDMC: Broken Plugins" = "EDMC: Broken Plugins";
+
+/* EDMarketConnector.py: Popup-text about 'broken' plugins that failed to load; In files: EDMarketConnector.py:2266; */
+"One or more of your enabled plugins failed to load. Please see the list on the '{PLUGINS}' tab of '{FILE}' > '{SETTINGS}'. This could be caused by a wrong folder structure. The load.py file should be located under plugins/PLUGIN_NAME/load.py.\r\n\r\nYou can disable a plugin by renaming its folder to have '{DISABLED}' on the end of the name." = "One or more of your enabled plugins failed to load. Please see the list on the '{PLUGINS}' tab of '{FILE}' > '{SETTINGS}'. This could be caused by a wrong folder structure. The load.py file should be located under plugins/PLUGIN_NAME/load.py.\r\n\r\nYou can disable a plugin by renaming its folder to have '{DISABLED}' on the end of the name.";
 
 /* journal_lock.py: Title text on popup when Journal directory already locked; In files: journal_lock.py:208; */
 "Journal directory already locked" = "Journal directory already locked";
@@ -267,9 +267,6 @@
 /* coriolis.py: Settings>Coriolis - invalid override mode found; In files: coriolis.py:156; */
 "Invalid Coriolis override mode!" = "Invalid Coriolis override mode!";
 
-
-/* eddb.py: Journal Processing disabled due to an active killswitch; In files: eddb.py:179; */
-"EDDB Journal processing disabled. See Log." = "EDDB Journal processing disabled. See Log.";
 /* eddn.py: Error while trying to send data to EDDN; In files: eddn.py:458; eddn.py:2413; eddn.py:2451; eddn.py:2519; */
 "Error: Can't connect to EDDN" = "Error: Can't connect to EDDN";
 
@@ -297,9 +294,6 @@
 /* eddn.py: Status text shown while attempting to send data; In files: eddn.py:2507; */
 "Sending data to EDDN..." = "Sending data to EDDN...";
 
-
-/* edsm.py: Settings>EDSM - Label on checkbox for 'send data'; In files: edsm.py:308; */
-"Send flight log and Cmdr status to EDSM" = "Send flight log and Cmdr status to EDSM";
 /* edsm.py: Settings>EDSM - Label on header/URL to EDSM API key page; In files: edsm.py:319; */
 "Elite Dangerous Star Map credentials" = "Elite Dangerous Star Map credentials";
 
@@ -478,7 +472,7 @@
 "Enabled Plugins" = "Enabled Plugins";
 
 /* prefs.py: Plugins - Label for list of 'enabled' plugins that don't work with Python 3.x; In files: prefs.py:954; */
-"Plugins Without Python 3.x Support:" = "Plugins Without Python 3.x Support:";
+"Plugins Without Python 3.x Support" = "Plugins Without Python 3.x Support";
 
 /* prefs.py: Plugins - Label on URL to documentation about migrating plugins from Python 2.7; In files: prefs.py:962; */
 "Information on migrating plugins" = "Information on migrating plugins";

--- a/coriolis-update-files.py
+++ b/coriolis-update-files.py
@@ -28,8 +28,12 @@ if __name__ == "__main__":
         assert name not in modules, name
         modules[name] = attributes
 
-    # Regenerate coriolis-data distribution
-    subprocess.check_call('npm install', cwd='coriolis-data', shell=True, stdout=sys.stdout, stderr=sys.stderr)
+    try:
+        # Regenerate coriolis-data distribution
+        subprocess.check_call('npm install', cwd='coriolis-data', shell=True, stdout=sys.stdout, stderr=sys.stderr)
+    except NotADirectoryError as err:
+        sys.exit("Coriolis-Data Directory not found! Have you set up your submodules? \n"
+                 "https://github.com/EDCD/EDMarketConnector/wiki/Running-from-source#obtain-a-copy-of-the-application-source")
 
     file_path = 'coriolis-data/dist/index.json'
     with open(file_path) as file:

--- a/coriolis-update-files.py
+++ b/coriolis-update-files.py
@@ -31,9 +31,9 @@ if __name__ == "__main__":
     try:
         # Regenerate coriolis-data distribution
         subprocess.check_call('npm install', cwd='coriolis-data', shell=True, stdout=sys.stdout, stderr=sys.stderr)
-    except NotADirectoryError as err:
+    except NotADirectoryError:
         sys.exit("Coriolis-Data Directory not found! Have you set up your submodules? \n"
-                 "https://github.com/EDCD/EDMarketConnector/wiki/Running-from-source#obtain-a-copy-of-the-application-source")
+                 "https://github.com/EDCD/EDMarketConnector/wiki/Running-from-source#obtain-a-copy-of-the-application-source")  # noqa: E501
 
     file_path = 'coriolis-data/dist/index.json'
     with open(file_path) as file:

--- a/plug.py
+++ b/plug.py
@@ -27,6 +27,7 @@ logger = get_main_logger()
 # List of loaded Plugins
 PLUGINS = []
 PLUGINS_not_py3 = []
+PLUGINS_broken = []
 
 
 # For asynchronous error display
@@ -198,6 +199,7 @@ def _load_found_plugins():
                 plugin_logger = EDMCLogging.get_plugin_logger(name)
                 found.append(Plugin(name, os.path.join(config.plugin_dir_path, name, 'load.py'), plugin_logger))
             except Exception:
+                PLUGINS_broken.append(Plugin(name, None, logger))
                 logger.exception(f'Failure loading found Plugin "{name}"')
                 pass
     return found

--- a/prefs.py
+++ b/prefs.py
@@ -1029,6 +1029,23 @@ class PreferencesDialog(tk.Toplevel):
                 nb.Label(plugins_frame, text=plugin.name).grid(
                     columnspan=2, padx=self.LISTX, pady=self.PADY, sticky=tk.W, row=row.get()
                 )
+        ############################################################
+        # Show plugins that failed to load
+        ############################################################
+        if len(plug.PLUGINS_broken):
+            ttk.Separator(plugins_frame, orient=tk.HORIZONTAL).grid(
+                columnspan=3, padx=self.PADX, pady=self.SEPY, sticky=tk.EW, row=row.get()
+            )
+            # LANG: Plugins - Label for list of 'broken' plugins that failed to load
+            nb.Label(plugins_frame, text=_('Broken Plugins')+':').grid(
+                padx=self.PADX, pady=self.PADY, sticky=tk.W, row=row.get()
+            )
+
+            for plugin in plug.PLUGINS_broken:
+                if plugin.folder:  # 'system' ones have this set to None to suppress listing in Plugins prefs tab
+                    nb.Label(plugins_frame, text=plugin.name).grid(
+                        columnspan=2, padx=self.LISTX, pady=self.PADY, sticky=tk.W, row=row.get()
+                    )
 
         # LANG: Label on Settings > Plugins tab
         notebook.add(plugins_frame, text=_('Plugins'))		# Tab heading in settings


### PR DESCRIPTION
# Description
Adds a popup at startup about plugins that failed to load, presumably due to a wrong folder structure. This popup will come up at every EDMC start, unlike the "Plugin without Python 3.x support" one that only pops up every 24h. This PR also adds a list of those Plugins under their own entry in the Settings - Plugins tab.

## Type of change
- Adds a Popup at startup about Plugins that failed to load.
- Adds entry about broken Plugins in the Settings - Plugins tab.
- Adds corresponding translation entries.
- Includes a minor fix for try/except if coriolis-data is missing.

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- All PyTest tests pass.
- `find_localised_strings.py` doesn't complain.
- Multiple install runs.
- Tested feature with multiple "broken" plugins.