### PR TITLE
[#901] Add Additional Status for Incomplete Logins

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -809,6 +809,8 @@ class AppWindow:
 
         # Check for Valid Providers
         validate_providers()
+        if monitor.cmdr is None:
+            self.status['text'] = _("Awaiting Full CMDR Login")
 
         # Start a protocol handler to handle cAPI registration. Requires main loop to be running.
         self.w.after_idle(lambda: protocol.protocolhandler.start(self.w))

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -810,7 +810,7 @@ class AppWindow:
         # Check for Valid Providers
         validate_providers()
         if monitor.cmdr is None:
-            self.status['text'] = _("Awaiting Full CMDR Login")
+            self.status['text'] = _("Awaiting Full CMDR Login")  # LANG: Await Full CMDR Login to Game
 
         # Start a protocol handler to handle cAPI registration. Requires main loop to be running.
         self.w.after_idle(lambda: protocol.protocolhandler.start(self.w))

--- a/L10n/en.template
+++ b/L10n/en.template
@@ -240,6 +240,9 @@
 /* EDMarketConnector.py: Popup window title for Reset Providers; In files: EDMarketConnector.py:2161; */
 "EDMC: Default Providers Reset" = "EDMC: Default Providers Reset";
 
+/* EDMarketConnector.py: Await Full CMDR Login to Game; In files: EDMarketConnector.py:813; */
+"Awaiting Full CMDR Login" = "Awaiting Full CMDR Login";
+
 /* journal_lock.py: Title text on popup when Journal directory already locked; In files: journal_lock.py:208; */
 "Journal directory already locked" = "Journal directory already locked";
 


### PR DESCRIPTION
# Description
From #901, If you didn't actually login during the last start of your game client then the latest Journal file doesn't have Commander information.

This adds a new "status" message to indicate the stage the player is on, to fill out some of the UI, and to indicate the application is not frozen or broken.

## Type of change
- Feature Enhancement

## How Has This Been Tested?
Testing using provided recreation steps. Tested to ensure that this status doesn't stick around when the login flow continues or this edge case isn't present.

Closes #901 