### PR TITLE
[2251] Fix FDevID Update Paths

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -25,6 +25,7 @@ from os import chdir, environ, path
 from time import localtime, strftime, time
 from typing import TYPE_CHECKING, Any, Literal
 from constants import applongname, appname, protocolhandler_redirect
+from update import check_for_fdev_updates
 
 # Have this as early as possible for people running EDMarketConnector.exe
 # from cmd.exe or a bat file or similar.  Else they might not be in the correct
@@ -2323,6 +2324,7 @@ sys.path: {sys.path}'''
     root.after(2, show_killswitch_poppup, root)
     # Start the main event loop
     try:
+        check_for_fdev_updates()
         root.mainloop()
     except KeyboardInterrupt:
         logger.info("Ctrl+C Detected, Attempting Clean Shutdown")

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -25,7 +25,6 @@ from os import chdir, environ, path
 from time import localtime, strftime, time
 from typing import TYPE_CHECKING, Any, Literal
 from constants import applongname, appname, protocolhandler_redirect
-from update import check_for_fdev_updates
 
 # Have this as early as possible for people running EDMarketConnector.exe
 # from cmd.exe or a bat file or similar.  Else they might not be in the correct
@@ -66,6 +65,7 @@ from config import appversion, appversion_nobuild, config, copyright
 
 from EDMCLogging import edmclogger, logger, logging
 from journal_lock import JournalLock, JournalLockResult
+from update import check_for_fdev_updates
 
 if __name__ == '__main__':  # noqa: C901
     # Command-line arguments

--- a/build.py
+++ b/build.py
@@ -208,5 +208,5 @@ def build() -> None:
 
 
 if __name__ == "__main__":
-    check_for_fdev_updates()
+    check_for_fdev_updates(local=True)
     build()

--- a/collate.py
+++ b/collate.py
@@ -22,6 +22,7 @@ from traceback import print_exc
 
 import companion
 import outfitting
+from config import config
 from edmc_data import companion_category_map, ship_name_map
 
 
@@ -50,7 +51,10 @@ def addcommodities(data) -> None:  # noqa: CCR001
     if not data['lastStarport'].get('commodities'):
         return
 
-    commodityfile = pathlib.Path('FDevIDs/commodity.csv')
+    try:
+        commodityfile = pathlib.Path(config.app_dir_path / 'FDevIDs' / 'commodity.csv')
+    except FileNotFoundError:
+        commodityfile = pathlib.Path('FDevIDs/commodity.csv')
     commodities = {}
 
     # slurp existing

--- a/companion.py
+++ b/companion.py
@@ -1203,10 +1203,10 @@ def fixup(data: CAPIData) -> CAPIData:  # noqa: C901, CCR001 # Can't be usefully
     if not commodity_map:
         # Lazily populate
         for f in ('commodity.csv', 'rare_commodity.csv'):
-            if not os.path.isfile(config.respath_path / 'FDevIDs/' / f):
+            if not os.path.isfile(config.app_dir_path / 'FDevIDs/' / f):
                 logger.warning(f'FDevID file {f} not found! Generating output without these commodity name rewrites.')
                 continue
-            with open(config.respath_path / 'FDevIDs' / f, 'r') as csvfile:
+            with open(config.app_dir_path / 'FDevIDs' / f, 'r') as csvfile:
                 reader = csv.DictReader(csvfile)
 
                 for row in reader:

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -54,7 +54,7 @@ appcmdname = 'EDMC'
 # <https://semver.org/#semantic-versioning-specification-semver>
 # Major.Minor.Patch(-prerelease)(+buildmetadata)
 # NB: Do *not* import this, use the functions appversion() and appversion_nobuild()
-_static_appversion = '5.11.0'
+_static_appversion = '5.11.1-alpha2'
 _cached_version: semantic_version.Version | None = None
 copyright = '© 2015-2019 Jonathan Harris, 2020-2024 EDCD'
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -54,7 +54,7 @@ appcmdname = 'EDMC'
 # <https://semver.org/#semantic-versioning-specification-semver>
 # Major.Minor.Patch(-prerelease)(+buildmetadata)
 # NB: Do *not* import this, use the functions appversion() and appversion_nobuild()
-_static_appversion = '5.11.1-alpha2'
+_static_appversion = '5.11.1-alpha3'
 _cached_version: semantic_version.Version | None = None
 copyright = '© 2015-2019 Jonathan Harris, 2020-2024 EDCD'
 

--- a/update.py
+++ b/update.py
@@ -49,7 +49,7 @@ def check_for_fdev_updates(silent: bool = False, local: bool = False) -> None:  
             logger.info(f'File {file} not found. Writing from bundle...')
             try:
                 for localfile in files_urls:
-                    filepath = f"FDevIDs/{localfile[0]}"
+                    filepath = pathlib.Path(f"FDevIDs/{localfile[0]}")
                     try:
                         shutil.copy(filepath, pathway / 'FDevIDs')
                     except shutil.SameFileError:

--- a/update.py
+++ b/update.py
@@ -30,9 +30,9 @@ logger = get_main_logger()
 def check_for_fdev_updates(silent: bool = False, local: bool = False) -> None:  # noqa: CCR001
     """Check for and download FDEV ID file updates."""
     if local:
-        pathway = config.app_dir_path
-    else:
         pathway = config.respath_path
+    else:
+        pathway = config.app_dir_path
 
     files_urls = [
         ('commodity.csv', 'https://raw.githubusercontent.com/EDCD/FDevIDs/master/commodity.csv'),
@@ -47,12 +47,15 @@ def check_for_fdev_updates(silent: bool = False, local: bool = False) -> None:  
                 local_content = f.read()
         except FileNotFoundError:
             logger.info(f'File {file} not found. Writing from bundle...')
-            for localfile in files_urls:
-                filepath = f"FDevIDs/{localfile[0]}"
-                shutil.copy(filepath, pathway / 'FDevIDs')
-                fdevid_file = pathlib.Path(pathway / 'FDevIDs' / file)
-            with open(fdevid_file, newline='', encoding='utf-8') as f:
-                local_content = f.read()
+            try:
+                for localfile in files_urls:
+                    filepath = f"FDevIDs/{localfile[0]}"
+                    shutil.copy(filepath, pathway / 'FDevIDs')
+                    fdevid_file = pathlib.Path(pathway / 'FDevIDs' / file)
+                    with open(fdevid_file, newline='', encoding='utf-8') as f:
+                        local_content = f.read()
+            except FileNotFoundError:
+                local_content = None
 
         response = requests.get(url, timeout=20)
         if response.status_code != 200:

--- a/update.py
+++ b/update.py
@@ -54,7 +54,7 @@ def check_for_fdev_updates(silent: bool = False, local: bool = False) -> None:  
             with open(fdevid_file, newline='', encoding='utf-8') as f:
                 local_content = f.read()
 
-        response = requests.get(url)
+        response = requests.get(url, timeout=20)
         if response.status_code != 200:
             if not silent:
                 logger.error(f'Failed to download {file}! Unable to continue.')

--- a/update.py
+++ b/update.py
@@ -50,7 +50,10 @@ def check_for_fdev_updates(silent: bool = False, local: bool = False) -> None:  
             try:
                 for localfile in files_urls:
                     filepath = f"FDevIDs/{localfile[0]}"
-                    shutil.copy(filepath, pathway / 'FDevIDs')
+                    try:
+                        shutil.copy(filepath, pathway / 'FDevIDs')
+                    except shutil.SameFileError:
+                        logger.info("Not replacing same file...")
                     fdevid_file = pathlib.Path(pathway / 'FDevIDs' / file)
                     with open(fdevid_file, newline='', encoding='utf-8') as f:
                         local_content = f.read()

--- a/update.py
+++ b/update.py
@@ -187,6 +187,12 @@ class Updater:
             self.updater.win_sparkle_check_update_with_ui()
 
         check_for_fdev_updates()
+        # TEMP: Only include until 6.0
+        try:
+            check_for_fdev_updates(local=True)
+        except Exception as e:
+            logger.info('Tried to update local FDEV files but failed.')
+            logger.info(e)
 
     def check_appcast(self) -> EDMCVersion | None:
         """

--- a/update.py
+++ b/update.py
@@ -191,8 +191,9 @@ class Updater:
         try:
             check_for_fdev_updates(local=True)
         except Exception as e:
-            logger.info('Tried to update local FDEV files but failed.')
-            logger.info(e)
+            logger.info("Tried to update bundle FDEV files but failed. Don't worry, "
+                        "this likely isn't important and can be ignored unless"
+                        f" you run into other issues. If you're curious: {e}")
 
     def check_appcast(self) -> EDMCVersion | None:
         """


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
This PR fixes an issue that could occur when non-installer distributions running in locations where the running users can't write to couldn't pull and update their FDEVID files. This alters the system to write to the same general location as the Plugins folder is located, as well as run the fdevid updater on startup. 

This also adapts the function to accept a "local" argument to try and force the program to update the files at the same location as the program itself, such as for builds or for backward compatibility (although backward compatibility with the FDEVID files has never been guaranteed).

Also adds a sanity check to the addcommodity function just as a quick safety net. 

# Type of Change
<!-- What type of change is this? New Feature? Enhancement to Existing Feature? Bug Fix? Translation Update? -->
Fix

# How Tested
Tested with the EDCD Discord including several Linux developers who pointed out this issue.

# Notes
Closes #2251.
