### PR TITLE
[#635] Properly Convert Message Object from OrderedDict

### DIFF
--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -801,15 +801,15 @@ class EDDN:
             self.send_message(data['commander']['name'], {
                 '$schemaRef': f'https://eddn.edcd.io/schemas/outfitting/2{"/test" if is_beta else ""}',
                 'message': {
-                    ('timestamp',   data['timestamp']),
-                    ('systemName',  data['lastSystem']['name']),
-                    ('stationName', data['lastStarport']['name']),
-                    ('marketId',    data['lastStarport']['id']),
-                    ('horizons',    horizons),
-                    ('modules',     outfitting),
-                    ('odyssey',     this.odyssey),
+                    'timestamp': data['timestamp'],
+                    'systemName': data['lastSystem']['name'],
+                    'stationName': data['lastStarport']['name'],
+                    'marketId': data['lastStarport']['id'],
+                    'horizons': horizons,
+                    'modules': outfitting,
+                    'odyssey': this.odyssey,
                 },
-                'header':     self.standard_header(
+                'header': self.standard_header(
                     game_version=self.capi_gameversion_from_host_endpoint(
                         data.source_host, companion.Session.FRONTIER_CAPI_PATH_SHIPYARD
                     ),
@@ -863,13 +863,13 @@ class EDDN:
             self.send_message(data['commander']['name'], {
                 '$schemaRef': f'https://eddn.edcd.io/schemas/shipyard/2{"/test" if is_beta else ""}',
                 'message': {
-                    ('timestamp',   data['timestamp']),
-                    ('systemName',  data['lastSystem']['name']),
-                    ('stationName', data['lastStarport']['name']),
-                    ('marketId',    data['lastStarport']['id']),
-                    ('horizons',    horizons),
-                    ('ships',       shipyard),
-                    ('odyssey',     this.odyssey),
+                    'timestamp': data['timestamp'],
+                    'systemName': data['lastSystem']['name'],
+                    'stationName': data['lastStarport']['name'],
+                    'marketId': data['lastStarport']['id'],
+                    'horizons': horizons,
+                    'ships': shipyard,
+                    'odyssey': this.odyssey,
                 },
                 'header': self.standard_header(
                     game_version=self.capi_gameversion_from_host_endpoint(


### PR DESCRIPTION
# Description
This fixes a bug introduced in #2139 which would result in EDDN messages not being properly sent. This ensures EDMC does not attempt to hash an unhashable list object.

## Type of change
- Bug Fix

## How Has This Been Tested?
Testing using provided recreation steps and ensuring EDDN messages are being sent successfully, which was not happening with the bugged version on startup.


