### PR TITLE
[2202] Add a number of missing modules

### DIFF
--- a/edmc_data.py
+++ b/edmc_data.py
@@ -69,6 +69,8 @@ outfitting_weapon_map = {
     'advancedtorppylon':                 'Torpedo Pylon',
     'atdumbfiremissile':                 'AX Missile Rack',
     'atmulticannon':                     'AX Multi-Cannon',
+    ('atmulticannon', 'v2'):             'Enhanced AX Multi-Cannon',
+    ('atdumbfiremissile', 'v2'):         'Enhanced AX Missile Rack',
     'basicmissilerack':                  'Seeker Missile Rack',
     'beamlaser':                         'Beam Laser',
     ('beamlaser', 'heat'):               'Retributor Beam Laser',
@@ -88,6 +90,8 @@ outfitting_weapon_map = {
     'mining_abrblstr':                   'Abrasion Blaster',
     'mining_seismchrgwarhd':             'Seismic Charge Launcher',
     'mining_subsurfdispmisle':           'Sub-Surface Displacement Missile',
+    'human_extraction':                  'Sub-Surface Extraction Missile',
+    'atventdisruptorpylon':              'Guardian Nanite Torpedo Pylon',
     'mininglaser':                       'Mining Laser',
     ('mininglaser', 'advanced'):         'Mining Lance Beam Laser',
     'multicannon':                       'Multi-Cannon',
@@ -266,6 +270,11 @@ outfitting_weaponrating_map = {
     'hpt_slugshot_turret_medium':                'D',
     'hpt_slugshot_turret_large':                 'C',
     'hpt_xenoscannermk2_basic_tiny':             '?',
+    'hpt_atmulticannon_gimbal_large':            'C',
+    'hpt_atmulticannon_gimbal_medium':           'E',
+    'hpt_human_extraction_fixed_medium':         'B',
+    'hpt_atventdisruptorpylon_fixed_medium':     'I',
+    'hpt_atventdisruptorpylon_fixed_large':      'I',
 }
 
 # Old standard weapon variants
@@ -278,13 +287,14 @@ outfitting_weaponoldvariant_map = {
 }
 
 outfitting_countermeasure_map = {
-    'antiunknownshutdown':        ('Shutdown Field Neutraliser', 'F'),
-    'chafflauncher':              ('Chaff Launcher', 'I'),
-    'electroniccountermeasure':   ('Electronic Countermeasure', 'F'),
-    'heatsinklauncher':           ('Heat Sink Launcher', 'I'),
-    'plasmapointdefence':         ('Point Defence', 'I'),
-    'xenoscanner':                ('Xeno Scanner', 'E'),
-    'xenoscannermk2':             ('Unknown Xeno Scanner Mk II', '?'),
+    'antiunknownshutdown':          ('Shutdown Field Neutraliser', 'F'),
+    ('antiunknownshutdown', 'v2'):  ('Thargoid Pulse Neutraliser', 'E'),
+    'chafflauncher':                ('Chaff Launcher', 'I'),
+    'electroniccountermeasure':     ('Electronic Countermeasure', 'F'),
+    'heatsinklauncher':             ('Heat Sink Launcher', 'I'),
+    'plasmapointdefence':           ('Point Defence', 'I'),
+    'xenoscanner':                  ('Xeno Scanner', 'E'),
+    'xenoscannermk2':               ('Unknown Xeno Scanner Mk II', '?'),
 }
 
 outfitting_utility_map = {
@@ -347,6 +357,7 @@ outfitting_standard_map = {
     'guardianpowerdistributor':     'Guardian Hybrid Power Distributor',
     'guardianpowerplant':           'Guardian Hybrid Power Plant',
     'hyperdrive':                   'Frame Shift Drive',
+    ('hyperdrive', 'overcharge'):   'Frame Shift Drive',
     'lifesupport':                  'Life Support',
     # 'planetapproachsuite':        handled separately
     'powerdistributor':             'Power Distributor',
@@ -376,6 +387,11 @@ outfitting_internal_map = {
     'refinery':                     'Refinery',
     'recon':                        'Recon Limpet Controller',
     'repair':                       'Repair Limpet Controller',
+    'rescue':                       'Rescue Limpet Controller',
+    'mining':                       'Mining Multi Limpet Controller',
+    'xeno':                         'Xeno Multi Limpet Controller',
+    'operations':                   'Operations Multi Limpet Controller',
+    'universal':                    'Universal Multi Limpet Controller',
     'repairer':                     'Auto Field-Maintenance Unit',
     'resourcesiphon':               'Hatch Breaker Limpet Controller',
     'shieldcellbank':               'Shield Cell Bank',
@@ -383,6 +399,7 @@ outfitting_internal_map = {
     ('shieldgenerator', 'fast'):    'Bi-Weave Shield Generator',
     ('shieldgenerator', 'strong'):  'Prismatic Shield Generator',
     'unkvesselresearch':            'Research Limpet Controller',
+    'expmodulestabiliser':          'Experimental Weapon Stabiliser',
 }
 
 # Dashboard Flags constants

--- a/outfitting.py
+++ b/outfitting.py
@@ -98,6 +98,12 @@ def lookup(module, ship_map, entitled=False) -> dict | None:  # noqa: C901, CCR0
     elif not entitled and name[1] == 'planetapproachsuite':
         return None
 
+    # V2 Shutdown Field Neutralizer - Hpt_AntiUnknownShutdown_Tiny_V2
+    elif name[0] == 'hpt' and name[1] in countermeasure_map and len(name) == 4 and name[3] == 'v2':
+        new['category'] = 'utility'
+        new['name'], new['rating'] = countermeasure_map[name[1]]
+        new['class'] = weaponclass_map[name[-2]]
+
     # Countermeasures - e.g. Hpt_PlasmaPointDefence_Turret_Tiny
     elif name[0] == 'hpt' and name[1] in countermeasure_map:
         new['category'] = 'utility'
@@ -179,12 +185,18 @@ def lookup(module, ship_map, entitled=False) -> dict | None:  # noqa: C901, CCR0
         if name[1] == 'dronecontrol':  # e.g. Int_DroneControl_Collection_Size1_Class1
             name.pop(0)
 
+        elif name[1] == 'multidronecontrol':  # e.g. Int_MultiDroneControl_Rescue_Size3_Class3
+            name.pop(0)
+
         elif name[-1] == 'free':  # Starter Sidewinder or Freagle modules - just treat them like vanilla modules
             name.pop()
 
         if name[1] in standard_map:  # e.g. Int_Engine_Size2_Class1, Int_ShieldGenerator_Size8_Class5_Strong
             new['category'] = 'standard'
-            new['name'] = standard_map[len(name) > 4 and (name[1], name[4]) or name[1]]
+            if name[2] == 'overcharge':
+                new['name'] = standard_map[(name[1], name[2])]
+            else:
+                new['name'] = standard_map[len(name) > 4 and (name[1], name[4]) or name[1]]
 
         elif name[1] in internal_map:  # e.g. Int_CargoRack_Size8_Class1
             new['category'] = 'internal'
@@ -208,6 +220,9 @@ def lookup(module, ship_map, entitled=False) -> dict | None:  # noqa: C901, CCR0
 
         elif len(name) < 4 and name[1] == 'guardianfsdbooster':  # Hack! No class.
             (new['class'], new['rating']) = (str(name[2][4:]), 'H')
+
+        elif len(name) > 4 and name[1] == 'hyperdrive':  # e.g. Int_Hyperdrive_Overcharge_Size6_Class3
+            (new['class'], new['rating']) = (str(name[4][-1:]), 'C')
 
         else:
             if len(name) < 3:


### PR DESCRIPTION
TCE has identified an error where the new SCO modules weren't being detected by EDMC. This is a two-part issue: 

1) The FDEVID files which we use for a lot of things haven't been updated (https://github.com/EDCD/FDevIDs/pull/88)
2) We didn't have the code to process these oddly named modules. These two together caused a number of errors and caused EDMC to be considered "crashed" to some tools like TCE. 

While investigating this, it was discovered that if one of these missing modules (universal limpet controllers and some of the thargoid war stuff) was encountered, it would stop the module review and leave out-of-date or incomplete module exports from stations. 

This PR adds the logic to process these missing modules.

Resolves #2202 