### PR TITLE
[Fix] Add Required Dupe Imports

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -336,6 +336,8 @@ if __name__ == '__main__':  # noqa: C901
 
     def already_running_popup():
         """Create the "already running" popup."""
+        import tkinter as tk
+        from tkinter import ttk
         # Check for CL arg that suppresses this popup.
         if args.suppress_dupe_process_popup:
             sys.exit(0)


### PR DESCRIPTION
Fixes a bug introduced in 724dd2ce6af07c8be10a4a7eabb72b91d2d2fe2d

These imports are indeed duplicates, however, they are required for the "an instance of EDMC is already running" popup to function as intended. 

