### PR TITLE
Enabled DeprecationWarning by default and fixed references

### DIFF
--- a/EDMCLogging.py
+++ b/EDMCLogging.py
@@ -42,6 +42,7 @@ import logging.handlers
 import os
 import pathlib
 import tempfile
+import warnings
 from contextlib import suppress
 from fnmatch import fnmatch
 # So that any warning about accessing a protected member is only in one place.
@@ -98,6 +99,8 @@ logging.Logger.trace = lambda self, message, *args, **kwargs: self._log(  # type
 # MAGIC-CONT: local idea of it.  So don't expect our log timestamps to perfectly match Journal ones.
 # MAGIC-CONT: See MAGIC tagged comment in Logger.__init__()
 logging.Formatter.converter = gmtime
+
+warnings.simplefilter('default', DeprecationWarning)
 
 
 def _trace_if(self: logging.Logger, condition: str, message: str, *args, **kwargs) -> None:

--- a/EDMCLogging.py
+++ b/EDMCLogging.py
@@ -101,8 +101,6 @@ logging.Logger.trace = lambda self, message, *args, **kwargs: self._log(  # type
 logging.Formatter.converter = gmtime
 
 warnings.simplefilter('default', DeprecationWarning)
-# TODO remove after infi.systray drops pkg_resources
-warnings.filterwarnings('ignore', '.*pkg_resources', DeprecationWarning)
 
 
 def _trace_if(self: logging.Logger, condition: str, message: str, *args, **kwargs) -> None:

--- a/EDMCLogging.py
+++ b/EDMCLogging.py
@@ -101,6 +101,8 @@ logging.Logger.trace = lambda self, message, *args, **kwargs: self._log(  # type
 logging.Formatter.converter = gmtime
 
 warnings.simplefilter('default', DeprecationWarning)
+# TODO remove after infi.systray drops pkg_resources
+warnings.filterwarnings('ignore', '.*pkg_resources', DeprecationWarning)
 
 
 def _trace_if(self: logging.Logger, condition: str, message: str, *args, **kwargs) -> None:

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -396,7 +396,7 @@ if TYPE_CHECKING:
     from logging import TRACE  # type: ignore # noqa: F401 # Needed to update mypy
 
     if sys.platform == 'win32':
-        from infi.systray import SysTrayIcon
+        from simplesystray import SysTrayIcon
     # isort: on
 
 
@@ -452,7 +452,7 @@ class AppWindow:
         self.prefsdialog = None
 
         if sys.platform == 'win32':
-            from infi.systray import SysTrayIcon
+            from simplesystray import SysTrayIcon
 
             def open_window(systray: 'SysTrayIcon') -> None:
                 self.w.deiconify()

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -328,6 +328,7 @@ class AbstractConfig(abc.ABC):
         :raises OSError: On Windows, if a Registry error occurs.
         :return: The data or the default.
         """
+        # DEPRECATED: Migrate to specific type getters. Will remove in 6.0 or later.
         warnings.warn('get is Deprecated. use the specific getter for your type', DeprecationWarning, stacklevel=2)
 
         if (a_list := self._suppress_call(self.get_list, ValueError, key, default=None)) is not None:
@@ -386,6 +387,7 @@ class AbstractConfig(abc.ABC):
         See get_int for its replacement.
         :raises OSError: On Windows, if a Registry error occurs.
         """
+        # DEPRECATED: Migrate to get_int. Will remove in 6.0 or later.
         warnings.warn('getint is Deprecated. Use get_int instead', DeprecationWarning, stacklevel=2)
 
         return self.get_int(key, default=default)
@@ -443,6 +445,7 @@ class AbstractConfig(abc.ABC):
         """Close this config and release any associated resources."""
         raise NotImplementedError
 
+# DEPRECATED: Password system doesn't do anything. Will remove in 6.0 or later.
     def get_password(self, account: str) -> None:
         """Legacy password retrieval."""
         warnings.warn("password subsystem is no longer supported", DeprecationWarning, stacklevel=2)
@@ -454,6 +457,7 @@ class AbstractConfig(abc.ABC):
     def delete_password(self, account: str) -> None:
         """Legacy password deletion."""
         warnings.warn("password subsystem is no longer supported", DeprecationWarning, stacklevel=2)
+# End Dep Zone
 
 
 def get_config(*args, **kwargs) -> AbstractConfig:
@@ -486,6 +490,7 @@ def get_update_feed() -> str:
     return 'https://raw.githubusercontent.com/EDCD/EDMarketConnector/releases/edmarketconnector.xml'
 
 
+# DEPRECATED: Migrate to get_update_feed(). Will remove in 6.0 or later.
 def __getattr__(name: str):
     if name == 'update_feed':
         warnings.warn('update_feed is deprecated, and will be removed in 6.0 or later. '

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -41,7 +41,6 @@ import pathlib
 import re
 import subprocess
 import sys
-import traceback
 import warnings
 from abc import abstractmethod
 from typing import Any, Callable, Type, TypeVar
@@ -329,8 +328,7 @@ class AbstractConfig(abc.ABC):
         :raises OSError: On Windows, if a Registry error occurs.
         :return: The data or the default.
         """
-        warnings.warn(DeprecationWarning('get is Deprecated. use the specific getter for your type'))
-        logger.debug('Attempt to use Deprecated get() method\n' + ''.join(traceback.format_stack()))
+        warnings.warn('get is Deprecated. use the specific getter for your type', DeprecationWarning, stacklevel=2)
 
         if (a_list := self._suppress_call(self.get_list, ValueError, key, default=None)) is not None:
             return a_list
@@ -388,8 +386,7 @@ class AbstractConfig(abc.ABC):
         See get_int for its replacement.
         :raises OSError: On Windows, if a Registry error occurs.
         """
-        warnings.warn(DeprecationWarning('getint is Deprecated. Use get_int instead'))
-        logger.debug('Attempt to use Deprecated getint() method\n' + ''.join(traceback.format_stack()))
+        warnings.warn('getint is Deprecated. Use get_int instead', DeprecationWarning, stacklevel=2)
 
         return self.get_int(key, default=default)
 
@@ -448,15 +445,15 @@ class AbstractConfig(abc.ABC):
 
     def get_password(self, account: str) -> None:
         """Legacy password retrieval."""
-        warnings.warn("password subsystem is no longer supported", DeprecationWarning)
+        warnings.warn("password subsystem is no longer supported", DeprecationWarning, stacklevel=2)
 
     def set_password(self, account: str, password: str) -> None:
         """Legacy password setting."""
-        warnings.warn("password subsystem is no longer supported", DeprecationWarning)
+        warnings.warn("password subsystem is no longer supported", DeprecationWarning, stacklevel=2)
 
     def delete_password(self, account: str) -> None:
         """Legacy password deletion."""
-        warnings.warn("password subsystem is no longer supported", DeprecationWarning)
+        warnings.warn("password subsystem is no longer supported", DeprecationWarning, stacklevel=2)
 
 
 def get_config(*args, **kwargs) -> AbstractConfig:
@@ -489,5 +486,9 @@ def get_update_feed() -> str:
     return 'https://raw.githubusercontent.com/EDCD/EDMarketConnector/releases/edmarketconnector.xml'
 
 
-# WARNING: update_feed is deprecated, and will be removed in 6.0 or later. Please migrate to get_update_feed()
-update_feed = get_update_feed()
+def __getattr__(name: str):
+    if name == 'update_feed':
+        warnings.warn('update_feed is deprecated, and will be removed in 6.0 or later. '
+                      'Please migrate to get_update_feed()', DeprecationWarning, stacklevel=2)
+        return get_update_feed()
+    raise AttributeError(name=name)

--- a/l10n.py
+++ b/l10n.py
@@ -261,7 +261,7 @@ class _Locale:
     """Locale holds a few utility methods to convert data to and from localized versions."""
 
     # DEPRECATED: Migrate to _Locale.string_from_number. Will remove in 6.0 or later.
-    def stringFromNumber(self, number: float | int, decimals: int | None = None) -> str:  # noqa:
+    def stringFromNumber(self, number: float | int, decimals: int | None = None) -> str:  # noqa: N802
         warnings.warn('use _Locale.string_from_number instead.', DeprecationWarning, stacklevel=2)
         return self.string_from_number(number, decimals)  # type: ignore
 

--- a/l10n.py
+++ b/l10n.py
@@ -263,15 +263,15 @@ class _Locale:
     """Locale holds a few utility methods to convert data to and from localized versions."""
 
     def stringFromNumber(self, number: float | int, decimals: int | None = None) -> str:  # noqa: N802
-        warnings.warn(DeprecationWarning('use _Locale.string_from_number instead.'))
+        warnings.warn('use _Locale.string_from_number instead.', DeprecationWarning, stacklevel=2)
         return self.string_from_number(number, decimals)  # type: ignore
 
     def numberFromString(self, string: str) -> int | float | None:  # noqa: N802
-        warnings.warn(DeprecationWarning('use _Locale.number_from_string instead.'))
+        warnings.warn('use _Locale.number_from_string instead.', DeprecationWarning, stacklevel=2)
         return self.number_from_string(string)
 
     def preferredLanguages(self) -> Iterable[str]:  # noqa: N802
-        warnings.warn(DeprecationWarning('use _Locale.preferred_languages instead.'))
+        warnings.warn('use _Locale.preferred_languages instead.', DeprecationWarning, stacklevel=2)
         return self.preferred_languages()
 
     def string_from_number(self, number: float | int, decimals: int = 5) -> str:
@@ -367,8 +367,8 @@ translations = Translations()
 # Begin Deprecation Zone
 class _Translations(Translations):
     def __init__(self):
-        logger.warning(DeprecationWarning('Translations and _Translations() are deprecated. '
-                       'Please use translations and Translations() instead.'))
+        warnings.warn('Translations and _Translations() are deprecated. '
+                      'Please use translations and Translations() instead.', DeprecationWarning, stacklevel=2)
         super().__init__()
 
 

--- a/l10n.py
+++ b/l10n.py
@@ -86,8 +86,7 @@ class Translations:
         Use when translation is not desired or not available
         """
         self.translations = {None: {}}
-        # WARNING: '_' is Deprecated. Will be removed in 6.0 or later.
-        # Migrate to calling translations.translate or tr.tl directly.
+        # DEPRECATED: Migrate to translations.translate or tr.tl. Will remove in 6.0 or later.
         builtins.__dict__['_'] = lambda x: str(x).replace(r'\"', '"').replace('{CR}', '\n')
 
     def install(self, lang: str | None = None) -> None:  # noqa: CCR001
@@ -131,8 +130,7 @@ class Translations:
                 except Exception:
                     logger.exception(f'Exception occurred while parsing {lang}.strings in plugin {plugin}')
 
-        # WARNING: '_' is Deprecated. Will be removed in 6.0 or later.
-        # Migrate to calling translations.translate or tr.tl directly.
+        # DEPRECATED: Migrate to translations.translate or tr.tl. Will remove in 6.0 or later.
         builtins.__dict__['_'] = self.translate
 
     def contents(self, lang: str, plugin_path: str | None = None) -> dict[str, str]:
@@ -262,14 +260,17 @@ class Translations:
 class _Locale:
     """Locale holds a few utility methods to convert data to and from localized versions."""
 
-    def stringFromNumber(self, number: float | int, decimals: int | None = None) -> str:  # noqa: N802
+    # DEPRECATED: Migrate to _Locale.string_from_number. Will remove in 6.0 or later.
+    def stringFromNumber(self, number: float | int, decimals: int | None = None) -> str:  # noqa:
         warnings.warn('use _Locale.string_from_number instead.', DeprecationWarning, stacklevel=2)
         return self.string_from_number(number, decimals)  # type: ignore
 
+    # DEPRECATED: Migrate to _Locale.number_from_string. Will remove in 6.0 or later.
     def numberFromString(self, string: str) -> int | float | None:  # noqa: N802
         warnings.warn('use _Locale.number_from_string instead.', DeprecationWarning, stacklevel=2)
         return self.number_from_string(string)
 
+    # DEPRECATED: Migrate to _Locale.preferred_languages. Will remove in 6.0 or later.
     def preferredLanguages(self) -> Iterable[str]:  # noqa: N802
         warnings.warn('use _Locale.preferred_languages instead.', DeprecationWarning, stacklevel=2)
         return self.preferred_languages()
@@ -362,8 +363,8 @@ Locale = _Locale()
 translations = Translations()
 
 
-# WARNING: 'Translations' singleton is deprecated. Will be removed in 6.0 or later.
-# Migrate to importing 'translations'.
+# DEPRECATED: Migrate to `translations`. Will be removed in 6.0 or later.
+# 'Translations' singleton is deprecated.
 # Begin Deprecation Zone
 class _Translations(Translations):
     def __init__(self):

--- a/myNotebook.py
+++ b/myNotebook.py
@@ -125,6 +125,7 @@ class EntryMenu(ttk.Entry):
 class Entry(EntryMenu):
     """Custom ttk.Entry class to fix some display issues."""
 
+    # DEPRECATED: Migrate to EntryMenu. Will remove in 6.0 or later.
     def __init__(self, master: ttk.Frame | None = None, **kw):
         warnings.warn('Migrate to EntryMenu. Will remove in 6.0 or later.', DeprecationWarning, stacklevel=2)
         EntryMenu.__init__(self, master, **kw)
@@ -143,6 +144,7 @@ class Button(ttk.Button):
 class ColoredButton(tk.Button):
     """Custom tk.Button class to fix some display issues."""
 
+    # DEPRECATED: Migrate to tk.Button. Will remove in 6.0 or later.
     def __init__(self, master: ttk.Frame | None = None, **kw):
         warnings.warn('Migrate to tk.Button. Will remove in 6.0 or later.', DeprecationWarning, stacklevel=2)
         tk.Button.__init__(self, master, **kw)

--- a/myNotebook.py
+++ b/myNotebook.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import sys
 import tkinter as tk
+import warnings
 from tkinter import ttk, messagebox
 from PIL import ImageGrab
 from l10n import translations as tr
@@ -124,8 +125,8 @@ class EntryMenu(ttk.Entry):
 class Entry(EntryMenu):
     """Custom ttk.Entry class to fix some display issues."""
 
-    # DEPRECATED: Migrate to EntryMenu. Will remove in 6.0 or later.
     def __init__(self, master: ttk.Frame | None = None, **kw):
+        warnings.warn('Migrate to EntryMenu. Will remove in 6.0 or later.', DeprecationWarning, stacklevel=2)
         EntryMenu.__init__(self, master, **kw)
 
 
@@ -142,8 +143,8 @@ class Button(ttk.Button):
 class ColoredButton(tk.Button):
     """Custom tk.Button class to fix some display issues."""
 
-    # DEPRECATED: Migrate to tk.Button. Will remove in 6.0 or later.
     def __init__(self, master: ttk.Frame | None = None, **kw):
+        warnings.warn('Migrate to tk.Button. Will remove in 6.0 or later.', DeprecationWarning, stacklevel=2)
         tk.Button.__init__(self, master, **kw)
 
 

--- a/prefs.py
+++ b/prefs.py
@@ -38,7 +38,7 @@ logger = get_main_logger()
 
 # May be imported by plugins
 
-
+# DEPRECATED: Migrate to open_log_folder. Will remove in 6.0 or later.
 def help_open_log_folder() -> None:
     """Open the folder logs are stored in."""
     warnings.warn('prefs.help_open_log_folder is deprecated, use open_log_folder instead. '

--- a/prefs.py
+++ b/prefs.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import tempfile
 import tkinter as tk
+import warnings
 from os import system
 from os.path import expanduser, expandvars, join, normpath
 from tkinter import colorchooser as tkColorChooser  # type: ignore # noqa: N812
@@ -40,10 +41,8 @@ logger = get_main_logger()
 
 def help_open_log_folder() -> None:
     """Open the folder logs are stored in."""
-    logger.warning(
-        DeprecationWarning("This function is deprecated, use open_log_folder instead. "
-                           "This function will be removed in 6.0 or later")
-    )
+    warnings.warn('prefs.help_open_log_folder is deprecated, use open_log_folder instead. '
+                  'This function will be removed in 6.0 or later', DeprecationWarning, stacklevel=2)
     open_folder(pathlib.Path(tempfile.gettempdir()) / appname)
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ wheel
 # We can't rely on just picking this up from either the base (not venv),
 # or venv-init-time version.  Specify here so that dependabot will prod us
 # about new versions.
-setuptools==69.2.0
+setuptools==70.0.0
 
 # Static analysis tools
 flake8==7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.32.3
 pillow==10.3.0
 watchdog==4.0.0
-infi.systray==0.1.12; sys_platform == 'win32'
+simplesystray==0.1.0; sys_platform == 'win32'
 semantic-version==2.10.0


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
Our use of `DeprecationWarning` falls into two traps described in [the `warnings` library documentation](https://docs.python.org/3/library/warnings.html):

1. Since Python 3.7 this particular warning is not shown by default, unless triggered directly in `__main__` (or the `-W` argument is set on the interpreter)
2. Calls to `warnings.warn()` display their own lines, which defeats the purpose of `DeprecationWarning` - the `stacklevel` exists for that, pointing one level down to the plugin function calling them.

# Type of Change
A convenience for plugin developers which would otherwise miss that they are using deprecated functions.

# How Tested
Running the latest version of some plugins showed immediate results - the use of `myNotebook.Label` being particularly common.

# Notes
<!-- Does this resolve any open issues? Was this PR discussed internally somewhere off GitHub? -->
