### PR TITLE
[#2146] Cleanup On KeyboardInterrupt

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -360,7 +360,6 @@ if __name__ == '__main__':  # noqa: C901
             sys.exit()
         logger.info('Exiting')
 
-
     journal_lock = JournalLock()
     locked = journal_lock.obtain_lock()
 

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -353,7 +353,13 @@ if __name__ == '__main__':  # noqa: C901
         button = ttk.Button(frame, text='OK', command=lambda: sys.exit(0))
         button.grid(row=2, column=0, sticky=tk.S)
 
-        root.mainloop()
+        try:
+            root.mainloop()
+        except KeyboardInterrupt:
+            logger.info("Ctrl+C Detected, Attempting Clean Shutdown")
+            sys.exit()
+        logger.info('Exiting')
+
 
     journal_lock = JournalLock()
     locked = journal_lock.obtain_lock()

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -2365,6 +2365,9 @@ sys.path: {sys.path}'''
     # Check for FDEV IDs
     root.after(3, check_fdev_ids)
     # Start the main event loop
-    root.mainloop()
-
+    try:
+        root.mainloop()
+    except KeyboardInterrupt:
+        logger.info("Ctrl+C Detected, Attempting Clean Shutdown")
+        app.onexit()
     logger.info('Exiting')


### PR DESCRIPTION
# Description
EDMC does not clean itself up cleanly after a ctrl+c when running from the console. This enhancement attempts to force EDMC to clean itself up on a keyboard interrupt. 

## Type of change
- Minor Bug Fix/Feature Enhancement


Resolves #2146 