### PR TITLE
Ttk-based theming

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -400,7 +400,6 @@ if TYPE_CHECKING:
     # isort: on
 
 
-import json
 import tkinter as tk
 import tkinter.filedialog
 import tkinter.font
@@ -412,7 +411,6 @@ import prefs
 import protocol
 import stats
 import td
-from commodity import COMMODITY_CSV
 from dashboard import dashboard
 from edmc_data import ship_name_map
 from hotkey import hotkeymgr
@@ -446,6 +444,7 @@ class AppWindow:
         self.minimizing = False
         self.w.rowconfigure(0, weight=1)
         self.w.columnconfigure(0, weight=1)
+        theme.initialize()
 
         # companion needs to be able to send <<CAPIResponse>> events
         companion.session.set_tk_master(self.w)
@@ -464,15 +463,6 @@ class AppWindow:
             self.systray.start()
 
         plug.load_plugins(master)
-        self.style = ttk.Style()
-        # ttk.Separator does not allow to configure its thickness, so we have to make our own
-        self.style.configure('Sep.TFrame', padding=2,
-                             background=self.style.lookup('TLabel', 'foreground', ['disabled']))
-        self.style.configure('Link.TLabel', font='TkDefaultFont', foreground='blue')  # HyperlinkLabel
-        with open('themes/dark.json') as f:
-            dark = json.load(f)
-            self.style.theme_create('dark', self.style.theme_use(), dark)
-        self.style.theme_use('dark')
 
         if sys.platform == 'win32':
             self.w.wm_iconbitmap(default='EDMarketConnector.ico')
@@ -966,7 +956,7 @@ class AppWindow:
                 # Fixup anomalies in the comodity data
                 fixed = companion.fixup(data)
                 if output_flags & config.OUT_MKT_CSV:
-                    commodity.export(fixed, COMMODITY_CSV)
+                    commodity.export(fixed, commodity.COMMODITY_CSV)
 
                 if output_flags & config.OUT_MKT_TD:
                     td.export(fixed)

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -350,7 +350,8 @@ if __name__ == '__main__':  # noqa: C901
 
     handle_edmc_callback_or_foregrounding()
 
-    if locked == JournalLockResult.ALREADY_LOCKED:
+    if False:
+    #if locked == JournalLockResult.ALREADY_LOCKED:
         # There's a copy already running.
 
         logger.info("An EDMarketConnector.exe process was already running, exiting.")
@@ -399,6 +400,7 @@ if TYPE_CHECKING:
     # isort: on
 
 
+import json
 import tkinter as tk
 import tkinter.filedialog
 import tkinter.font
@@ -462,6 +464,11 @@ class AppWindow:
             self.systray.start()
 
         plug.load_plugins(master)
+        self.style = ttk.Style()
+        with open('themes/dark.json') as f:
+            dark = json.load(f)
+            self.style.theme_create('dark', 'default', dark)
+        self.style.theme_use('dark')
 
         if sys.platform == 'win32':
             self.w.wm_iconbitmap(default='EDMarketConnector.ico')
@@ -523,7 +530,7 @@ class AppWindow:
         plugin_no = 0
         for plugin in plug.PLUGINS:
             # Per plugin separator
-            plugin_sep = ttk.Separator(frame, name=f"plugin_hr_{plugin_no + 1}")
+            plugin_sep = ttk.Frame(frame, name=f"plugin_hr_{plugin_no + 1}", style='Sep.TFrame')
             # Per plugin frame, for it to use as its parent for own widgets
             plugin_frame = ttk.Frame(
                 frame,
@@ -564,6 +571,7 @@ class AppWindow:
             frame,
             name='themed_update_button',
             width=28,
+            anchor=tk.CENTER,
             state=tk.DISABLED
         )
 
@@ -681,7 +689,7 @@ class AppWindow:
                           lambda e: self.help_menu.tk_popup(e.widget.winfo_rootx(),
                                                             e.widget.winfo_rooty()
                                                             + e.widget.winfo_height()))
-        ttk.Separator(self.theme_menubar).grid(columnspan=5, padx=self.PADX, sticky=tk.EW)
+        ttk.Frame(self.theme_menubar, style='Sep.TFrame').grid(columnspan=5, padx=self.PADX, sticky=tk.EW)
         theme.register(self.theme_minimize)  # images aren't automatically registered
         theme.register(self.theme_close)
         self.blank_menubar = ttk.Frame(frame, name="blank_menubar")

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -2006,22 +2006,22 @@ def show_killswitch_poppup(root=None):
     tl.columnconfigure(1, weight=1)
     tl.title("EDMC Features have been disabled")
 
-    frame = ttk.Frame(tl)
+    frame = tk.Frame(tl)
     frame.grid()
-    t = ttk.Label(frame, text=text)
+    t = tk.Label(frame, text=text)
     t.grid(columnspan=2)
     idx = 1
 
     for version in kills:
-        ttk.Label(frame, text=f'Version: {version.version}').grid(row=idx, sticky=tk.W)
+        tk.Label(frame, text=f'Version: {version.version}').grid(row=idx, sticky=tk.W)
         idx += 1
         for id, kill in version.kills.items():
-            ttk.Label(frame, text=id).grid(column=0, row=idx, sticky=tk.W, padx=(10, 0))
-            ttk.Label(frame, text=kill.reason).grid(column=1, row=idx, sticky=tk.E, padx=(0, 10))
+            tk.Label(frame, text=id).grid(column=0, row=idx, sticky=tk.W, padx=(10, 0))
+            tk.Label(frame, text=kill.reason).grid(column=1, row=idx, sticky=tk.E, padx=(0, 10))
             idx += 1
         idx += 1
 
-    ok_button = ttk.Button(frame, text="Ok", command=tl.destroy)
+    ok_button = tk.Button(frame, text="Ok", command=tl.destroy)
     ok_button.grid(columnspan=2, sticky=tk.EW)
 
 

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -465,9 +465,13 @@ class AppWindow:
 
         plug.load_plugins(master)
         self.style = ttk.Style()
+        # ttk.Separator does not allow to configure its thickness, so we have to make our own
+        self.style.configure('Sep.TFrame', padding=2,
+                             background=self.style.lookup('TLabel', 'foreground', ['disabled']))
+        self.style.configure('Link.TLabel', font='TkDefaultFont', foreground='blue')  # HyperlinkLabel
         with open('themes/dark.json') as f:
             dark = json.load(f)
-            self.style.theme_create('dark', 'default', dark)
+            self.style.theme_create('dark', self.style.theme_use(), dark)
         self.style.theme_use('dark')
 
         if sys.platform == 'win32':

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -478,19 +478,19 @@ class AppWindow:
         self.theme_close = tk.BitmapImage(
             data='#define im_width 16\n#define im_height 16\nstatic unsigned char im_bits[] = {\n   0x00, 0x00, 0x00, 0x00, 0x0c, 0x30, 0x1c, 0x38, 0x38, 0x1c, 0x70, 0x0e,\n   0xe0, 0x07, 0xc0, 0x03, 0xc0, 0x03, 0xe0, 0x07, 0x70, 0x0e, 0x38, 0x1c,\n   0x1c, 0x38, 0x0c, 0x30, 0x00, 0x00, 0x00, 0x00 };\n')  # noqa: E501
 
-        frame = tk.Frame(self.w, name=appname.lower())
+        frame = ttk.Frame(self.w, name=appname.lower())
         frame.grid(sticky=tk.NSEW)
         frame.columnconfigure(1, weight=1)
 
-        self.cmdr_label = tk.Label(frame, name='cmdr_label')
-        self.cmdr = tk.Label(frame, compound=tk.RIGHT, anchor=tk.W, name='cmdr')
-        self.ship_label = tk.Label(frame, name='ship_label')
+        self.cmdr_label = ttk.Label(frame, name='cmdr_label')
+        self.cmdr = ttk.Label(frame, compound=tk.RIGHT, anchor=tk.W, name='cmdr')
+        self.ship_label = ttk.Label(frame, name='ship_label')
         self.ship = HyperlinkLabel(frame, compound=tk.RIGHT, url=self.shipyard_url, name='ship', popup_copy=True)
-        self.suit_label = tk.Label(frame, name='suit_label')
-        self.suit = tk.Label(frame, compound=tk.RIGHT, anchor=tk.W, name='suit')
-        self.system_label = tk.Label(frame, name='system_label')
+        self.suit_label = ttk.Label(frame, name='suit_label')
+        self.suit = ttk.Label(frame, compound=tk.RIGHT, anchor=tk.W, name='suit')
+        self.system_label = ttk.Label(frame, name='system_label')
         self.system = HyperlinkLabel(frame, compound=tk.RIGHT, url=self.system_url, popup_copy=True, name='system')
-        self.station_label = tk.Label(frame, name='station_label')
+        self.station_label = ttk.Label(frame, name='station_label')
         self.station = HyperlinkLabel(frame, compound=tk.RIGHT, url=self.station_url, name='station', popup_copy=True)
         # system and station text is set/updated by the 'provider' plugins
         # edsm and inara.  Look for:
@@ -523,11 +523,9 @@ class AppWindow:
         plugin_no = 0
         for plugin in plug.PLUGINS:
             # Per plugin separator
-            plugin_sep = tk.Frame(
-                frame, highlightthickness=1, name=f"plugin_hr_{plugin_no + 1}"
-            )
+            plugin_sep = ttk.Separator(frame, name=f"plugin_hr_{plugin_no + 1}")
             # Per plugin frame, for it to use as its parent for own widgets
-            plugin_frame = tk.Frame(
+            plugin_frame = ttk.Frame(
                 frame,
                 name=f"plugin_{plugin_no + 1}"
             )
@@ -562,7 +560,7 @@ class AppWindow:
             default=tk.ACTIVE,
             state=tk.DISABLED
         )
-        self.theme_button = tk.Label(
+        self.theme_button = ttk.Label(
             frame,
             name='themed_update_button',
             width=28,
@@ -578,12 +576,12 @@ class AppWindow:
         theme.button_bind(self.theme_button, self.capi_request_data)
 
         # Bottom 'status' line.
-        self.status = tk.Label(frame, name='status', anchor=tk.W)
+        self.status = ttk.Label(frame, name='status', anchor=tk.W)
         self.status.grid(columnspan=2, sticky=tk.EW)
 
         for child in frame.winfo_children():
             child.grid_configure(padx=self.PADX, pady=(
-                sys.platform != 'win32' or isinstance(child, tk.Frame)) and 2 or 0)
+                sys.platform != 'win32' or isinstance(child, ttk.Frame)) and 2 or 0)
 
         self.menubar = tk.Menu()
 
@@ -645,9 +643,9 @@ class AppWindow:
         theme.register(self.help_menu)
 
         # Alternate title bar and menu for dark theme
-        self.theme_menubar = tk.Frame(frame, name="alternate_menubar")
+        self.theme_menubar = ttk.Frame(frame, name="alternate_menubar")
         self.theme_menubar.columnconfigure(2, weight=1)
-        theme_titlebar = tk.Label(
+        theme_titlebar = ttk.Label(
             self.theme_menubar,
             name="alternate_titlebar",
             text=applongname,
@@ -659,37 +657,37 @@ class AppWindow:
         theme_titlebar.bind('<Button-1>', self.drag_start)
         theme_titlebar.bind('<B1-Motion>', self.drag_continue)
         theme_titlebar.bind('<ButtonRelease-1>', self.drag_end)
-        theme_minimize = tk.Label(self.theme_menubar, image=self.theme_minimize)
+        theme_minimize = ttk.Label(self.theme_menubar, image=self.theme_minimize)
         theme_minimize.grid(row=0, column=3, padx=2)
         theme.button_bind(theme_minimize, self.oniconify, image=self.theme_minimize)
-        theme_close = tk.Label(self.theme_menubar, image=self.theme_close)
+        theme_close = ttk.Label(self.theme_menubar, image=self.theme_close)
         theme_close.grid(row=0, column=4, padx=2)
         theme.button_bind(theme_close, self.onexit, image=self.theme_close)
-        self.theme_file_menu = tk.Label(self.theme_menubar, anchor=tk.W)
+        self.theme_file_menu = ttk.Label(self.theme_menubar, anchor=tk.W)
         self.theme_file_menu.grid(row=1, column=0, padx=self.PADX, sticky=tk.W)
         theme.button_bind(self.theme_file_menu,
                           lambda e: self.file_menu.tk_popup(e.widget.winfo_rootx(),
                                                             e.widget.winfo_rooty()
                                                             + e.widget.winfo_height()))
-        self.theme_edit_menu = tk.Label(self.theme_menubar, anchor=tk.W)
+        self.theme_edit_menu = ttk.Label(self.theme_menubar, anchor=tk.W)
         self.theme_edit_menu.grid(row=1, column=1, sticky=tk.W)
         theme.button_bind(self.theme_edit_menu,
                           lambda e: self.edit_menu.tk_popup(e.widget.winfo_rootx(),
                                                             e.widget.winfo_rooty()
                                                             + e.widget.winfo_height()))
-        self.theme_help_menu = tk.Label(self.theme_menubar, anchor=tk.W)
+        self.theme_help_menu = ttk.Label(self.theme_menubar, anchor=tk.W)
         self.theme_help_menu.grid(row=1, column=2, sticky=tk.W)
         theme.button_bind(self.theme_help_menu,
                           lambda e: self.help_menu.tk_popup(e.widget.winfo_rootx(),
                                                             e.widget.winfo_rooty()
                                                             + e.widget.winfo_height()))
-        tk.Frame(self.theme_menubar, highlightthickness=1).grid(columnspan=5, padx=self.PADX, sticky=tk.EW)
+        ttk.Separator(self.theme_menubar).grid(columnspan=5, padx=self.PADX, sticky=tk.EW)
         theme.register(self.theme_minimize)  # images aren't automatically registered
         theme.register(self.theme_close)
-        self.blank_menubar = tk.Frame(frame, name="blank_menubar")
-        tk.Label(self.blank_menubar).grid()
-        tk.Label(self.blank_menubar).grid()
-        tk.Frame(self.blank_menubar, height=2).grid()
+        self.blank_menubar = ttk.Frame(frame, name="blank_menubar")
+        ttk.Label(self.blank_menubar).grid()
+        ttk.Label(self.blank_menubar).grid()
+        ttk.Frame(self.blank_menubar, height=2).grid()
         theme.register_alternate((self.menubar, self.theme_menubar, self.blank_menubar),
                                  {'row': 0, 'columnspan': 2, 'sticky': tk.NSEW})
         self.w.resizable(tk.TRUE, tk.FALSE)
@@ -2008,22 +2006,22 @@ def show_killswitch_poppup(root=None):
     tl.columnconfigure(1, weight=1)
     tl.title("EDMC Features have been disabled")
 
-    frame = tk.Frame(tl)
+    frame = ttk.Frame(tl)
     frame.grid()
-    t = tk.Label(frame, text=text)
+    t = ttk.Label(frame, text=text)
     t.grid(columnspan=2)
     idx = 1
 
     for version in kills:
-        tk.Label(frame, text=f'Version: {version.version}').grid(row=idx, sticky=tk.W)
+        ttk.Label(frame, text=f'Version: {version.version}').grid(row=idx, sticky=tk.W)
         idx += 1
         for id, kill in version.kills.items():
-            tk.Label(frame, text=id).grid(column=0, row=idx, sticky=tk.W, padx=(10, 0))
-            tk.Label(frame, text=kill.reason).grid(column=1, row=idx, sticky=tk.E, padx=(0, 10))
+            ttk.Label(frame, text=id).grid(column=0, row=idx, sticky=tk.W, padx=(10, 0))
+            ttk.Label(frame, text=kill.reason).grid(column=1, row=idx, sticky=tk.E, padx=(0, 10))
             idx += 1
         idx += 1
 
-    ok_button = tk.Button(frame, text="Ok", command=tl.destroy)
+    ok_button = ttk.Button(frame, text="Ok", command=tl.destroy)
     ok_button.grid(columnspan=2, sticky=tk.EW)
 
 

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -350,8 +350,7 @@ if __name__ == '__main__':  # noqa: C901
 
     handle_edmc_callback_or_foregrounding()
 
-    if False:
-    #if locked == JournalLockResult.ALREADY_LOCKED:
+    if locked == JournalLockResult.ALREADY_LOCKED:
         # There's a copy already running.
 
         logger.info("An EDMarketConnector.exe process was already running, exiting.")

--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -31,6 +31,7 @@ import tkinter as tk
 from platform import system
 from textwrap import dedent
 from threading import Lock
+from tkinter import ttk
 from typing import Any, Iterator, Mapping, MutableMapping
 import requests
 import companion
@@ -111,16 +112,16 @@ class This:
         self.eddn_delay_button: nb.Checkbutton
 
         # Tracking UI
-        self.ui: tk.Frame
-        self.ui_system_name: tk.Label
-        self.ui_system_address: tk.Label
-        self.ui_j_body_name: tk.Label
-        self.ui_j_body_id: tk.Label
-        self.ui_j_body_type: tk.Label
-        self.ui_s_body_name: tk.Label
-        self.ui_station_name: tk.Label
-        self.ui_station_type: tk.Label
-        self.ui_station_marketid: tk.Label
+        self.ui: ttk.Frame
+        self.ui_system_name: ttk.Label
+        self.ui_system_address: ttk.Label
+        self.ui_j_body_name: ttk.Label
+        self.ui_j_body_id: ttk.Label
+        self.ui_j_body_type: ttk.Label
+        self.ui_s_body_name: ttk.Label
+        self.ui_station_name: ttk.Label
+        self.ui_station_type: ttk.Label
+        self.ui_station_marketid: ttk.Label
 
 
 this = This()
@@ -2009,7 +2010,7 @@ def plugin_start3(plugin_dir: str) -> str:
     return 'EDDN'
 
 
-def plugin_app(parent: tk.Tk) -> tk.Frame | None:
+def plugin_app(parent: tk.Tk) -> ttk.Frame | None:
     """
     Set up any plugin-specific UI.
 
@@ -2023,7 +2024,7 @@ def plugin_app(parent: tk.Tk) -> tk.Frame | None:
     this.eddn = EDDN(parent)
 
     if config.eddn_tracking_ui:
-        this.ui = tk.Frame(parent)
+        this.ui = ttk.Frame(parent)
 
         row = this.ui.grid_size()[1]
 
@@ -2031,15 +2032,15 @@ def plugin_app(parent: tk.Tk) -> tk.Frame | None:
         # System
         #######################################################################
         # SystemName
-        system_name_label = tk.Label(this.ui, text="J:SystemName:")
+        system_name_label = ttk.Label(this.ui, text="J:SystemName:")
         system_name_label.grid(row=row, column=0, sticky=tk.W)
-        this.ui_system_name = tk.Label(this.ui, name='eddn_track_system_name', anchor=tk.W)
+        this.ui_system_name = ttk.Label(this.ui, name='eddn_track_system_name', anchor=tk.W)
         this.ui_system_name.grid(row=row, column=1, sticky=tk.E)
         row += 1
         # SystemAddress
-        system_address_label = tk.Label(this.ui, text="J:SystemAddress:")
+        system_address_label = ttk.Label(this.ui, text="J:SystemAddress:")
         system_address_label.grid(row=row, column=0, sticky=tk.W)
-        this.ui_system_address = tk.Label(this.ui, name='eddn_track_system_address', anchor=tk.W)
+        this.ui_system_address = ttk.Label(this.ui, name='eddn_track_system_address', anchor=tk.W)
         this.ui_system_address.grid(row=row, column=1, sticky=tk.E)
         row += 1
         #######################################################################
@@ -2048,27 +2049,27 @@ def plugin_app(parent: tk.Tk) -> tk.Frame | None:
         # Body
         #######################################################################
         # Body Name from Journal
-        journal_body_name_label = tk.Label(this.ui, text="J:BodyName:")
+        journal_body_name_label = ttk.Label(this.ui, text="J:BodyName:")
         journal_body_name_label.grid(row=row, column=0, sticky=tk.W)
-        this.ui_j_body_name = tk.Label(this.ui, name='eddn_track_j_body_name', anchor=tk.W)
+        this.ui_j_body_name = ttk.Label(this.ui, name='eddn_track_j_body_name', anchor=tk.W)
         this.ui_j_body_name.grid(row=row, column=1, sticky=tk.E)
         row += 1
         # Body ID from Journal
-        journal_body_id_label = tk.Label(this.ui, text="J:BodyID:")
+        journal_body_id_label = ttk.Label(this.ui, text="J:BodyID:")
         journal_body_id_label.grid(row=row, column=0, sticky=tk.W)
-        this.ui_j_body_id = tk.Label(this.ui, name='eddn_track_j_body_id', anchor=tk.W)
+        this.ui_j_body_id = ttk.Label(this.ui, name='eddn_track_j_body_id', anchor=tk.W)
         this.ui_j_body_id.grid(row=row, column=1, sticky=tk.E)
         row += 1
         # Body Type from Journal
-        journal_body_type_label = tk.Label(this.ui, text="J:BodyType:")
+        journal_body_type_label = ttk.Label(this.ui, text="J:BodyType:")
         journal_body_type_label.grid(row=row, column=0, sticky=tk.W)
-        this.ui_j_body_type = tk.Label(this.ui, name='eddn_track_j_body_type', anchor=tk.W)
+        this.ui_j_body_type = ttk.Label(this.ui, name='eddn_track_j_body_type', anchor=tk.W)
         this.ui_j_body_type.grid(row=row, column=1, sticky=tk.E)
         row += 1
         # Body Name from Status.json
-        status_body_name_label = tk.Label(this.ui, text="S:BodyName:")
+        status_body_name_label = ttk.Label(this.ui, text="S:BodyName:")
         status_body_name_label.grid(row=row, column=0, sticky=tk.W)
-        this.ui_s_body_name = tk.Label(this.ui, name='eddn_track_s_body_name', anchor=tk.W)
+        this.ui_s_body_name = ttk.Label(this.ui, name='eddn_track_s_body_name', anchor=tk.W)
         this.ui_s_body_name.grid(row=row, column=1, sticky=tk.E)
         row += 1
         #######################################################################
@@ -2077,21 +2078,21 @@ def plugin_app(parent: tk.Tk) -> tk.Frame | None:
         # Station
         #######################################################################
         # Name
-        status_station_name_label = tk.Label(this.ui, text="J:StationName:")
+        status_station_name_label = ttk.Label(this.ui, text="J:StationName:")
         status_station_name_label.grid(row=row, column=0, sticky=tk.W)
-        this.ui_station_name = tk.Label(this.ui, name='eddn_track_station_name', anchor=tk.W)
+        this.ui_station_name = ttk.Label(this.ui, name='eddn_track_station_name', anchor=tk.W)
         this.ui_station_name.grid(row=row, column=1, sticky=tk.E)
         row += 1
         # Type
-        status_station_type_label = tk.Label(this.ui, text="J:StationType:")
+        status_station_type_label = ttk.Label(this.ui, text="J:StationType:")
         status_station_type_label.grid(row=row, column=0, sticky=tk.W)
-        this.ui_station_type = tk.Label(this.ui, name='eddn_track_station_type', anchor=tk.W)
+        this.ui_station_type = ttk.Label(this.ui, name='eddn_track_station_type', anchor=tk.W)
         this.ui_station_type.grid(row=row, column=1, sticky=tk.E)
         row += 1
         # MarketID
-        status_station_marketid_label = tk.Label(this.ui, text="J:StationID:")
+        status_station_marketid_label = ttk.Label(this.ui, text="J:StationID:")
         status_station_marketid_label.grid(row=row, column=0, sticky=tk.W)
-        this.ui_station_marketid = tk.Label(this.ui, name='eddn_track_station_id', anchor=tk.W)
+        this.ui_station_marketid = ttk.Label(this.ui, name='eddn_track_station_id', anchor=tk.W)
         this.ui_station_marketid.grid(row=row, column=1, sticky=tk.E)
         row += 1
         #######################################################################
@@ -2107,11 +2108,11 @@ def tracking_ui_update() -> None:
         return
 
     this.ui_system_name['text'] = '≪None≫'
-    if this.ui_system_name is not None:
+    if this.system_name is not None:
         this.ui_system_name['text'] = this.system_name
 
     this.ui_system_address['text'] = '≪None≫'
-    if this.ui_system_address is not None:
+    if this.system_address is not None:
         this.ui_system_address['text'] = this.system_address
 
     this.ui_j_body_name['text'] = '≪None≫'

--- a/stats.py
+++ b/stats.py
@@ -305,7 +305,7 @@ def export_ships(companion_data: dict[str, Any], filename: AnyStr) -> None:
 class StatsDialog():
     """Status dialog containing all of the current cmdr's stats."""
 
-    def __init__(self, parent: tk.Tk, status: tk.Label) -> None:
+    def __init__(self, parent: tk.Tk, status: ttk.Label) -> None:
         self.parent: tk.Tk = parent
         self.status = status
         self.showstats()

--- a/theme.py
+++ b/theme.py
@@ -6,7 +6,7 @@ Licensed under the GNU General Public License.
 See LICENSE file.
 
 Because of various ttk limitations this app is an unholy mix of Tk and ttk widgets.
-So can't use ttk's theme support. So have to change colors manually.
+So can't just use ttk's theme support. So have to change colors manually.
 """
 from __future__ import annotations
 
@@ -17,7 +17,6 @@ import tkinter as tk
 from os.path import join
 from tkinter import ttk
 from typing import Callable
-from l10n import translations as tr
 from config import config
 from EDMCLogging import get_main_logger
 from ttkHyperlinkLabel import HyperlinkLabel

--- a/theme.py
+++ b/theme.py
@@ -163,7 +163,7 @@ class _Theme:
                 'menufont': tk.Menu()['font'],                # TkTextFont
             }
 
-        if widget not in self.widgets:
+        if widget not in self.widgets and not isinstance(widget, ttk.Widget):
             # No general way to tell whether the user has overridden, so compare against widget-type specific defaults
             attribs = set()
             if isinstance(widget, tk.BitmapImage):
@@ -171,14 +171,14 @@ class _Theme:
                     attribs.add('fg')
                 if widget['background'] not in ['', self.defaults['bitmapbg']]:
                     attribs.add('bg')
-            elif isinstance(widget, (tk.Entry, ttk.Entry)):
+            elif isinstance(widget, tk.Entry):
                 if widget['foreground'] not in ['', self.defaults['entryfg']]:
                     attribs.add('fg')
                 if widget['background'] not in ['', self.defaults['entrybg']]:
                     attribs.add('bg')
                 if 'font' in widget.keys() and str(widget['font']) not in ['', self.defaults['entryfont']]:
                     attribs.add('font')
-            elif isinstance(widget, (tk.Canvas, tk.Frame, ttk.Frame)):
+            elif isinstance(widget, (tk.Canvas, tk.Frame)):
                 if (
                     ('background' in widget.keys() or isinstance(widget, tk.Canvas))
                     and widget['background'] not in ['', self.defaults['frame']]

--- a/themes/dark.json
+++ b/themes/dark.json
@@ -1,20 +1,22 @@
 {
-    "TFrame": {
+    ".": {
         "configure": {
             "background": "grey4",
+            "foreground": "#ff8000"
+        }
+    },
+    "TFrame": {
+        "configure": {
             "highlightbackground": "#aa5500"
         }
     },
     "Sep.TFrame": {
         "configure": {
-            "background": "#ff8000",
             "padding": 2
         }
     },
     "TLabel": {
         "configure": {
-            "background": "grey4",
-            "foreground": "#ff8000",
             "padding": 1
         },
         "map": {
@@ -27,15 +29,14 @@
             ]
         }
     },
-    "Hyperlink.TLabel": {
+    "Link.TLabel": {
         "configure": {
-            "foreground": "white"
+            "foreground": "white",
+            "font": "TkDefaultFont"
         }
     },
     "TButton": {
         "configure": {
-            "background": "grey4",
-            "foreground": "#ff8000",
             "relief": "raised",
             "padding": 2
         },

--- a/themes/dark.json
+++ b/themes/dark.json
@@ -1,0 +1,55 @@
+{
+    "TFrame": {
+        "configure": {
+            "background": "grey4",
+            "highlightbackground": "#aa5500"
+        }
+    },
+    "Sep.TFrame": {
+        "configure": {
+            "background": "#ff8000",
+            "padding": 2
+        }
+    },
+    "TLabel": {
+        "configure": {
+            "background": "grey4",
+            "foreground": "#ff8000",
+            "padding": 1
+        },
+        "map": {
+            "background": [
+                ["active", "#ff8000"]
+            ],
+            "foreground": [
+                ["active", "grey4"],
+                ["disabled", "#aa5500"]
+            ]
+        }
+    },
+    "Hyperlink.TLabel": {
+        "configure": {
+            "foreground": "white"
+        }
+    },
+    "TButton": {
+        "configure": {
+            "background": "grey4",
+            "foreground": "#ff8000",
+            "relief": "raised",
+            "padding": 2
+        },
+        "map": {
+            "background": [
+                ["pressed", "#ff8000"]
+            ],
+            "foreground": [
+                ["pressed", "grey4"],
+                ["disabled", "#aa5500"]
+            ],
+            "relief": [
+                ["pressed", "sunken"]
+            ]
+        }
+    }
+}

--- a/themes/dark.json
+++ b/themes/dark.json
@@ -12,7 +12,7 @@
     },
     "Sep.TFrame": {
         "configure": {
-            "padding": 2
+            "background": "#ff8000"
         }
     },
     "TLabel": {

--- a/themes/transparent.json
+++ b/themes/transparent.json
@@ -1,0 +1,57 @@
+{
+    ".": {
+        "configure": {
+            "background": "grey4",
+            "foreground": "#ff8000",
+            "font": "\"Euro Caps\" 10"
+        }
+    },
+    "TFrame": {
+        "configure": {
+            "highlightbackground": "#aa5500"
+        }
+    },
+    "Sep.TFrame": {
+        "configure": {
+            "background": "#ff8000"
+        }
+    },
+    "TLabel": {
+        "configure": {
+            "padding": 1
+        },
+        "map": {
+            "background": [
+                ["active", "#ff8000"]
+            ],
+            "foreground": [
+                ["active", "grey4"],
+                ["disabled", "#aa5500"]
+            ]
+        }
+    },
+    "Link.TLabel": {
+        "configure": {
+            "foreground": "white",
+            "font": "\"Euro Caps\" 10"
+        }
+    },
+    "TButton": {
+        "configure": {
+            "relief": "raised",
+            "padding": 2
+        },
+        "map": {
+            "background": [
+                ["pressed", "#ff8000"]
+            ],
+            "foreground": [
+                ["pressed", "grey4"],
+                ["disabled", "#aa5500"]
+            ],
+            "relief": [
+                ["pressed", "sunken"]
+            ]
+        }
+    }
+}

--- a/ttkHyperlinkLabel.py
+++ b/ttkHyperlinkLabel.py
@@ -61,12 +61,15 @@ class HyperlinkLabel(ttk.Label):
         """
         self.font_u: tk_font.Font
         self.font_n = None
+        self.style = 'Hyperlink.TLabel'
         self.url = kw.pop('url', None)
         self.popup_copy = kw.pop('popup_copy', False)
         self.underline = kw.pop('underline', None)  # override ttk.Label's underline
-        self.foreground = kw.get('foreground', 'blue')
+        self.foreground = kw.get('foreground', ttk.Style().lookup(
+            'Hyperlink.TLabel', 'foreground'))
+        # ttk.Label doesn't support disabledforeground option
         self.disabledforeground = kw.pop('disabledforeground', ttk.Style().lookup(
-            'TLabel', 'foreground', ('disabled',)))  # ttk.Label doesn't support disabledforeground option
+            'Hyperlink.TLabel', 'foreground', ('disabled',)))
         ttk.Label.__init__(self, master, **kw)
 
         self.bind('<Button-1>', self._click)

--- a/ttkHyperlinkLabel.py
+++ b/ttkHyperlinkLabel.py
@@ -26,7 +26,7 @@ import tkinter as tk
 import webbrowser
 from tkinter import font as tk_font
 from tkinter import ttk
-from typing import Any
+from typing import Any, no_type_check
 import plug
 from os import path
 from config import config, logger
@@ -122,8 +122,9 @@ class HyperlinkLabel(ttk.Label):
         if opener:
             return webbrowser.open(opener)
 
+    @no_type_check
     def configure(  # noqa: CCR001
-        self, cnf: dict[str, Any] | None = None, **kw
+        self, cnf: dict[str, Any] | None = None, **kw: Any
     ) -> dict[str, tuple[str, str, str, Any, Any]] | None:
         """Change cursor and appearance depending on state and text."""
         # This class' state
@@ -174,7 +175,7 @@ class HyperlinkLabel(ttk.Label):
 
     def _leave(self, event: tk.Event) -> None:
         if not self.underline:
-            super().configure(font=self.font_n)
+            super().configure(font=self.font_n)  # type: ignore
 
     def _click(self, event: tk.Event) -> None:
         if self.url and self['text'] and str(self['state']) != tk.DISABLED:

--- a/ttkHyperlinkLabel.py
+++ b/ttkHyperlinkLabel.py
@@ -123,8 +123,8 @@ class HyperlinkLabel(ttk.Label):
             return webbrowser.open(opener)
 
     def configure(  # noqa: CCR001
-        self, cnf: dict[str, Any] | None = None, **kw: Any
-    ) -> dict[str, tuple[str, str, str, Any, Any]]:
+        self, cnf: dict[str, Any] | None = None, **kw
+    ) -> dict[str, tuple[str, str, str, Any, Any]] | None:
         """Change cursor and appearance depending on state and text."""
         # This class' state
         for thing in ('url', 'popup_copy', 'underline'):

--- a/ttkHyperlinkLabel.py
+++ b/ttkHyperlinkLabel.py
@@ -49,7 +49,7 @@ SHIPYARD_HTML_TEMPLATE = """
 """
 
 
-class HyperlinkLabel(tk.Label or ttk.Label):  # type: ignore
+class HyperlinkLabel(ttk.Label):
     """Clickable label for HTTP links."""
 
     def __init__(self, master: ttk.Frame | tk.Frame | None = None, **kw: Any) -> None:

--- a/ttkHyperlinkLabel.py
+++ b/ttkHyperlinkLabel.py
@@ -78,7 +78,8 @@ class HyperlinkLabel(ttk.Label):
         self.bind('<Leave>', self._leave)
 
         # set up initial appearance
-        self.configure(font=kw.get('font', ttk.Style().lookup(self.style, 'font')))
+        self.configure(state=kw.get('state', tk.NORMAL),
+                       font=kw.get('font', ttk.Style().lookup(self.style, 'font')))
 
         # Add Menu Options
         self.plug_options = kw.pop('plug_options', None)

--- a/ttkHyperlinkLabel.py
+++ b/ttkHyperlinkLabel.py
@@ -61,15 +61,14 @@ class HyperlinkLabel(ttk.Label):
         """
         self.font_u: tk_font.Font
         self.font_n = None
-        self.style = 'Hyperlink.TLabel'
+        self.style = kw.get('style', 'Link.TLabel')
         self.url = kw.pop('url', None)
         self.popup_copy = kw.pop('popup_copy', False)
         self.underline = kw.pop('underline', None)  # override ttk.Label's underline
-        self.foreground = kw.get('foreground', ttk.Style().lookup(
-            'Hyperlink.TLabel', 'foreground'))
+        self.foreground = kw.get('foreground', ttk.Style().lookup(self.style, 'foreground'))
         # ttk.Label doesn't support disabledforeground option
-        self.disabledforeground = kw.pop('disabledforeground', ttk.Style().lookup(
-            'Hyperlink.TLabel', 'foreground', ('disabled',)))
+        self.disabledforeground = kw.pop('disabledforeground',
+                                         ttk.Style().lookup(self.style, 'foreground', ('disabled',)))
         ttk.Label.__init__(self, master, **kw)
 
         self.bind('<Button-1>', self._click)
@@ -79,9 +78,7 @@ class HyperlinkLabel(ttk.Label):
         self.bind('<Leave>', self._leave)
 
         # set up initial appearance
-        self.configure(state=kw.get('state', tk.NORMAL),
-                       text=kw.get('text'),
-                       font=kw.get('font', ttk.Style().lookup('TLabel', 'font')))
+        self.configure(font=kw.get('font', ttk.Style().lookup(self.style, 'font')))
 
         # Add Menu Options
         self.plug_options = kw.pop('plug_options', None)

--- a/ttkHyperlinkLabel.py
+++ b/ttkHyperlinkLabel.py
@@ -124,7 +124,7 @@ class HyperlinkLabel(ttk.Label):
 
     def configure(  # noqa: CCR001
         self, cnf: dict[str, Any] | None = None, **kw: Any
-    ) -> dict[str, tuple[str, str, str, Any, Any]] | None:
+    ) -> dict[str, tuple[str, str, str, Any, Any]]:
         """Change cursor and appearance depending on state and text."""
         # This class' state
         for thing in ('url', 'popup_copy', 'underline'):


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
This replaces all Tk widgets on the main screen with their Ttk equivalents and makes `theme.apply()` use actual Ttk themes, stored in JSON files. From there, it generates the colors to be used by `_update_widget()` - just like it currently does for the Default theme.
Also excludes Ttk widgets from `theme.register()`, as they no longer need it.

Plugin widgets are not affected, which allows for a release that prepares the room for yanking most of `theme.py` on a future major version.

# Type of Change
UI rendering.

# How Tested
Works for the basic widgets; an example plugin will be built to demonstrate all of them (which should also aid plugin developers from then on).

# Notes
Some issues emerged in its current state:
- Although it's explicitly declared, the Transparent theme does not set its font on `HyperlinkLabel`
- What to make of the "Normal text" and "Highlighted text" settings?
- Ttk widgets on *all* windows are affected, most notably Settings; is that acceptable - or maybe even desirable?