### PR TITLE
[2228] Handle Unknown FSD Ranges

### DIFF
--- a/edmc_data.py
+++ b/edmc_data.py
@@ -357,7 +357,7 @@ outfitting_standard_map = {
     'guardianpowerdistributor':     'Guardian Hybrid Power Distributor',
     'guardianpowerplant':           'Guardian Hybrid Power Plant',
     'hyperdrive':                   'Frame Shift Drive',
-    ('hyperdrive', 'overcharge'):   'Frame Shift Drive',
+    ('hyperdrive', 'overcharge'):   'Frame Shift Drive (SCO)',
     'lifesupport':                  'Life Support',
     # 'planetapproachsuite':        handled separately
     'powerdistributor':             'Power Distributor',
@@ -501,6 +501,7 @@ ship_name_map = {
     'mamba':                        'Mamba',
     'orca':                         'Orca',
     'python':                       'Python',
+    'python_nx':                    'Python Mk II',
     'scout':                        'Taipan Fighter',
     'sidewinder':                   'Sidewinder',
     'testbuggy':                    'Scarab',

--- a/edshipyard.py
+++ b/edshipyard.py
@@ -106,7 +106,7 @@ def export(data, filename=None) -> None:  # noqa: C901, CCR001
             else:
                 name = module['name']  # type: ignore
 
-            if name == 'Frame Shift Drive':
+            if name == 'Frame Shift Drive' or name == 'Frame Shift Drive (SCO)':
                 fsd = module  # save for range calculation
 
                 if mods.get('OutfittingFieldType_FSDOptimalMass'):
@@ -167,15 +167,19 @@ def export(data, filename=None) -> None:  # noqa: C901, CCR001
     try:
         mass += ships[ship_name_map[data['ship']['name'].lower()]]['hullMass']
         string += f'Mass  : {mass:.2f} T empty\n        {mass + fuel + cargo:.2f} T full\n'
+        maxfuel = fsd.get('maxfuel', 0)  # type: ignore
+        fuelmul = fsd.get('fuelmul', 0)  # type: ignore
 
-        multiplier = pow(min(fuel, fsd['maxfuel']) / fsd['fuelmul'], 1.0  # type: ignore
-                         / fsd['fuelpower']) * fsd['optmass']  # type: ignore
-
-        range_unladen = multiplier / (mass + fuel) + jumpboost
-        range_laden = multiplier / (mass + fuel + cargo) + jumpboost
-        # As of 2021-04-07 edsy.org says text import not yet implemented, so ignore the possible issue with
-        # a locale that uses comma for decimal separator.
-        string += f'Range : {range_unladen:.2f} LY unladen\n        {range_laden:.2f} LY laden\n'
+        try:
+            multiplier = pow(min(fuel, maxfuel) / fuelmul, 1.0 / fsd['fuelpower']) * fsd['optmass']  # type: ignore
+            range_unladen = multiplier / (mass + fuel) + jumpboost
+            range_laden = multiplier / (mass + fuel + cargo) + jumpboost
+            # As of 2021-04-07 edsy.org says text import not yet implemented, so ignore the possible issue with
+            # a locale that uses comma for decimal separator.
+        except ZeroDivisionError:
+            range_unladen = range_laden = 0.0
+        string += (f'Range : {range_unladen:.2f} LY current without cargo\n'
+                   f'        {range_laden:.2f} LY current with cargo\n')
 
     except Exception:
         if __debug__:

--- a/outfitting.py
+++ b/outfitting.py
@@ -222,7 +222,7 @@ def lookup(module, ship_map, entitled=False) -> dict | None:  # noqa: C901, CCR0
             (new['class'], new['rating']) = (str(name[2][4:]), 'H')
 
         elif len(name) > 4 and name[1] == 'hyperdrive':  # e.g. Int_Hyperdrive_Overcharge_Size6_Class3
-            (new['class'], new['rating']) = (str(name[4][-1:]), 'C')
+            (new['class'], new['rating']) = (str(name[3][-1:]), rating_map[name[4][-1:]])
 
         else:
             if len(name) < 3:
@@ -257,7 +257,7 @@ def lookup(module, ship_map, entitled=False) -> dict | None:  # noqa: C901, CCR0
         if not m:
             print(f'No data for module {key}')
 
-        elif new['name'] == 'Frame Shift Drive':
+        elif new['name'] == 'Frame Shift Drive' or new['name'] == 'Frame Shift Drive (SCO)':
             assert 'mass' in m and 'optmass' in m and 'maxfuel' in m and 'fuelmul' in m and 'fuelpower' in m, m
 
         else:

--- a/ships.json
+++ b/ships.json
@@ -89,6 +89,9 @@
     "Python": {
         "hullMass": 350
     },
+    "Python Mk II": {
+        "hullMass": 450
+    },
     "Sidewinder": {
         "hullMass": 25
     },


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
<!-- What does this PR Do? -->
This PR addresses the first of probably many issues that will be presented by Elite: Dangerous update 18.04. This issue is due to the fact that the exact details of the new frameshift drive modules are not in any of the sources that EDMC uses, and is required to calculate a user's jump range when using the new SCO modules. 

The eventual fix for this will need to come in multiple stages. First, the exact module details for each of the SCO modules (including any changes to the fuelmul and fuelpower constants) will need to be extracted. For EDMC, we use Coriolis's data library for this information. 

Once those numbers are known, they'll need to be added to Coriolis (this is simple to do, just time-consuming for the nearly 40 modules). That will come in a later PR. 

Without these updated numbers, we won't be able to determine the exact numbers of laden, unladen, and other jump range details. As such, we'll be filling these values with temporary placeholders of 0.0 if we can't figure out the range from the existing data. 

This PR implements a check for these missing modules and prevents a crash of EDMC when attempting to parse the data when not present. 

This PR also includes a few of the details that will be present in the Python Mk II but does not add total support for the vessel. Additionally, fixes a bug that would occur when using the new SCO modules.

# Type of Change
- Bug Fix

# How Tested
Tested with reporting conditions from #2228, to ensure the crash does not occur. 

# Notes

Related to, but does not close, #2228