### PR TITLE
[1181] Save Coriolis URL override when changing languages

### DIFF
--- a/L10n/en.template
+++ b/L10n/en.template
@@ -255,13 +255,13 @@
 /* l10n.py: The system default language choice in Settings > Appearance; prefs.py: Settings > Configuration - Label on 'reset journal files location to default' button; prefs.py: The system default language choice in Settings > Appearance; prefs.py: Label for 'Default' theme radio button; In files: l10n.py:193; prefs.py:455; prefs.py:709; prefs.py:742; */
 "Default" = "Default";
 
-/* coriolis.py: 'Auto' label for Coriolis site override selection; coriolis.py: Coriolis normal/beta selection - auto; In files: coriolis.py:74; coriolis.py:77; coriolis.py:123; coriolis.py:139; coriolis.py:145; */
+/* coriolis.py: 'Auto' label for Coriolis site override selection; coriolis.py: Coriolis normal/beta selection - auto; In files: coriolis.py:48; coriolis.py:74; coriolis.py:77; coriolis.py:94; coriolis.py:123; coriolis.py:139; coriolis.py:145; coriolis.py:179; coriolis.py:182; */
 "Auto" = "Auto";
 
-/* coriolis.py: 'Normal' label for Coriolis site override selection; coriolis.py: Coriolis normal/beta selection - normal; In files: coriolis.py:75; coriolis.py:121; coriolis.py:137; */
+/* coriolis.py: 'Normal' label for Coriolis site override selection; coriolis.py: Coriolis normal/beta selection - normal; In files: coriolis.py:49; coriolis.py:75; coriolis.py:95; coriolis.py:121; coriolis.py:137; coriolis.py:180; */
 "Normal" = "Normal";
 
-/* coriolis.py: 'Beta' label for Coriolis site override selection; coriolis.py: Coriolis normal/beta selection - beta; In files: coriolis.py:76; coriolis.py:122; coriolis.py:138; */
+/* coriolis.py: 'Beta' label for Coriolis site override selection; coriolis.py: Coriolis normal/beta selection - beta; In files: coriolis.py:50; coriolis.py:76; coriolis.py:96; coriolis.py:122; coriolis.py:138; coriolis.py:181; */
 "Beta" = "Beta";
 
 /* coriolis.py: Settings>Coriolis: Help/hint for changing coriolis URLs; In files: coriolis.py:91:93; */

--- a/plugins/coriolis.py
+++ b/plugins/coriolis.py
@@ -45,6 +45,9 @@ class CoriolisConfig:
         self.normal_url = ''
         self.beta_url = ''
         self.override_mode = ''
+        self.override_text_old_auto = _('Auto')  # LANG: Coriolis normal/beta selection - auto
+        self.override_text_old_normal = _('Normal')  # LANG: Coriolis normal/beta selection - normal
+        self.override_text_old_beta = _('Beta')  # LANG: Coriolis normal/beta selection - beta
 
         self.normal_textvar = tk.StringVar()
         self.beta_textvar = tk.StringVar()
@@ -87,6 +90,11 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str | None, is_beta: bool) -> tk.Fr
     PADY = 1  # noqa: N806
     BOXY = 2  # noqa: N806  # box spacing
 
+    # Save the old text values for the override mode, so we can update them if the language is changed
+    coriolis_config.override_text_old_auto = _('Auto')  # LANG: Coriolis normal/beta selection - auto
+    coriolis_config.override_text_old_normal = _('Normal')  # LANG: Coriolis normal/beta selection - normal
+    coriolis_config.override_text_old_beta = _('Beta')  # LANG: Coriolis normal/beta selection - beta
+    
     conf_frame = nb.Frame(parent)
     conf_frame.columnconfigure(index=1, weight=1)
     cur_row = 0
@@ -157,6 +165,24 @@ def prefs_changed(cmdr: str | None, is_beta: bool) -> None:
         _('Auto'): 'auto',      # LANG: Coriolis normal/beta selection - auto
     }.get(coriolis_config.override_mode, coriolis_config.override_mode)
 
+    # Check if the language was changed and the override_mode was valid before the change
+    if coriolis_config.override_mode not in ('beta', 'normal', 'auto'):
+        coriolis_config.override_mode = {
+            coriolis_config.override_text_old_normal: 'normal',
+            coriolis_config.override_text_old_beta: 'beta',
+            coriolis_config.override_text_old_auto: 'auto',
+        }.get(coriolis_config.override_mode, coriolis_config.override_mode)
+        # Language was seemingly changed, so we need to update the textvars
+        if coriolis_config.override_mode in ('beta', 'normal', 'auto'):
+            coriolis_config.override_textvar.set(
+                value={
+                    'auto': _('Auto'),  # LANG: 'Auto' label for Coriolis site override selection
+                    'normal': _('Normal'),  # LANG: 'Normal' label for Coriolis site override selection
+                    'beta': _('Beta')  # LANG: 'Beta' label for Coriolis site override selection
+                }.get(coriolis_config.override_mode)
+            )
+    
+    # If the override mode is still invalid, default to auto
     if coriolis_config.override_mode not in ('beta', 'normal', 'auto'):
         logger.warning(f'Unexpected value {coriolis_config.override_mode=!r}. Defaulting to "auto"')
         coriolis_config.override_mode = 'auto'

--- a/plugins/coriolis.py
+++ b/plugins/coriolis.py
@@ -179,7 +179,7 @@ def prefs_changed(cmdr: str | None, is_beta: bool) -> None:
                     'auto': _('Auto'),  # LANG: 'Auto' label for Coriolis site override selection
                     'normal': _('Normal'),  # LANG: 'Normal' label for Coriolis site override selection
                     'beta': _('Beta')  # LANG: 'Beta' label for Coriolis site override selection
-                # LANG: 'Auto' label for Coriolis site override selection
+                    # LANG: 'Auto' label for Coriolis site override selection
                 }.get(coriolis_config.override_mode, _('Auto'))
             )
 

--- a/plugins/coriolis.py
+++ b/plugins/coriolis.py
@@ -179,7 +179,8 @@ def prefs_changed(cmdr: str | None, is_beta: bool) -> None:
                     'auto': _('Auto'),  # LANG: 'Auto' label for Coriolis site override selection
                     'normal': _('Normal'),  # LANG: 'Normal' label for Coriolis site override selection
                     'beta': _('Beta')  # LANG: 'Beta' label for Coriolis site override selection
-                }.get(coriolis_config.override_mode, _('Auto'))  # LANG: 'Auto' label for Coriolis site override selection
+                # LANG: 'Auto' label for Coriolis site override selection
+                }.get(coriolis_config.override_mode, _('Auto'))
             )
 
     # If the override mode is still invalid, default to auto

--- a/plugins/coriolis.py
+++ b/plugins/coriolis.py
@@ -94,7 +94,7 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str | None, is_beta: bool) -> tk.Fr
     coriolis_config.override_text_old_auto = _('Auto')  # LANG: Coriolis normal/beta selection - auto
     coriolis_config.override_text_old_normal = _('Normal')  # LANG: Coriolis normal/beta selection - normal
     coriolis_config.override_text_old_beta = _('Beta')  # LANG: Coriolis normal/beta selection - beta
-    
+
     conf_frame = nb.Frame(parent)
     conf_frame.columnconfigure(index=1, weight=1)
     cur_row = 0
@@ -179,9 +179,9 @@ def prefs_changed(cmdr: str | None, is_beta: bool) -> None:
                     'auto': _('Auto'),  # LANG: 'Auto' label for Coriolis site override selection
                     'normal': _('Normal'),  # LANG: 'Normal' label for Coriolis site override selection
                     'beta': _('Beta')  # LANG: 'Beta' label for Coriolis site override selection
-                }.get(coriolis_config.override_mode)
+                }.get(coriolis_config.override_mode, _('Auto'))  # LANG: 'Auto' label for Coriolis site override selection
             )
-    
+
     # If the override mode is still invalid, default to auto
     if coriolis_config.override_mode not in ('beta', 'normal', 'auto'):
         logger.warning(f'Unexpected value {coriolis_config.override_mode=!r}. Defaulting to "auto"')


### PR DESCRIPTION
# Description
Currently changing languages may cause Coriolis URL overrides to revert back to auto (default) if the current selection has a different display string between the old and new language. This PR fixes that by saving the old display strings when creating the prefs window and checking against those when closing it. 

## Type of change
- Bug Fix

## How Has This Been Tested?
- Switching between languages with and without changing the override setting at the same time.
- Manually editing Registry to ensure original fallback to default still works.

Closes #1181 