### PR TITLE
[2166] Update Watchdog Type Hints

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -42,7 +42,7 @@ if sys.platform == 'win32':
     import ctypes
     from ctypes.wintypes import BOOL, HWND, LPARAM, LPWSTR
 
-    from watchdog.events import FileCreatedEvent, FileSystemEventHandler
+    from watchdog.events import FileSystemEventHandler, FileSystemEvent
     from watchdog.observers import Observer
     from watchdog.observers.api import BaseObserver
 
@@ -64,7 +64,7 @@ else:
     FileSystemEventHandler = object  # dummy
     if TYPE_CHECKING:
         # this isn't ever used, but this will make type checking happy
-        from watchdog.events import FileCreatedEvent
+        from watchdog.events import FileSystemEvent
         from watchdog.observers import Observer
         from watchdog.observers.api import BaseObserver
 
@@ -350,7 +350,7 @@ class EDLogs(FileSystemEventHandler):
         """
         return bool(self.thread and self.thread.is_alive())
 
-    def on_created(self, event: 'FileCreatedEvent') -> None:
+    def on_created(self, event: 'FileSystemEvent') -> None:
         """Watchdog callback when, e.g. client (re)started."""
         if not event.is_directory and self._RE_LOGFILE.search(basename(event.src_path)):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pillow==10.3.0
 # requests depends on this now ?
 charset-normalizer==3.3.2
 
-watchdog==3.0.0
+watchdog==4.0.0
 # Commented out because this doesn't package well with py2exe
 infi.systray==0.1.12; sys_platform == 'win32'
 # argh==0.26.2 watchdog dep


### PR DESCRIPTION
# Description
Watchdog 4.0.0 included an update to the public API where FileSystemEvent, and subclasses, are now dataclasses, and their repr() has changed.

As such, (insofar as I can tell) the FileCreatedEvent is now a FileSystemEvent. MyPy also suggests that this is a FileSystemEvent as well. This type hint change should have no practical impact on the code, only how items that are calling this function expect data from it. 

# Type of Change
* Minor Fix

# How Has This Been Tested?
* MyPy tests, boot tests, and minor gameplay time to ensure no new errors are generated.

Replacement for #2166 