### PR TITLE
[2199] Better Exceptions on URL Errors

### DIFF
--- a/killswitch.py
+++ b/killswitch.py
@@ -361,8 +361,8 @@ def fetch_kill_switches(target=DEFAULT_KILLSWITCH_URL) -> KillSwitchJSONFile | N
         logger.warning(f"Failed to get kill switches, data was invalid: {e}")
         return None
 
-    except (requests.exceptions.BaseHTTPError, requests.exceptions.ConnectionError) as e:  # type: ignore
-        logger.warning(f"unable to connect to {target!r}: {e}")
+    except requests.exceptions.RequestException as requ_err:
+        logger.warning(f"unable to connect to {target!r}: {requ_err}")
         return None
 
     return data

--- a/myNotebook.py
+++ b/myNotebook.py
@@ -63,7 +63,7 @@ class Label(tk.Label):
         super().__init__(master, **kw)
 
 
-class EntryMenu:
+class EntryMenu(ttk.Entry):
     """Extended entry widget that includes a context menu with Copy, Cut-and-Paste commands."""
 
     def __init__(self, *args, **kwargs) -> None:
@@ -120,7 +120,7 @@ class EntryMenu:
             pass
 
 
-class Entry(ttk.Entry, EntryMenu):
+class Entry(EntryMenu):
     """Custom t(t)k.Entry class to fix some display issues."""
 
     # DEPRECATED: Migrate to ttk.Entry or EntryMenu. Will remove in 5.12 or later.

--- a/myNotebook.py
+++ b/myNotebook.py
@@ -63,11 +63,11 @@ class Label(tk.Label):
         super().__init__(master, **kw)
 
 
-class EntryMenu(ttk.Entry):
+class EntryMenu:
     """Extended entry widget that includes a context menu with Copy, Cut-and-Paste commands."""
 
     def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+        ttk.Entry.__init__(self, *args, **kwargs)
 
         self.menu = tk.Menu(self, tearoff=False)
         self.menu.add_command(label="Copy", command=self.copy)
@@ -120,7 +120,7 @@ class EntryMenu(ttk.Entry):
             pass
 
 
-class Entry(ttk.Entry or EntryMenu):  # type: ignore
+class Entry(ttk.Entry, EntryMenu):
     """Custom t(t)k.Entry class to fix some display issues."""
 
     # DEPRECATED: Migrate to ttk.Entry or EntryMenu. Will remove in 5.12 or later.


### PR DESCRIPTION
In the event of a connection issue to github, there are a number of errors and exceptions that can be thrown. A number of exception types are accounted for. Some are not. 

This PR changes to the general requests exception to handle, and prevent EDSM from crashing if the killswtich file cannot be contacted for whatever reason. 

Also includes a minor fix to the EntryMenu class which will allow greater plugin compatibility with existing plugins which use an unclear nb.Entry. 

Discovered by #2199