### PR TITLE
[2163] Update Inara plugin to better handle Thargoid Combat events

### DIFF
--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -1008,7 +1008,8 @@ def journal_entry(  # noqa: C901, CCR001
             opponent_name_issue = 'opponentName' not in data or data['opponentName'] == ""
             wing_opponent_names_issue = 'wingOpponentNames' not in data or data['wingOpponentNames'] == []
             if opponent_name_issue and wing_opponent_names_issue:
-                logger.warning('Dropping addCommanderCombatDeath message because opponentName and wingOpponentNames came out as ""')
+                logger.warning('Dropping addCommanderCombatDeath message'
+                               'because opponentName and wingOpponentNames came out as ""')
 
             else:
                 new_add_event('addCommanderCombatDeath', entry['timestamp'], data)

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -1019,8 +1019,11 @@ def journal_entry(  # noqa: C901, CCR001
             elif 'Power' in entry:
                 data['opponentName'] = entry['Power']
 
+            elif 'IsThargoid' in entry and entry['IsThargoid']:
+                data['opponentName'] = 'Thargoid'
+
             # Paranoia in case of e.g. Thargoid activity not having complete data
-            if data['opponentName'] == "":
+            if 'opponentName' not in data or data['opponentName'] == "":
                 logger.warning('Dropping addCommanderCombatInterdicted message because opponentName came out as ""')
 
             else:
@@ -1042,8 +1045,13 @@ def journal_entry(  # noqa: C901, CCR001
             elif 'Power' in entry:
                 data['opponentName'] = entry['Power']
 
+            # Shouldn't be needed here as Interdiction events can't target Thargoids (yet)
+            # but done just in case of future changes or so
+            elif 'IsThargoid' in entry and entry['IsThargoid']:
+                data['opponentName'] = 'Thargoid'
+
             # Paranoia in case of e.g. Thargoid activity not having complete data
-            if data['opponentName'] == "":
+            if 'opponentName' not in data or data['opponentName'] == "":
                 logger.warning('Dropping addCommanderCombatInterdiction message because opponentName came out as ""')
 
             else:

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -1058,23 +1058,23 @@ def journal_entry(  # noqa: C901, CCR001
                 new_add_event('addCommanderCombatInterdiction', entry['timestamp'], data)
 
         elif event_name == 'EscapeInterdiction':
+            data = {
+                'starsystemName': system,
+                'isPlayer': entry['IsPlayer'],
+            }
+
+            if 'Interdictor' in entry:
+                data['opponentName'] = entry['Interdictor']
+
+            elif 'isThargoid' in entry and entry['isThargoid']:
+                data['opponentName'] = 'Thargoid'
+
             # Paranoia in case of e.g. Thargoid activity not having complete data
-            if entry.get('Interdictor') is None or entry['Interdictor'] == "":
-                logger.warning(
-                    'Dropping addCommanderCombatInterdictionEscape message'
-                    'because opponentName came out as ""'
-                )
+            if 'opponentName' not in data or data['opponentName'] == "":
+                logger.warning('Dropping addCommanderCombatInterdiction message because opponentName came out as ""')
 
             else:
-                new_add_event(
-                    'addCommanderCombatInterdictionEscape',
-                    entry['timestamp'],
-                    {
-                        'starsystemName': system,
-                        'opponentName': entry['Interdictor'],
-                        'isPlayer': entry['IsPlayer'],
-                    }
-                )
+                new_add_event('addCommanderCombatInterdictionEscape', entry['timestamp'], data)
 
         elif event_name == 'PVPKill':
             new_add_event(

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -1066,6 +1066,12 @@ def journal_entry(  # noqa: C901, CCR001
             if 'Interdictor' in entry:
                 data['opponentName'] = entry['Interdictor']
 
+            elif 'Faction' in entry:
+                data['opponentName'] = entry['Faction']
+
+            elif 'Power' in entry:
+                data['opponentName'] = entry['Power']
+
             elif 'isThargoid' in entry and entry['isThargoid']:
                 data['opponentName'] = 'Thargoid'
 

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -1001,7 +1001,17 @@ def journal_entry(  # noqa: C901, CCR001
             elif 'KillerName' in entry:
                 data['opponentName'] = entry['KillerName']
 
-            new_add_event('addCommanderCombatDeath', entry['timestamp'], data)
+            elif 'KillerShip' in entry:
+                data['opponentName'] = entry['KillerShip']
+
+            # Paranoia in case of e.g. Thargoid activity not having complete data
+            opponent_name_issue = 'opponentName' not in data or data['opponentName'] == ""
+            wing_opponent_names_issue = 'wingOpponentNames' not in data or data['wingOpponentNames'] == []
+            if opponent_name_issue and wing_opponent_names_issue:
+                logger.warning('Dropping addCommanderCombatDeath message because opponentName and wingOpponentNames came out as ""')
+
+            else:
+                new_add_event('addCommanderCombatDeath', entry['timestamp'], data)
 
         elif event_name == 'Interdicted':
             data = {


### PR DESCRIPTION
# Description
In May 2023 a new parameter called ``isThargoid`` was added to the ``Interdicted`` and ``EscapeInterdiction`` journal events which caused issues with the way the Inara plugin handled Interdiction events. Additionally Thargoid caused deaths didn't show up in Inara's Combat Log.
This PR:
- Updates the Inara plugin to check for that ``isThargoid`` flag and set the ``opponentName`` in Thargoid related Inara API updates to ``Thargoid`` if it is set.
- Adds a check to the ``Died`` event to use the Killer's ship's name as ``opponentName`` if the Killer's name is not present in the journal entry (as is the case for Thargoid caused deaths).
- Rewrites the ``EscapeInterdiction`` path to match the other Interdiction paths.
- Updates the Interdiction related Paranoia checks to also work in cases of missing and not just empty parameters.

## Type of change
- Match journal update
- Bug Fixes
- Minor Code Rewrites

## How Has This Been Tested?
- Testing multiple Interdiction source (Player, NPC and Thargoids) and outcome (interdicted and escaped) combinations in game.
- Checking that getting interdicted and destroyed by Thargoids shows up properly in Inara's Combat Log.

Closes #2163 