### PR TITLE
[2186] Refine macOS to preserve ContextMenu

### DIFF
--- a/docs/examples/click_counter/load.py
+++ b/docs/examples/click_counter/load.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import logging
 import tkinter as tk
-from tkinter import ttk
 
 import myNotebook as nb  # noqa: N813
 from config import appname, config
@@ -65,7 +64,7 @@ class ClickCounter:
 
         # setup our config in a "Click Count: number"
         nb.Label(frame, text='Click Count').grid(row=current_row)
-        ttk.Entry(frame, textvariable=self.click_count).grid(row=current_row, column=1)
+        nb.EntryMenu(frame, textvariable=self.click_count).grid(row=current_row, column=1)
         current_row += 1  # Always increment our row counter, makes for far easier tkinter design.
         return frame
 

--- a/myNotebook.py
+++ b/myNotebook.py
@@ -67,7 +67,7 @@ class EntryMenu(ttk.Entry):
     """Extended entry widget that includes a context menu with Copy, Cut-and-Paste commands."""
 
     def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+        ttk.Entry.__init__(self, *args, **kwargs)
 
         self.menu = tk.Menu(self, tearoff=False)
         self.menu.add_command(label="Copy", command=self.copy)
@@ -120,7 +120,7 @@ class EntryMenu(ttk.Entry):
             pass
 
 
-class Entry(EntryMenu or ttk.Entry):  # type: ignore
+class Entry(EntryMenu):
     """Custom ttk.Entry class to fix some display issues."""
 
     # DEPRECATED: Migrate to EntryMenu. Will remove in 5.12 or later.

--- a/myNotebook.py
+++ b/myNotebook.py
@@ -40,7 +40,7 @@ class Notebook(ttk.Notebook):
 
 
 class Frame(ttk.Frame):
-    """Custom t(t)k.Frame class to fix some display issues."""
+    """Custom ttk.Frame class to fix some display issues."""
 
     def __init__(self, master: ttk.Notebook | None = None, **kw):
         if sys.platform == 'win32':
@@ -120,18 +120,17 @@ class EntryMenu(ttk.Entry):
             pass
 
 
-class Entry(ttk.Entry or EntryMenu):  # type: ignore
-    """Custom t(t)k.Entry class to fix some display issues."""
+class Entry(EntryMenu or ttk.Entry):  # type: ignore
+    """Custom ttk.Entry class to fix some display issues."""
 
-    # DEPRECATED: Migrate to ttk.Entry or EntryMenu. Will remove in 5.12 or later.
+    # DEPRECATED: Migrate to EntryMenu. Will remove in 5.12 or later.
     def __init__(self, master: ttk.Frame | None = None, **kw):
         EntryMenu.__init__(self, master, **kw)
 
 
-class Button(ttk.Button):  # type: ignore
-    """Custom t(t)k.Button class to fix some display issues."""
+class Button(ttk.Button):
+    """Custom ttk.Button class to fix some display issues."""
 
-    # DEPRECATED: Migrate to ttk.Button. Will remove in 5.12 or later.
     def __init__(self, master: ttk.Frame | None = None, **kw):
         if sys.platform == 'win32':
             ttk.Button.__init__(self, master, style='nb.TButton', **kw)
@@ -139,8 +138,8 @@ class Button(ttk.Button):  # type: ignore
             ttk.Button.__init__(self, master, **kw)
 
 
-class ColoredButton(tk.Button):  # type: ignore
-    """Custom t(t)k.ColoredButton class to fix some display issues."""
+class ColoredButton(tk.Button):
+    """Custom tk.Button class to fix some display issues."""
 
     # DEPRECATED: Migrate to tk.Button. Will remove in 5.12 or later.
     def __init__(self, master: ttk.Frame | None = None, **kw):
@@ -148,15 +147,15 @@ class ColoredButton(tk.Button):  # type: ignore
 
 
 class Checkbutton(ttk.Checkbutton):
-    """Custom t(t)k.Checkbutton class to fix some display issues."""
+    """Custom ttk.Checkbutton class to fix some display issues."""
 
-    def __init__(self, master=None, **kw):
+    def __init__(self, master: ttk.Frame | None = None, **kw):
         style = 'nb.TCheckbutton' if sys.platform == 'win32' else None
         super().__init__(master, style=style, **kw)  # type: ignore
 
 
 class Radiobutton(ttk.Radiobutton):
-    """Custom t(t)k.Radiobutton class to fix some display issues."""
+    """Custom ttk.Radiobutton class to fix some display issues."""
 
     def __init__(self, master: ttk.Frame | None = None, **kw):
         style = 'nb.TRadiobutton' if sys.platform == 'win32' else None

--- a/plugins/coriolis.py
+++ b/plugins/coriolis.py
@@ -106,25 +106,24 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str | None, is_beta: bool) -> nb.Fr
 
     # LANG: Settings>Coriolis: Label for 'NOT alpha/beta game version' URL
     nb.Label(conf_frame, text=_('Normal URL')).grid(sticky=tk.W, row=cur_row, column=0, padx=PADX, pady=PADY)
-    ttk.Entry(conf_frame,
-              textvariable=coriolis_config.normal_textvar).grid(
+    nb.EntryMenu(conf_frame, textvariable=coriolis_config.normal_textvar).grid(
                 sticky=tk.EW, row=cur_row, column=1, padx=PADX, pady=BOXY
             )
     # LANG: Generic 'Reset' button label
-    ttk.Button(conf_frame, text=_("Reset"),
-               command=lambda: coriolis_config.normal_textvar.set(value=DEFAULT_NORMAL_URL)).grid(
+    nb.Button(conf_frame, text=_("Reset"),
+              command=lambda: coriolis_config.normal_textvar.set(value=DEFAULT_NORMAL_URL)).grid(
         sticky=tk.W, row=cur_row, column=2, padx=PADX, pady=0
     )
     cur_row += 1
 
     # LANG: Settings>Coriolis: Label for 'alpha/beta game version' URL
     nb.Label(conf_frame, text=_('Beta URL')).grid(sticky=tk.W, row=cur_row, column=0, padx=PADX, pady=PADY)
-    ttk.Entry(conf_frame, textvariable=coriolis_config.beta_textvar).grid(
-        sticky=tk.EW, row=cur_row, column=1, padx=PADX, pady=BOXY
+    nb.EntryMenu(conf_frame, textvariable=coriolis_config.beta_textvar).grid(
+                 sticky=tk.EW, row=cur_row, column=1, padx=PADX, pady=BOXY
     )
     # LANG: Generic 'Reset' button label
-    ttk.Button(conf_frame, text=_('Reset'),
-               command=lambda: coriolis_config.beta_textvar.set(value=DEFAULT_BETA_URL)).grid(
+    nb.Button(conf_frame, text=_('Reset'),
+              command=lambda: coriolis_config.beta_textvar.set(value=DEFAULT_BETA_URL)).grid(
         sticky=tk.W, row=cur_row, column=2, padx=PADX, pady=0
     )
     cur_row += 1

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -113,10 +113,10 @@ class This:
         self.cmdr_text: nb.Label | None = None
 
         self.user_label: nb.Label | None = None
-        self.user: ttk.Entry | None = None
+        self.user: nb.EntryMenu | None = None
 
         self.apikey_label: nb.Label | None = None
-        self.apikey: ttk.Entry | None = None
+        self.apikey: nb.EntryMenu | None = None
 
 
 this = This()
@@ -345,14 +345,14 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str | None, is_beta: bool) -> nb.Fr
     # LANG: EDSM Commander name label in EDSM settings
     this.user_label = nb.Label(frame, text=_('Commander Name'))
     this.user_label.grid(row=cur_row, padx=PADX, pady=PADY, sticky=tk.W)
-    this.user = ttk.Entry(frame)
+    this.user = nb.EntryMenu(frame)
     this.user.grid(row=cur_row, column=1, padx=PADX, pady=BOXY, sticky=tk.EW)
 
     cur_row += 1
     # LANG: EDSM API key label
     this.apikey_label = nb.Label(frame, text=_('API Key'))
     this.apikey_label.grid(row=cur_row, padx=PADX, pady=PADY, sticky=tk.W)
-    this.apikey = ttk.Entry(frame, show="*", width=50)
+    this.apikey = nb.EntryMenu(frame, show="*", width=50)
     this.apikey.grid(row=cur_row, column=1, padx=PADX, pady=BOXY, sticky=tk.EW)
     cur_row += 1
 

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -125,7 +125,7 @@ class This:
         self.log: 'tk.IntVar'
         self.log_button: nb.Checkbutton
         self.label: HyperlinkLabel
-        self.apikey: ttk.Entry
+        self.apikey: nb.EntryMenu
         self.apikey_label: tk.Label
 
         self.events: dict[Credentials, Deque[Event]] = defaultdict(deque)
@@ -292,7 +292,7 @@ def plugin_prefs(parent: ttk.Notebook, cmdr: str, is_beta: bool) -> nb.Frame:
     # LANG: Inara API key label
     this.apikey_label = nb.Label(frame, text=_('API Key'))  # Inara setting
     this.apikey_label.grid(row=cur_row, padx=PADX, pady=PADY, sticky=tk.W)
-    this.apikey = ttk.Entry(frame, show="*", width=50)
+    this.apikey = nb.EntryMenu(frame, show="*", width=50)
     this.apikey.grid(row=cur_row, column=1, padx=PADX, pady=BOXY, sticky=tk.EW)
     cur_row += 1
 

--- a/prefs.py
+++ b/prefs.py
@@ -376,8 +376,6 @@ class PreferencesDialog(tk.Toplevel):
         )
         self.outbutton.grid(column=1, padx=self.PADX, pady=self.PADY, sticky=tk.EW, row=row.get())
 
-        nb.Frame(output_frame).grid(row=row.get())  # type: ignore # bottom spacer # TODO: does nothing?
-
         # LANG: Label for 'Output' Settings/Preferences tab
         root_notebook.add(output_frame, text=_('Output'))  # Tab heading in settings
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 certifi==2024.2.2
 requests==2.31.0
-pillow==10.2.0
+pillow==10.3.0
 # requests depends on this now ?
-charset-normalizer==2.1.1
+charset-normalizer==3.3.2
 
 watchdog==3.0.0
 # Commented out because this doesn't package well with py2exe


### PR DESCRIPTION
The previous PR to remove macOS support (#2187) was a little too overzealous and removed the functionality added by #2183 by converting the usage of nb.Entry to ttk.Entry instead of the intended nb.EntryMenu. 

nb.Entry usage still should be eliminated, but the alternative should be our menu class. 

Also clarifies some side issues and details. Removes a [GNDN](https://www.urbandictionary.com/define.php?term=GNDN) line of code which we don't need. 

Resolves #2186 

All other details of #2187 are still valid. 