### PR TITLE
[#2077] Ensure Providers Are Valid

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -2162,6 +2162,7 @@ def validate_providers():
         popup_text
     )
 
+
 # Run the app
 if __name__ == "__main__":  # noqa: C901
     logger.info(f'Startup v{appversion()} : Running on Python v{sys.version}')

--- a/L10n/en.template
+++ b/L10n/en.template
@@ -231,6 +231,15 @@
 /* EDMarketConnector.py: Popup-text about 'broken' plugins that failed to load; In files: EDMarketConnector.py:2266; */
 "One or more of your enabled plugins failed to load. Please see the list on the '{PLUGINS}' tab of '{FILE}' > '{SETTINGS}'. This could be caused by a wrong folder structure. The load.py file should be located under plugins/PLUGIN_NAME/load.py.\r\n\r\nYou can disable a plugin by renaming its folder to have '{DISABLED}' on the end of the name." = "One or more of your enabled plugins failed to load. Please see the list on the '{PLUGINS}' tab of '{FILE}' > '{SETTINGS}'. This could be caused by a wrong folder structure. The load.py file should be located under plugins/PLUGIN_NAME/load.py.\r\n\r\nYou can disable a plugin by renaming its folder to have '{DISABLED}' on the end of the name.";
 
+/* EDMarketConnector.py: Popup-text about Reset Providers; In files: EDMarketConnector.py:2146; */
+"One or more of your URL Providers were invalid, and have been reset:\r\n\r\n" = "One or more of your URL Providers were invalid, and have been reset:\r\n\r\n";
+
+/* EDMarketConnector.py: Text About What Provider Was Reset; In files: EDMarketConnector.py:2148; */
+"{PROVIDER} was set to {OLDPROV}, and has been reset to {NEWPROV}\r\n" = "{PROVIDER} was set to {OLDPROV}, and has been reset to {NEWPROV}\r\n";
+
+/* EDMarketConnector.py: Popup window title for Reset Providers; In files: EDMarketConnector.py:2161; */
+"EDMC: Default Providers Reset" = "EDMC: Default Providers Reset";
+
 /* journal_lock.py: Title text on popup when Journal directory already locked; In files: journal_lock.py:208; */
 "Journal directory already locked" = "Journal directory already locked";
 


### PR DESCRIPTION
# Description
In rare instances, if an invalid System, Station, or Plugin provider is set in the configuration (such as EDDB in Station or System provider), this can result in the program breaking. This alleviates this issue by checking if the set configuration values are valid at startup. If not, reset them to the default values and throw an error to the user. 

This fix also includes the required LANG changes to allow localization. 

![image](https://github.com/EDCD/EDMarketConnector/assets/26337384/7b8c3ff6-6e64-41e1-b810-a3fa7c6357b1)

## Type of change
- Bug Fix

Closes #2077