### PR TITLE
[1654] Add Ship Jump Range and Cargo Capacity to Inara

### DIFF
--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -553,23 +553,6 @@ def journal_entry(  # noqa: C901, CCR001
 
             # Ship change
             if event_name == 'Loadout' and this.shipswap:
-                cur_ship = {
-                    'shipType': state['ShipType'],
-                    'shipGameID': state['ShipID'],
-                    'shipName': state['ShipName'],  # Can be None
-                    'shipIdent': state['ShipIdent'],  # Can be None
-                    'isCurrentShip': True,
-                }
-
-                if state['HullValue']:
-                    cur_ship['shipHullValue'] = state['HullValue']
-
-                if state['ModulesValue']:
-                    cur_ship['shipModulesValue'] = state['ModulesValue']
-
-                cur_ship['shipRebuyCost'] = state['Rebuy']
-                new_add_event('setCommanderShip', entry['timestamp'], cur_ship)
-
                 this.loadout = make_loadout(state)
                 new_add_event('setCommanderShipLoadout', entry['timestamp'], this.loadout)
                 this.shipswap = False
@@ -857,7 +840,7 @@ def journal_entry(  # noqa: C901, CCR001
                 for ship in this.fleet:
                     new_add_event('setCommanderShip', entry['timestamp'], ship)
         # Loadout
-        if event_name == 'Loadout' and not this.newsession:
+        if event_name == 'Loadout':
             loadout = make_loadout(state)
             if this.loadout != loadout:
                 this.loadout = loadout
@@ -870,6 +853,26 @@ def journal_entry(  # noqa: C901, CCR001
                 )
 
                 new_add_event('setCommanderShipLoadout', entry['timestamp'], this.loadout)
+
+            cur_ship = {
+                'shipType': state['ShipType'],
+                'shipGameID': state['ShipID'],
+                'shipName': state['ShipName'],  # Can be None
+                'shipIdent': state['ShipIdent'],  # Can be None
+                'isCurrentShip': True,
+                'shipMaxJumpRange': entry['MaxJumpRange'],
+                'shipCargoCapacity': entry['CargoCapacity']
+            }
+            if state['HullValue']:
+                cur_ship['shipHullValue'] = state['HullValue']
+
+            if state['ModulesValue']:
+                cur_ship['shipModulesValue'] = state['ModulesValue']
+
+            if state['Rebuy']:
+                cur_ship['shipRebuyCost'] = state['Rebuy']
+
+            new_add_event('setCommanderShip', entry['timestamp'], cur_ship)
 
         # Stored modules
         if event_name == 'StoredModules':


### PR DESCRIPTION
# Description
As of mid-2022, Inara includes the ability to set the maximum ship jump range and cargo capacity of a given ship to the setCommanderShip event. This PR adds that data to the information we send to Inara, and increases the number of places where this data event is updated. 

This is done by processing this data anytime a Loadout event is sent, including on session startup as all of the data needed can be found on startup events. Additionally, the update for setCommanderShip is moved out of shipswap events and into any time the Loadout event is recorded by the game. 

# Type of Change
* Enhancement

# How Has This Been Tested?
* Tested with various setCommanderShip event triggers to determine where data is available 
* Ensured duplicate events are not sent to Inara where possible on Loadout events

Resolves #1654