### PR TITLE
[1173] Add Right-Click Menu to UI Elements

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -515,13 +515,13 @@ class AppWindow:
         self.cmdr_label = tk.Label(frame, name='cmdr_label')
         self.cmdr = tk.Label(frame, compound=tk.RIGHT, anchor=tk.W, name='cmdr')
         self.ship_label = tk.Label(frame, name='ship_label')
-        self.ship = HyperlinkLabel(frame, compound=tk.RIGHT, url=self.shipyard_url, name='ship')
+        self.ship = HyperlinkLabel(frame, compound=tk.RIGHT, url=self.shipyard_url, name='ship', popup_copy=True)
         self.suit_label = tk.Label(frame, name='suit_label')
         self.suit = tk.Label(frame, compound=tk.RIGHT, anchor=tk.W, name='suit')
         self.system_label = tk.Label(frame, name='system_label')
         self.system = HyperlinkLabel(frame, compound=tk.RIGHT, url=self.system_url, popup_copy=True, name='system')
         self.station_label = tk.Label(frame, name='station_label')
-        self.station = HyperlinkLabel(frame, compound=tk.RIGHT, url=self.station_url, name='station')
+        self.station = HyperlinkLabel(frame, compound=tk.RIGHT, url=self.station_url, name='station', popup_copy=True)
         # system and station text is set/updated by the 'provider' plugins
         # edsm and inara.  Look for:
         #
@@ -1627,7 +1627,7 @@ class AppWindow:
                 hotkeymgr.play_bad()
 
     def shipyard_url(self, shipname: str) -> str | None:
-        """Despatch a ship URL to the configured handler."""
+        """Dispatch a ship URL to the configured handler."""
         if not (loadout := monitor.ship()):
             logger.warning('No ship loadout, aborting.')
             return ''
@@ -1654,13 +1654,13 @@ class AppWindow:
         return f'file://localhost/{file_name}'
 
     def system_url(self, system: str) -> str | None:
-        """Despatch a system URL to the configured handler."""
+        """Dispatch a system URL to the configured handler."""
         return plug.invoke(
             config.get_str('system_provider', default='EDSM'), 'EDSM', 'system_url', monitor.state['SystemName']
         )
 
     def station_url(self, station: str) -> str | None:
-        """Despatch a station URL to the configured handler."""
+        """Dispatch a station URL to the configured handler."""
         return plug.invoke(
             config.get_str('station_provider', default='EDSM'), 'EDSM', 'station_url',
             monitor.state['SystemName'], monitor.state['StationName']

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -431,24 +431,9 @@ from hotkey import hotkeymgr
 from l10n import translations as tr
 from monitor import monitor
 from theme import theme
-from ttkHyperlinkLabel import HyperlinkLabel
+from ttkHyperlinkLabel import HyperlinkLabel, SHIPYARD_HTML_TEMPLATE
 
 SERVER_RETRY = 5  # retry pause for Companion servers [s]
-
-SHIPYARD_HTML_TEMPLATE = """
-<!DOCTYPE HTML>
-<html>
-    <head>
-        <meta http-equiv="refresh" content="0; url={link}">
-        <title>Redirecting you to your {ship_name} at {provider_name}...</title>
-    </head>
-    <body>
-        <a href="{link}">
-            You should be redirected to your {ship_name} at {provider_name} shortly...
-        </a>
-    </body>
-</html>
-"""
 
 
 class AppWindow:

--- a/L10n/en.template
+++ b/L10n/en.template
@@ -782,3 +782,6 @@
 
 /* myNotebook.py: Can't Paste Images or Files in Text; */
 "Cannot paste non-text content." = "Cannot paste non-text content.";
+
+/* ttkHyperlinkLabel.py: Open Element In Selected Provider; */
+"Open in {URL}" = "Open in {URL}";

--- a/myNotebook.py
+++ b/myNotebook.py
@@ -121,7 +121,7 @@ class EntryMenu(ttk.Entry):
 class Entry(EntryMenu):
     """Custom ttk.Entry class to fix some display issues."""
 
-    # DEPRECATED: Migrate to EntryMenu. Will remove in 5.12 or later.
+    # DEPRECATED: Migrate to EntryMenu. Will remove in 6.0 or later.
     def __init__(self, master: ttk.Frame | None = None, **kw):
         EntryMenu.__init__(self, master, **kw)
 
@@ -139,7 +139,7 @@ class Button(ttk.Button):
 class ColoredButton(tk.Button):
     """Custom tk.Button class to fix some display issues."""
 
-    # DEPRECATED: Migrate to tk.Button. Will remove in 5.12 or later.
+    # DEPRECATED: Migrate to tk.Button. Will remove in 6.0 or later.
     def __init__(self, master: ttk.Frame | None = None, **kw):
         tk.Button.__init__(self, master, **kw)
 

--- a/ttkHyperlinkLabel.py
+++ b/ttkHyperlinkLabel.py
@@ -32,7 +32,21 @@ from os import path
 from config import config, logger
 from l10n import translations as tr
 from monitor import monitor
-from EDMarketConnector import SHIPYARD_HTML_TEMPLATE
+
+SHIPYARD_HTML_TEMPLATE = """
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <meta http-equiv="refresh" content="0; url={link}">
+        <title>Redirecting you to your {ship_name} at {provider_name}...</title>
+    </head>
+    <body>
+        <a href="{link}">
+            You should be redirected to your {ship_name} at {provider_name} shortly...
+        </a>
+    </body>
+</html>
+"""
 
 
 class HyperlinkLabel(tk.Label or ttk.Label):  # type: ignore


### PR DESCRIPTION
# Description
This feature adds a pop-up menu for the three core HyperlinkLabel elements on the main UI (that is, Ship, System, and Station). This menu includes the ability to open the selected element in any of the available URL providers, even the ones that are not currently selected in the configuration system. This also enables the "Copy" option on the Station and Ship elements. This also adds a new translation check for the needed elements. 

# Example Images
![image](https://github.com/EDCD/EDMarketConnector/assets/26337384/06bf9732-ccfe-459d-94ed-929657310b80)
![python_N5rV4vvnJk](https://github.com/EDCD/EDMarketConnector/assets/26337384/c803f8f4-93bf-4d38-b3f8-c3c1924da55e)

# Type of change
- New Feature

# Notes
Relies upon #2209 for the updated translation system. Until that PR is merged in, this will appear with a larger diff than it really has. 

Resolves #1173