### PR TITLE
[2198] Cleanup Dependency Clutter

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -53,7 +53,7 @@ appcmdname = 'EDMC'
 # <https://semver.org/#semantic-versioning-specification-semver>
 # Major.Minor.Patch(-prerelease)(+buildmetadata)
 # NB: Do *not* import this, use the functions appversion() and appversion_nobuild()
-_static_appversion = '5.10.4'
+_static_appversion = '5.11.0-alpha1'
 
 _cached_version: semantic_version.Version | None = None
 copyright = '© 2015-2019 Jonathan Harris, 2020-2024 EDCD'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,5 @@
-certifi==2024.2.2
 requests==2.31.0
 pillow==10.3.0
-# requests depends on this now ?
-charset-normalizer==3.3.2
-
 watchdog==3.0.0
-# Commented out because this doesn't package well with py2exe
 infi.systray==0.1.12; sys_platform == 'win32'
-# argh==0.26.2 watchdog dep
-# pyyaml==5.3.1 watchdog dep
 semantic-version==2.10.0


### PR DESCRIPTION
# Description
Certifi and charset-normalizer are dependencies of Requests. As such, we should let Requests handle which version those programs want without pinning them ourselves. This reduces the overhead we have to maintain as well as helps to prevent issues with dependency updates. 

Additionally, removes argh and pyyaml for similar reasons. 

## Type of change
- Dependency Update

## How Has This Been Tested?
- Building with clean environments and on GH actions to ensure that the required dependencies are included.

Resolves #2198
