### PR TITLE
[2215] Move Logging Directory

### DIFF
--- a/EDMCLogging.py
+++ b/EDMCLogging.py
@@ -41,7 +41,6 @@ import logging
 import logging.handlers
 import os
 import pathlib
-import tempfile
 import warnings
 from contextlib import suppress
 from fnmatch import fnmatch
@@ -51,7 +50,6 @@ from threading import get_native_id as thread_native_id
 from time import gmtime
 from traceback import print_exc
 from typing import TYPE_CHECKING, cast
-
 import config as config_mod
 from config import appcmdname, appname, config
 
@@ -184,8 +182,7 @@ class Logger:
         # We want the files in %TEMP%\{appname}\ as {logger_name}-debug.log and
         # rotated versions.
         # This is {logger_name} so that EDMC.py logs to a different file.
-        logfile_rotating = pathlib.Path(tempfile.gettempdir())
-        logfile_rotating /= f'{appname}'
+        logfile_rotating = pathlib.Path(config.app_dir_path / 'logs')
         logfile_rotating.mkdir(exist_ok=True)
         logfile_rotating /= f'{logger_name}-debug.log'
 

--- a/EDMCLogging.py
+++ b/EDMCLogging.py
@@ -50,8 +50,7 @@ from threading import get_native_id as thread_native_id
 from time import gmtime
 from traceback import print_exc
 from typing import TYPE_CHECKING, cast
-import config as config_mod
-from config import appcmdname, appname, config
+from config import appcmdname, appname, config, trace_on
 
 # TODO: Tests:
 #
@@ -102,7 +101,7 @@ warnings.simplefilter('default', DeprecationWarning)
 
 
 def _trace_if(self: logging.Logger, condition: str, message: str, *args, **kwargs) -> None:
-    if any(fnmatch(condition, p) for p in config_mod.trace_on):
+    if any(fnmatch(condition, p) for p in trace_on):
         self._log(logging.TRACE, message, args, **kwargs)  # type: ignore # we added it
         return
 

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -20,7 +20,6 @@ import subprocess
 import sys
 import threading
 import webbrowser
-import tempfile
 from os import chdir, environ, path
 from time import localtime, strftime, time
 from typing import TYPE_CHECKING, Any, Literal
@@ -42,16 +41,19 @@ else:
     # not frozen.
     chdir(pathlib.Path(__file__).parent)
 
-
 # config will now cause an appname logger to be set up, so we need the
 # console redirect before this
 if __name__ == '__main__':
     # Keep this as the very first code run to be as sure as possible of no
     # output until after this redirect is done, if needed.
     if getattr(sys, 'frozen', False):
+        from config import config
         # By default py2exe tries to write log to dirname(sys.executable) which fails when installed
         # unbuffered not allowed for text in python3, so use `1 for line buffering
-        log_file_path = path.join(tempfile.gettempdir(), f'{appname}.log')
+        log_file_path = pathlib.Path(config.app_dir_path / 'logs')
+        log_file_path.mkdir(exist_ok=True)
+        log_file_path /= f'{appname}.log'
+
         sys.stdout = sys.stderr = open(log_file_path, mode='wt', buffering=1)  # Do NOT use WITH here.
     # TODO: Test: Make *sure* this redirect is working, else py2exe is going to cause an exit popup
 
@@ -619,7 +621,7 @@ class AppWindow:
         self.help_menu.add_command(command=lambda: self.updater.check_for_updates())  # Check for Updates...
         # About E:D Market Connector
         self.help_menu.add_command(command=lambda: not self.HelpAbout.showing and self.HelpAbout(self.w))
-        logfile_loc = pathlib.Path(tempfile.gettempdir()) / appname
+        logfile_loc = pathlib.Path(config.app_dir_path / 'logs')
         self.help_menu.add_command(command=lambda: prefs.open_folder(logfile_loc))  # Open Log Folder
         self.help_menu.add_command(command=lambda: prefs.help_open_system_profiler(self))  # Open Log Folde
 

--- a/debug_webserver.py
+++ b/debug_webserver.py
@@ -4,20 +4,18 @@ from __future__ import annotations
 import gzip
 import json
 import pathlib
-import tempfile
 import threading
 import zlib
 from http import server
 from typing import Any, Callable, Literal
 from urllib.parse import parse_qs
-
-from config import appname
+import config
 from EDMCLogging import get_main_logger
 
 logger = get_main_logger()
 
 output_lock = threading.Lock()
-output_data_path = pathlib.Path(tempfile.gettempdir()) / f'{appname}' / 'http_debug'
+output_data_path = pathlib.Path(config.app_dir_path / 'logs' / 'http_debug')
 SAFE_TRANSLATE = str.maketrans({x: '_' for x in "!@#$%^&*()./\\\r\n[]-+='\";:?<>,~`"})
 
 

--- a/prefs.py
+++ b/prefs.py
@@ -7,7 +7,6 @@ import logging
 import pathlib
 import subprocess
 import sys
-import tempfile
 import tkinter as tk
 import warnings
 from os import system
@@ -20,7 +19,6 @@ import myNotebook as nb  # noqa: N813
 import plug
 from config import appversion_nobuild, config
 from EDMCLogging import edmclogger, get_main_logger
-from constants import appname
 from hotkey import hotkeymgr
 from l10n import translations as tr
 from monitor import monitor
@@ -43,7 +41,7 @@ def help_open_log_folder() -> None:
     """Open the folder logs are stored in."""
     warnings.warn('prefs.help_open_log_folder is deprecated, use open_log_folder instead. '
                   'This function will be removed in 6.0 or later', DeprecationWarning, stacklevel=2)
-    open_folder(pathlib.Path(tempfile.gettempdir()) / appname)
+    open_folder(pathlib.Path(config.app_dir_path / 'logs'))
 
 
 def open_folder(file: pathlib.Path) -> None:
@@ -323,7 +321,7 @@ class PreferencesDialog(tk.Toplevel):
                 self.geometry(f"+{position.left}+{position.top}")
 
         # Set Log Directory
-        self.logfile_loc = pathlib.Path(tempfile.gettempdir()) / appname
+        self.logfile_loc = pathlib.Path(config.app_dir_path / 'logs')
 
         # Set minimum size to prevent content cut-off
         self.update_idletasks()  # Update "requested size" from geometry manager


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
This PR moves the default logging directory away from $TEMPDIR or %TEMP% and to the current app data directory (Linux: `~/.local/share/edmarketconnector/logs`, Windows: `%localappdata%/edmarketconnector/logs`). 

This change is done to better follow the XDG Base Directory specifications, and to unify where files exist to fewer locations. (From up to 3 locations down to 1 for log files, plugin data, and other app files). 

# Type of Change
Enhancement

# How Tested
Tested with various builds and install locations with both installers and user-frozen exe's to ensure logging refers correctly without errors. 

# Notes
Resolves #2215 
