### PR TITLE
[635] Remove Ordered Dict

### DIFF
--- a/companion.py
+++ b/companion.py
@@ -28,7 +28,7 @@ import urllib.parse
 import webbrowser
 from email.utils import parsedate
 from queue import Queue
-from typing import TYPE_CHECKING, Any, Mapping, OrderedDict, TypeVar
+from typing import TYPE_CHECKING, Any, Mapping, TypeVar
 import requests
 import config as conf_module
 import killswitch
@@ -1328,7 +1328,7 @@ def index_possibly_sparse_list(data: Mapping[str, V] | list[V], key: int) -> V:
     if isinstance(data, list):
         return data[key]
 
-    if isinstance(data, (dict, OrderedDict)):
+    if isinstance(data, (dict, dict)):
         return data[str(key)]
 
     raise ValueError(f'Unexpected data type {type(data)}')

--- a/coriolis-update-files.py
+++ b/coriolis-update-files.py
@@ -16,7 +16,6 @@ FDevIDs/ version of the file, copy it over the local one.
 import json
 import subprocess
 import sys
-from collections import OrderedDict
 
 import outfitting
 from edmc_data import coriolis_ship_map, ship_name_map
@@ -56,7 +55,7 @@ if __name__ == "__main__":
         for i, bulkhead in enumerate(bulkheads):
             modules['_'.join([reverse_ship_map[name], 'armour', bulkhead])] = {'mass': m['bulkheads'][i]['mass']}
 
-    ships = OrderedDict([(k, ships[k]) for k in sorted(ships)])  # sort for easier diffing
+    ships = {k: ships[k] for k in sorted(ships)}
     with open("ships.json", "w") as ships_file:
         json.dump(ships, ships_file, indent=4)
 
@@ -91,6 +90,6 @@ if __name__ == "__main__":
     add(modules, 'hpt_multicannon_fixed_small_advanced',          {'mass': 2})
     add(modules, 'hpt_multicannon_fixed_medium_advanced',         {'mass': 4})
 
-    modules = OrderedDict([(k, modules[k]) for k in sorted(modules)])  # sort for easier diffing
+    modules = {k: modules[k] for k in sorted(modules)}
     with open("modules.json", "w") as modules_file:
         json.dump(modules, modules_file, indent=4)

--- a/edmc_data.py
+++ b/edmc_data.py
@@ -4,7 +4,6 @@ Static data.
 For easy reference any variable should be prefixed with the name of the file it
 was either in originally, or where the primary code utilising it is.
 """
-from collections import OrderedDict
 
 # Map numeric 'demand/supply brackets' to the names as shown in-game.
 commodity_bracketmap = {
@@ -57,13 +56,14 @@ edshipyard_slot_map = {
 
 # Map API module names to in-game names
 
-outfitting_armour_map = OrderedDict([
-    ('grade1',   'Lightweight Alloy'),
-    ('grade2',   'Reinforced Alloy'),
-    ('grade3',   'Military Grade Composite'),
-    ('mirrored', 'Mirrored Surface Composite'),
-    ('reactive', 'Reactive Surface Composite'),
-])
+outfitting_armour_map = {
+    'grade1': 'Lightweight Alloy',
+    'grade2': 'Reinforced Alloy',
+    'grade3': 'Military Grade Composite',
+    'mirrored': 'Mirrored Surface Composite',
+    'reactive': 'Reactive Surface Composite',
+}
+
 
 outfitting_weapon_map = {
     'advancedtorppylon':                 'Torpedo Pylon',

--- a/l10n.py
+++ b/l10n.py
@@ -16,7 +16,6 @@ import numbers
 import re
 import sys
 import warnings
-from collections import OrderedDict
 from contextlib import suppress
 from os import pardir, listdir, sep, makedirs
 from os.path import basename, dirname, isdir, isfile, join, abspath, exists
@@ -192,10 +191,10 @@ class _Translations:
 
     def available_names(self) -> dict[str | None, str]:
         """Available language names by code."""
-        names: dict[str | None, str] = OrderedDict([
+        names: dict[str | None, str] = {
             # LANG: The system default language choice in Settings > Appearance
-            (None, _('Default')),  # Appearance theme and language setting
-        ])
+            None: _('Default'),  # Appearance theme and language setting
+        }
         names.update(sorted(
             [(lang, self.contents(lang).get(LANGUAGE_ID, lang)) for lang in self.available()] +
             [(_Translations.FALLBACK, _Translations.FALLBACK_NAME)],

--- a/monitor.py
+++ b/monitor.py
@@ -1073,7 +1073,7 @@ class EDLogs(FileSystemEventHandler):
                 # From 3.3 full Cargo event (after the first one) is written to a separate file
                 if 'Inventory' not in entry:
                     with open(join(self.currentdir, 'Cargo.json'), 'rb') as h:  # type: ignore
-                        entry = json.load(h)  # Preserve property order because why not?
+                        entry = json.load(h)
                         self.state['CargoJSON'] = entry
 
                 clean = self.coalesce_cargo(entry['Inventory'])

--- a/monitor.py
+++ b/monitor.py
@@ -14,7 +14,7 @@ import re
 import sys
 import threading
 from calendar import timegm
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from os import SEEK_END, SEEK_SET, listdir
 from os.path import basename, expanduser, getctime, isdir, join
 from time import gmtime, localtime, mktime, sleep, strftime, strptime, time
@@ -567,7 +567,7 @@ class EDLogs(FileSystemEventHandler):
 
         try:
             # Preserve property order because why not?
-            entry: MutableMapping[str, Any] = json.loads(line, object_pairs_hook=OrderedDict)
+            entry: MutableMapping[str, Any] = json.loads(line)
             assert 'timestamp' in entry, "Timestamp does not exist in the entry"
 
             self.__navroute_retry()
@@ -1042,7 +1042,7 @@ class EDLogs(FileSystemEventHandler):
                         rank[k] = (rank[k][0], min(v, 100))
 
             elif event_type in ('reputation', 'statistics'):
-                payload = OrderedDict(entry)
+                payload = dict(entry)
                 payload.pop('event')
                 payload.pop('timestamp')
                 # NB: We need the original casing for these keys
@@ -1073,7 +1073,7 @@ class EDLogs(FileSystemEventHandler):
                 # From 3.3 full Cargo event (after the first one) is written to a separate file
                 if 'Inventory' not in entry:
                     with open(join(self.currentdir, 'Cargo.json'), 'rb') as h:  # type: ignore
-                        entry = json.load(h, object_pairs_hook=OrderedDict)  # Preserve property order because why not?
+                        entry = json.load(h)  # Preserve property order because why not?
                         self.state['CargoJSON'] = entry
 
                 clean = self.coalesce_cargo(entry['Inventory'])
@@ -1108,7 +1108,7 @@ class EDLogs(FileSystemEventHandler):
                     attempts += 1
                     try:
                         with open(shiplocker_filename, 'rb') as h:
-                            entry = json.load(h, object_pairs_hook=OrderedDict)
+                            entry = json.load(h)
                             self.state['ShipLockerJSON'] = entry
                             break
 
@@ -2189,7 +2189,7 @@ class EDLogs(FileSystemEventHandler):
             'PowerDistributor', 'Radar', 'FuelTank'
         )
 
-        d: MutableMapping[str, Any] = OrderedDict()
+        d: MutableMapping[str, Any] = {}
         if timestamped:
             d['timestamp'] = strftime('%Y-%m-%dT%H:%M:%SZ', gmtime())
 

--- a/outfitting.py
+++ b/outfitting.py
@@ -8,8 +8,6 @@ See LICENSE file.
 from __future__ import annotations
 
 import json
-from collections import OrderedDict
-from typing import OrderedDict as OrderedDictT
 from config import config
 from edmc_data import (
     outfitting_armour_map as armour_map,
@@ -36,7 +34,7 @@ from EDMCLogging import get_main_logger
 logger = get_main_logger()
 
 # Module mass, FSD data etc
-moduledata: OrderedDictT = OrderedDict()
+moduledata: dict = {}
 
 
 def lookup(module, ship_map, entitled=False) -> dict | None:  # noqa: C901, CCR001


### PR DESCRIPTION
# Description
Before Python 3.7, Dictionaries did not maintain their order by default. However, in the modern age of Python, Dictionaries do maintain their order and this import and complication is largely unnecessary. This removes all orderedicts from the project. 

This is technically a 3.11 milestone task, however can be done as a drop-in replacement patch in the 5.10.x line.

## Type of change
- Old Code Rewrite

Closes #635