### PR TITLE
[2232] Fix Missing Preferences

### DIFF
--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -493,17 +493,17 @@ def credentials(cmdr: str) -> tuple[str, str] | None:
 
     if not edsm_usernames:  # https://github.com/EDCD/EDMarketConnector/issues/2232
         edsm_usernames = ["" for _ in range(len(cmdrs))]
-        config.set('edsm_usernames', edsm_usernames)
     else:  # Check for Mismatched Length - fill with null values.
         if len(edsm_usernames) < len(cmdrs):
             edsm_usernames.extend(["" for _ in range(len(cmdrs) - len(edsm_usernames))])
+    config.set('edsm_usernames', edsm_usernames)
 
     if not edsm_apikeys:
         edsm_apikeys = ["" for _ in range(len(cmdrs))]
-        config.set('edsm_apikeys', edsm_apikeys)
     else:  # Check for Mismatched Length - fill with null values.
         if len(edsm_apikeys) < len(cmdrs):
             edsm_apikeys.extend(["" for _ in range(len(cmdrs) - len(edsm_apikeys))])
+    config.set('edsm_apikeys', edsm_apikeys)
 
     if cmdr in cmdrs and len(cmdrs) == len(edsm_usernames) == len(edsm_apikeys):
         idx = cmdrs.index(cmdr)

--- a/plugins/edsm.py
+++ b/plugins/edsm.py
@@ -491,6 +491,20 @@ def credentials(cmdr: str) -> tuple[str, str] | None:
     edsm_usernames = config.get_list('edsm_usernames')
     edsm_apikeys = config.get_list('edsm_apikeys')
 
+    if not edsm_usernames:  # https://github.com/EDCD/EDMarketConnector/issues/2232
+        edsm_usernames = ["" for _ in range(len(cmdrs))]
+        config.set('edsm_usernames', edsm_usernames)
+    else:  # Check for Mismatched Length - fill with null values.
+        if len(edsm_usernames) < len(cmdrs):
+            edsm_usernames.extend(["" for _ in range(len(cmdrs) - len(edsm_usernames))])
+
+    if not edsm_apikeys:
+        edsm_apikeys = ["" for _ in range(len(cmdrs))]
+        config.set('edsm_apikeys', edsm_apikeys)
+    else:  # Check for Mismatched Length - fill with null values.
+        if len(edsm_apikeys) < len(cmdrs):
+            edsm_apikeys.extend(["" for _ in range(len(cmdrs) - len(edsm_apikeys))])
+
     if cmdr in cmdrs and len(cmdrs) == len(edsm_usernames) == len(edsm_apikeys):
         idx = cmdrs.index(cmdr)
         if idx < len(edsm_usernames) and idx < len(edsm_apikeys):


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
<!-- What does this PR Do? -->
Fixes an issue that could present on clean installs where the EDSM keys weren't generated properly. This will set the key if totally missing, else try and extend a mismatched API set with null values when able. This issue would most often present itself on clean installs.

# Type of Change
<!-- What type of change is this? New Feature? Enhancement to Existing Feature? Bug Fix? Translation Update? -->
Bug Fix

# How Tested
<!-- How have you tested this change to ensure it works and doesn't cause new issues -->
Tested with mismatched, missing, and malformed EDSM preferences key entries, and ensuring the program recovers successfully from the reported replication steps. 

# Notes
<!-- Does this resolve any open issues? Was this PR discussed internally somewhere off GitHub? -->
Resolves #2232 