### PR TITLE
[1268] Handover to Path.is_reserved()

### DIFF
--- a/util_ships.py
+++ b/util_ships.py
@@ -5,18 +5,21 @@ Copyright (c) EDCD, All Rights Reserved
 Licensed under the GNU General Public License.
 See LICENSE file.
 """
+from pathlib import Path
 from edmc_data import ship_name_map
 
 
 def ship_file_name(ship_name: str, ship_type: str) -> str:
     """Return a ship name suitable for a filename."""
     name = str(ship_name or ship_name_map.get(ship_type.lower(), ship_type)).strip()
-    if name.endswith('.'):
-        name = name[:-2]
 
-    if name.lower() in ('con', 'prn', 'aux', 'nul',
-                        'com0', 'com2', 'com3', 'com4', 'com5', 'com6', 'com7', 'com8', 'com9',
-                        'lpt0', 'lpt2', 'lpt3', 'lpt4', 'lpt5', 'lpt6', 'lpt7', 'lpt8', 'lpt9'):
-        name += '_'
+    # Handle suffix using Pathlib's with_suffix method
+    name = Path(name).with_suffix("").name
 
-    return name.translate({ord(x): '_' for x in ('\0', '<', '>', ':', '"', '/', '\\', '|', '?', '*')})
+    # Check if the name is a reserved filename
+    if Path(name).is_reserved():
+        name += "_"
+
+    return name.translate(
+        {ord(x): "_" for x in ("\0", "<", ">", ":", '"', "/", "\\", "|", "?", "*")}
+    )


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
<!-- What does this PR Do? -->
This PR adds additional robust checking to make sure that a ship name is not in the Windows Reserved Filename list. This removes the older self-maintained version, and dumps the responsibility for that on Python's Pathlib module. (Why replicate existing work?)

This slightly renames how ship names can be output, however, remains safe for use in Windows and Linux (Linux will accept any filename). 

# Type of Change
- Feature Enhancement

# How Tested
<!-- How have you tested this change to ensure it works and doesn't cause new issues -->
Tested on a number of ship names using Windows reserved naming schemes. (Hello con, the Adder!)

# Notes
<!-- Does this resolve any open issues? Was this PR discussed internally somewhere off GitHub? -->

Resolves #1268 