### PR TITLE
[830] Open Log Folder Natively

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -18,6 +18,7 @@ import subprocess
 import sys
 import threading
 import webbrowser
+import tempfile
 from os import chdir, environ, path
 from time import localtime, strftime, time
 from typing import TYPE_CHECKING, Any, Literal
@@ -47,8 +48,6 @@ if __name__ == '__main__':
     # output until after this redirect is done, if needed.
     if getattr(sys, 'frozen', False):
         # By default py2exe tries to write log to dirname(sys.executable) which fails when installed
-        import tempfile
-
         # unbuffered not allowed for text in python3, so use `1 for line buffering
         log_file_path = path.join(tempfile.gettempdir(), f'{appname}.log')
         sys.stdout = sys.stderr = open(log_file_path, mode='wt', buffering=1)  # Do NOT use WITH here.
@@ -651,7 +650,8 @@ class AppWindow:
         self.help_menu.add_command(command=lambda: self.updater.check_for_updates())  # Check for Updates...
         # About E:D Market Connector
         self.help_menu.add_command(command=lambda: not self.HelpAbout.showing and self.HelpAbout(self.w))
-        self.help_menu.add_command(command=prefs.help_open_log_folder)  # Open Log Folder
+        logfile_loc = pathlib.Path(tempfile.gettempdir()) / appname
+        self.help_menu.add_command(command=lambda: prefs.open_folder(logfile_loc))  # Open Log Folder
 
         self.menubar.add_cascade(menu=self.help_menu)
         if sys.platform == 'win32':

--- a/prefs.py
+++ b/prefs.py
@@ -8,14 +8,12 @@ import pathlib
 import sys
 import tempfile
 import tkinter as tk
-import webbrowser
 from os import system
 from os.path import expanduser, expandvars, join, normpath
 from tkinter import colorchooser as tkColorChooser  # type: ignore # noqa: N812
 from tkinter import ttk
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Callable, Optional, Type
-
 import myNotebook as nb  # noqa: N813
 import plug
 from config import appversion_nobuild, config
@@ -44,14 +42,21 @@ if TYPE_CHECKING:
 
 def help_open_log_folder() -> None:
     """Open the folder logs are stored in."""
-    logfile_loc = pathlib.Path(tempfile.gettempdir())
-    logfile_loc /= f'{appname}'
+    logger.warning(
+        DeprecationWarning("This function is deprecated, use open_log_folder instead. "
+                           "This function will be removed in 6.0 or later")
+    )
+    open_folder(pathlib.Path(tempfile.gettempdir()) / appname)
+
+
+def open_folder(file: pathlib.Path) -> None:
+    """Open the given file in the OS file explorer."""
     if sys.platform.startswith('win'):
         # On Windows, use the "start" command to open the folder
-        system(f'start "" "{logfile_loc}"')
+        system(f'start "" "{file}"')
     elif sys.platform.startswith('linux'):
         # On Linux, use the "xdg-open" command to open the folder
-        system(f'xdg-open "{logfile_loc}"')
+        system(f'xdg-open "{file}"')
 
 
 class PrefsVersion:
@@ -299,6 +304,9 @@ class PreferencesDialog(tk.Toplevel):
                 0x10000, None, position
             ):
                 self.geometry(f"+{position.left}+{position.top}")
+
+        # Set Log Directory
+        self.logfile_loc = pathlib.Path(tempfile.gettempdir()) / appname
 
     def __setup_output_tab(self, root_notebook: ttk.Notebook) -> None:
         output_frame = nb.Frame(root_notebook)
@@ -625,7 +633,7 @@ class PreferencesDialog(tk.Toplevel):
                 config_frame,
                 # LANG: Label on button used to open a filesystem folder
                 text=_('Open Log Folder'),  # Button that opens a folder in Explorer/Finder
-                command=lambda: help_open_log_folder()
+                command=lambda: open_folder(self.logfile_loc)
             ).grid(column=2, padx=self.PADX, pady=0, sticky=tk.NSEW, row=cur_row)
 
         # Big spacer
@@ -884,7 +892,7 @@ class PreferencesDialog(tk.Toplevel):
                 plugins_frame,
                 # LANG: Label on button used to open a filesystem folder
                 text=_('Open'),  # Button that opens a folder in Explorer/Finder
-                command=lambda: webbrowser.open(f'file:///{config.plugin_dir_path}')
+                command=lambda: open_folder(config.plugin_dir_path)
             ).grid(column=1, padx=self.PADX, pady=self.PADY, sticky=tk.N, row=cur_row)
 
         enabled_plugins = list(filter(lambda x: x.folder and x.module, plug.PLUGINS))


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
<!-- What does this PR Do? -->
Currently, when choosing "Open Plugin Location" on Linux, the system calls the web-browser and instead opens the directory in the web-browser instead of the file explorer. This is sub-optimal. Instead of calling the web-browser, this PR instructs the OS to open the file or folder indicated natively. 

This is done by leveraging the `help_open_log_folder()` function (renamed to `open_folder()`), and generalizing the file. The existing `help_open_log_folder()` is deprecated and slated for removal in 6.0. 

# Type of Change
<!-- What type of change is this? New Feature? Enhancement to Existing Feature? Bug Fix? Translation Update? -->
- Enhancement

# How Tested
<!-- How have you tested this change to ensure it works and doesn't cause new issues -->
- Tested in available Windows and Linux builds to ensure that the file does not open in a webbrowser.

# Notes
<!-- Does this resolve any open issues? Was this PR discussed internally somewhere off GitHub? -->
Resolves #830 