### PR TITLE
[1801] Add Warning for FDevIDs

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -2319,11 +2319,11 @@ sys.path: {sys.path}'''
             config.set('plugins_not_py3_last', int(time()))
 
     def check_fdev_ids():
-        """Display message about missing FDEVID files"""
+        """Display message about missing FDEVID files."""
         fdev_files = {'commodity.csv', 'rare_commodity.csv'}
         for file in fdev_files:
-            file = pathlib.Path(config.respath_path / 'FDevIDs' / file)
-            if file.is_file():
+            fdevid_file = pathlib.Path(config.respath_path / 'FDevIDs' / file)
+            if fdevid_file.is_file():
                 continue
             # LANG: Popup-text about missing FDEVID Files
             popup_text = _(

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -2318,6 +2318,35 @@ sys.path: {sys.path}'''
             )
             config.set('plugins_not_py3_last', int(time()))
 
+    def check_fdev_ids():
+        """Display message about missing FDEVID files"""
+        fdev_files = {'commodity.csv', 'rare_commodity.csv'}
+        for file in fdev_files:
+            file = pathlib.Path(config.respath_path / 'FDevIDs' / file)
+            if file.is_file():
+                continue
+            # LANG: Popup-text about missing FDEVID Files
+            popup_text = _(
+                "FDevID Files not found! Some functionality regarding commodities "
+                r"may be disabled.\r\n\r\n Do you want to open the Wiki page on "
+                "how to set up submodules?"
+            )
+            # And now we do need these to be actual \r\n
+            popup_text = popup_text.replace('\\n', '\n')
+            popup_text = popup_text.replace('\\r', '\r')
+
+            openwikipage = tk.messagebox.askquestion(
+                # LANG: Popup window title for missing FDEVID files
+                _('FDevIDs: Missing Commodity Files'),
+                popup_text
+            )
+            if openwikipage == "yes":
+                webbrowser.open(
+                    "https://github.com/EDCD/EDMarketConnector/wiki/Running-from-source"
+                    "#obtain-a-copy-of-the-application-source"
+                )
+            break
+
     # UI Transparency
     ui_transparency = config.get_int('ui_transparency')
     if ui_transparency == 0:
@@ -2331,6 +2360,8 @@ sys.path: {sys.path}'''
     root.after(1, messagebox_not_py3)
     # Show warning popup for killswitches matching current version
     root.after(2, show_killswitch_poppup, root)
+    # Check for FDEV IDs
+    root.after(3, check_fdev_ids)
     # Start the main event loop
     root.mainloop()
 

--- a/L10n/en.template
+++ b/L10n/en.template
@@ -213,6 +213,12 @@
 /* EDMarketConnector.py: Popup-text about 'active' plugins without Python 3.x support; In files: EDMarketConnector.py:2253:2259; */
 "One or more of your enabled plugins do not yet have support for Python 3.x. Please see the list on the '{PLUGINS}' tab of '{FILE}' > '{SETTINGS}'. You should check if there is an updated version available, else alert the developer that they need to update the code for Python 3.x.\r\n\r\nYou can disable a plugin by renaming its folder to have '{DISABLED}' on the end of the name." = "One or more of your enabled plugins do not yet have support for Python 3.x. Please see the list on the '{PLUGINS}' tab of '{FILE}' > '{SETTINGS}'. You should check if there is an updated version available, else alert the developer that they need to update the code for Python 3.x.\r\n\r\nYou can disable a plugin by renaming its folder to have '{DISABLED}' on the end of the name.";
 
+/* EDMarketConnector.py: Popup-text about missing FDEVID Files; In files: EDMarketConnector.py:2329; */
+"FDevID Files not found! Some functionality regarding commodities may be disabled.\r\n\r\n Do you want to open the Wiki page on how to set up submodules?" = "FDevID Files not found! Some functionality regarding commodities may be disabled.\r\n\r\n Do you want to open the Wiki page on how to set up submodules?";
+
+/* EDMarketConnector.py: Popup window title for missing FDEVID files; In files: EDMarketConnector.py:2340; */
+"FDevIDs: Missing Commodity Files" = "FDevIDs: Missing Commodity Files";
+
 /* EDMarketConnector.py: Settings > Plugins tab; prefs.py: Label on Settings > Plugins tab; In files: EDMarketConnector.py:2263; prefs.py:986; */
 "Plugins" = "Plugins";
 

--- a/build.py
+++ b/build.py
@@ -177,13 +177,20 @@ def build() -> None:
         ],
     }
 
-    py2exe.freeze(
-        version_info=version_info,
-        windows=[windows_config],
-        console=[console_config],
-        data_files=data_files,
-        options=options,
-    )
+    try:
+        py2exe.freeze(
+            version_info=version_info,
+            windows=[windows_config],
+            console=[console_config],
+            data_files=data_files,
+            options=options,
+        )
+    except FileNotFoundError:
+        sys.exit(
+            "Build Failed due to Missing Files! Have you set up your submodules? \n"
+            "https://github.com/EDCD/EDMarketConnector/wiki/Running-from-source"
+            "#obtain-a-copy-of-the-application-source"
+            )
 
     iss_template_path: str = "./resources/EDMC_Installer_Config_template.txt"
     iss_file_path: str = "./EDMC_Installer_Config.iss"

--- a/companion.py
+++ b/companion.py
@@ -1204,6 +1204,9 @@ def fixup(data: CAPIData) -> CAPIData:  # noqa: C901, CCR001 # Can't be usefully
     if not commodity_map:
         # Lazily populate
         for f in ('commodity.csv', 'rare_commodity.csv'):
+            if not os.path.isfile(config.respath_path / 'FDevIDs/' / f):
+                logger.warning(f'FDevID file {f} not found! Generating output without these commodity name rewrites.')
+                continue
             with open(config.respath_path / 'FDevIDs' / f, 'r') as csvfile:
                 reader = csv.DictReader(csvfile)
 


### PR DESCRIPTION
# Description
Adds a popup at startup about missing FDevIDs files on startup to EDMC. This popup will come up at every EDMC start, unlike the "Plugin without Python 3.x support" one that only pops up every 24 hours. This includes an option to open the wiki to view the instructions for installing the Git Submodule. 

This should only be an issue encountered if running from the source, as the packaged/distributed installs will include this information and files by default. The popup is designed so that it will only pop up once even if both fdevid files are missing or only one is missing. 

## Type of change
- Adds a Popup at startup about Plugins that failed to load.
- Adds corresponding translation entries.

# How Has This Been Tested?
- All PyTest tests pass.
- `find_localised_strings.py` doesn't complain.
- Tested feature with missing and found FDEVIDs

This is a measure related to #1801 but does not close. Further research should be done for later versions to determine how to avoid the need for this entirely. 