### PR TITLE
[2256] Allow Variable Num of Variables

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -454,7 +454,7 @@ class AppWindow:
         if sys.platform == 'win32':
             from simplesystray import SysTrayIcon
 
-            def open_window(systray: 'SysTrayIcon') -> None:
+            def open_window(systray: 'SysTrayIcon', *args) -> None:
                 self.w.deiconify()
 
             menu_options = (("Open", None, open_window),)


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
<!-- What does this PR Do? -->
In 5.11.1, a handover occurred from the older/out of date infi.systray to a more updated fork, simplesystray. This worked for the most part, however, a few edge cases showed this fork was not as drop-in a replacement as we were lead to believe.

This fixes the issue (reported in #2256) by allowing the open_window() function to accept any number of variables, with a minimum of 1. This works with both infi.systray and simplesystray logic.

# Type of Change
Bugfix

# How Tested
Tested with various iterations of minimize to tray and on both infi and simple systray.

# Notes
Closes #2256.
