### PR TITLE
[2114] Pathlib Handover

### DIFF
--- a/EDMC.py
+++ b/EDMC.py
@@ -230,7 +230,7 @@ def main():  # noqa: C901, CCR001
             try:
                 monitor.currentdir = Path(config.get_str('journaldir', default=config.default_journal_dir))
                 if not monitor.currentdir:
-                    monitor.currentdir = Path(config.default_journal_dir)
+                    monitor.currentdir = config.default_journal_dir_path
 
                 logger.debug(f'logdir = "{monitor.currentdir}"')
                 logfile = monitor.journal_newest_filename(monitor.currentdir)

--- a/EDMCLogging.py
+++ b/EDMCLogging.py
@@ -26,12 +26,13 @@ To utilise logging in core code, or internal plugins, include this:
 
 To utilise logging in a 'found' (third-party) plugin, include this:
 
-    import os
+    from pathlib import Path
     import logging
 
-    plugin_name = os.path.basename(os.path.dirname(__file__))
+    # Retrieve the name of the plugin folder
+    plugin_name = Path(__file__).resolve().parent.name
+    # Set up logger with hierarchical name including appname and plugin_name
     # plugin_name here *must* be the name of the folder the plugin resides in
-    # See, plug.py:load_plugins()
     logger = logging.getLogger(f'{appname}.{plugin_name}')
 """
 from __future__ import annotations

--- a/EDMCLogging.py
+++ b/EDMCLogging.py
@@ -490,8 +490,8 @@ class EDMCContextFilter(logging.Filter):
         :return: The munged module_name.
         """
         file_name = pathlib.Path(frame_info.filename).expanduser()
-        plugin_dir = pathlib.Path(config.plugin_dir_path).expanduser()
-        internal_plugin_dir = pathlib.Path(config.internal_plugin_dir_path).expanduser()
+        plugin_dir = config.plugin_dir_path.expanduser()
+        internal_plugin_dir = config.internal_plugin_dir_path.expanduser()
         # Find the first parent called 'plugins'
         plugin_top = file_name
         while plugin_top and plugin_top.name != '':

--- a/EDMCSystemProfiler.py
+++ b/EDMCSystemProfiler.py
@@ -116,12 +116,12 @@ def main() -> None:
     root.withdraw()  # Hide the window initially to calculate the dimensions
     try:
         icon_image = tk.PhotoImage(
-            file=pathlib.Path(cur_config.respath_path) / "io.edcd.EDMarketConnector.png"
+            file=cur_config.respath_path / "io.edcd.EDMarketConnector.png"
         )
 
         root.iconphoto(True, icon_image)
     except tk.TclError:
-        root.iconbitmap(pathlib.Path(cur_config.respath_path) / "EDMarketConnector.ico")
+        root.iconbitmap(cur_config.respath_path / "EDMarketConnector.ico")
 
     sys_report = get_sys_report(cur_config)
 

--- a/EDMCSystemProfiler.py
+++ b/EDMCSystemProfiler.py
@@ -11,7 +11,7 @@ import locale
 import webbrowser
 import platform
 import sys
-from os import chdir, environ, path
+from os import chdir, environ
 import pathlib
 import logging
 from journal_lock import JournalLock
@@ -19,10 +19,10 @@ from journal_lock import JournalLock
 if getattr(sys, "frozen", False):
     # Under py2exe sys.path[0] is the executable name
     if sys.platform == "win32":
-        chdir(path.dirname(sys.path[0]))
+        chdir(pathlib.Path(sys.path[0]).parent)
         # Allow executable to be invoked from any cwd
-        environ["TCL_LIBRARY"] = path.join(path.dirname(sys.path[0]), "lib", "tcl")
-        environ["TK_LIBRARY"] = path.join(path.dirname(sys.path[0]), "lib", "tk")
+        environ['TCL_LIBRARY'] = str(pathlib.Path(sys.path[0]).parent / 'lib' / 'tcl')
+        environ['TK_LIBRARY'] = str(pathlib.Path(sys.path[0]).parent / 'lib' / 'tk')
 
 else:
     # We still want to *try* to have CWD be where the main script is, even if
@@ -44,11 +44,12 @@ def get_sys_report(config: config.AbstractConfig) -> str:
     plt = platform.uname()
     locale.setlocale(locale.LC_ALL, "")
     lcl = locale.getlocale()
-    monitor.currentdir = config.get_str(
+    monitor.currentdir = pathlib.Path(config.get_str(
         "journaldir", default=config.default_journal_dir
+        )
     )
     if not monitor.currentdir:
-        monitor.currentdir = config.default_journal_dir
+        monitor.currentdir = pathlib.Path(config.default_journal_dir)
     try:
         logfile = monitor.journal_newest_filename(monitor.currentdir)
         if logfile is None:
@@ -115,12 +116,12 @@ def main() -> None:
     root.withdraw()  # Hide the window initially to calculate the dimensions
     try:
         icon_image = tk.PhotoImage(
-            file=path.join(cur_config.respath_path, "io.edcd.EDMarketConnector.png")
+            file=pathlib.Path(cur_config.respath_path) / "io.edcd.EDMarketConnector.png"
         )
 
         root.iconphoto(True, icon_image)
     except tk.TclError:
-        root.iconbitmap(path.join(cur_config.respath_path, "EDMarketConnector.ico"))
+        root.iconbitmap(pathlib.Path(cur_config.respath_path) / "EDMarketConnector.ico")
 
     sys_report = get_sys_report(cur_config)
 

--- a/EDMCSystemProfiler.py
+++ b/EDMCSystemProfiler.py
@@ -49,7 +49,7 @@ def get_sys_report(config: config.AbstractConfig) -> str:
         )
     )
     if not monitor.currentdir:
-        monitor.currentdir = pathlib.Path(config.default_journal_dir)
+        monitor.currentdir = config.default_journal_dir_path
     try:
         logfile = monitor.journal_newest_filename(monitor.currentdir)
         if logfile is None:

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -21,7 +21,7 @@ import sys
 import threading
 import webbrowser
 import tempfile
-from os import chdir, environ, path
+from os import chdir, environ
 from time import localtime, strftime, time
 from typing import TYPE_CHECKING, Any, Literal
 from constants import applongname, appname, protocolhandler_redirect
@@ -32,10 +32,10 @@ from constants import applongname, appname, protocolhandler_redirect
 if getattr(sys, 'frozen', False):
     # Under py2exe sys.path[0] is the executable name
     if sys.platform == 'win32':
-        chdir(path.dirname(sys.path[0]))
+        os.chdir(pathlib.Path(sys.path[0]).parent)
         # Allow executable to be invoked from any cwd
-        environ['TCL_LIBRARY'] = path.join(path.dirname(sys.path[0]), 'lib', 'tcl')
-        environ['TK_LIBRARY'] = path.join(path.dirname(sys.path[0]), 'lib', 'tk')
+        environ['TCL_LIBRARY'] = str(pathlib.Path(sys.path[0]).parent / 'lib' / 'tcl')
+        environ['TK_LIBRARY'] = str(pathlib.Path(sys.path[0]).parent / 'lib' / 'tk')
 
 else:
     # We still want to *try* to have CWD be where the main script is, even if
@@ -51,7 +51,7 @@ if __name__ == '__main__':
     if getattr(sys, 'frozen', False):
         # By default py2exe tries to write log to dirname(sys.executable) which fails when installed
         # unbuffered not allowed for text in python3, so use `1 for line buffering
-        log_file_path = path.join(tempfile.gettempdir(), f'{appname}.log')
+        log_file_path = pathlib.Path(tempfile.gettempdir()) / f'{appname}.log'
         sys.stdout = sys.stderr = open(log_file_path, mode='wt', buffering=1)  # Do NOT use WITH here.
     # TODO: Test: Make *sure* this redirect is working, else py2exe is going to cause an exit popup
 
@@ -468,8 +468,8 @@ class AppWindow:
             self.w.wm_iconbitmap(default='EDMarketConnector.ico')
 
         else:
-            self.w.tk.call('wm', 'iconphoto', self.w, '-default',
-                           tk.PhotoImage(file=path.join(config.respath_path, 'io.edcd.EDMarketConnector.png')))
+            image_path = pathlib.Path(config.respath_path) / 'io.edcd.EDMarketConnector.png'
+            self.w.tk.call('wm', 'iconphoto', self.w, '-default', image=tk.PhotoImage(file=image_path))
 
         # TODO: Export to files and merge from them in future ?
         self.theme_icon = tk.PhotoImage(
@@ -1639,7 +1639,7 @@ class AppWindow:
         # Avoid file length limits if possible
         provider = config.get_str('shipyard_provider', default='EDSY')
         target = plug.invoke(provider, 'EDSY', 'shipyard_url', loadout, monitor.is_beta)
-        file_name = path.join(config.app_dir_path, "last_shipyard.html")
+        file_name = pathlib.Path(config.app_dir_path) / "last_shipyard.html"
 
         with open(file_name, 'w') as f:
             f.write(SHIPYARD_HTML_TEMPLATE.format(

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -468,7 +468,7 @@ class AppWindow:
             self.w.wm_iconbitmap(default='EDMarketConnector.ico')
 
         else:
-            image_path = pathlib.Path(config.respath_path) / 'io.edcd.EDMarketConnector.png'
+            image_path = config.respath_path / 'io.edcd.EDMarketConnector.png'
             self.w.tk.call('wm', 'iconphoto', self.w, '-default', image=tk.PhotoImage(file=image_path))
 
         # TODO: Export to files and merge from them in future ?
@@ -1639,7 +1639,7 @@ class AppWindow:
         # Avoid file length limits if possible
         provider = config.get_str('shipyard_provider', default='EDSY')
         target = plug.invoke(provider, 'EDSY', 'shipyard_url', loadout, monitor.is_beta)
-        file_name = pathlib.Path(config.app_dir_path) / "last_shipyard.html"
+        file_name = config.app_dir_path / "last_shipyard.html"
 
         with open(file_name, 'w') as f:
             f.write(SHIPYARD_HTML_TEMPLATE.format(

--- a/build.py
+++ b/build.py
@@ -10,7 +10,6 @@ import shutil
 import sys
 import pathlib
 from string import Template
-from os.path import join, isdir
 import py2exe
 from config import (
     appcmdname,
@@ -37,7 +36,7 @@ def iss_build(template_path: str, output_file: str) -> None:
         new_file.write(newfile)
 
 
-def system_check(dist_dir: str) -> str:
+def system_check(dist_dir: pathlib.Path) -> str:
     """Check if the system is able to build."""
     if sys.version_info < (3, 11):
         sys.exit(f"Unexpected Python version {sys.version}")
@@ -55,17 +54,17 @@ def system_check(dist_dir: str) -> str:
 
     print(f"Git short hash: {git_shorthash}")
 
-    if dist_dir and len(dist_dir) > 1 and isdir(dist_dir):
+    if dist_dir and pathlib.Path.is_dir(dist_dir):
         shutil.rmtree(dist_dir)
     return gitversion_file
 
 
 def generate_data_files(
     app_name: str, gitversion_file: str, plugins: list[str]
-) -> list[tuple[str, list[str]]]:
+) -> list[tuple[object, object]]:
     """Create the required datafiles to build."""
     l10n_dir = "L10n"
-    fdevids_dir = "FDevIDs"
+    fdevids_dir = pathlib.Path("FDevIDs")
     data_files = [
         (
             "",
@@ -88,13 +87,13 @@ def generate_data_files(
         ),
         (
             l10n_dir,
-            [join(l10n_dir, x) for x in os.listdir(l10n_dir) if x.endswith(".strings")],
+            [pathlib.Path(l10n_dir) / x for x in os.listdir(l10n_dir) if x.endswith(".strings")]
         ),
         (
             fdevids_dir,
             [
-                join(fdevids_dir, "commodity.csv"),
-                join(fdevids_dir, "rare_commodity.csv"),
+                pathlib.Path(fdevids_dir / "commodity.csv"),
+                pathlib.Path(fdevids_dir / "rare_commodity.csv"),
             ],
         ),
         ("plugins", plugins),
@@ -104,7 +103,7 @@ def generate_data_files(
 
 def build() -> None:
     """Build EDMarketConnector using Py2Exe."""
-    dist_dir: str = "dist.win32"
+    dist_dir: pathlib.Path = pathlib.Path("dist.win32")
     gitversion_filename: str = system_check(dist_dir)
 
     # Constants
@@ -142,7 +141,7 @@ def build() -> None:
     }
 
     # Function to generate DATA_FILES list
-    data_files: list[tuple[str, list[str]]] = generate_data_files(
+    data_files: list[tuple[object, object]] = generate_data_files(
         appname, gitversion_filename, plugins
     )
 

--- a/collate.py
+++ b/collate.py
@@ -51,7 +51,7 @@ def addcommodities(data) -> None:  # noqa: CCR001
         return
 
     try:
-        commodityfile = pathlib.Path(config.app_dir_path / 'FDevIDs' / 'commodity.csv')
+        commodityfile = config.app_dir_path / 'FDevIDs' / 'commodity.csv'
     except FileNotFoundError:
         commodityfile = pathlib.Path('FDevIDs/commodity.csv')
     commodities = {}

--- a/collate.py
+++ b/collate.py
@@ -17,7 +17,6 @@ import json
 import os
 import pathlib
 import sys
-from os.path import isfile
 from traceback import print_exc
 
 import companion
@@ -35,7 +34,7 @@ def __make_backup(file_name: pathlib.Path, suffix: str = '.bak') -> None:
     """
     backup_name = file_name.parent / (file_name.name + suffix)
 
-    if isfile(backup_name):
+    if pathlib.Path.is_file(backup_name):
         os.unlink(backup_name)
 
     os.rename(file_name, backup_name)
@@ -58,7 +57,7 @@ def addcommodities(data) -> None:  # noqa: CCR001
     commodities = {}
 
     # slurp existing
-    if isfile(commodityfile):
+    if pathlib.Path.is_file(commodityfile):
         with open(commodityfile) as csvfile:
             reader = csv.DictReader(csvfile)
             for row in reader:
@@ -86,7 +85,7 @@ def addcommodities(data) -> None:  # noqa: CCR001
     if len(commodities) <= size_pre:
         return
 
-    if isfile(commodityfile):
+    if pathlib.Path.is_file(commodityfile):
         __make_backup(commodityfile)
 
     with open(commodityfile, 'w', newline='\n') as csvfile:
@@ -109,7 +108,7 @@ def addmodules(data):  # noqa: C901, CCR001
     fields = ('id', 'symbol', 'category', 'name', 'mount', 'guidance', 'ship', 'class', 'rating', 'entitlement')
 
     # slurp existing
-    if isfile(outfile):
+    if pathlib.Path.is_file(outfile):
         with open(outfile) as csvfile:
             reader = csv.DictReader(csvfile, restval='')
             for row in reader:
@@ -147,7 +146,7 @@ def addmodules(data):  # noqa: C901, CCR001
     if not len(modules) > size_pre:
         return
 
-    if isfile(outfile):
+    if pathlib.Path.is_file(outfile):
         __make_backup(outfile)
 
     with open(outfile, 'w', newline='\n') as csvfile:
@@ -170,7 +169,7 @@ def addships(data) -> None:  # noqa: CCR001
     fields = ('id', 'symbol', 'name')
 
     # slurp existing
-    if isfile(shipfile):
+    if pathlib.Path.is_file(shipfile):
         with open(shipfile) as csvfile:
             reader = csv.DictReader(csvfile, restval='')
             for row in reader:
@@ -200,7 +199,7 @@ def addships(data) -> None:  # noqa: CCR001
     if not len(ships) > size_pre:
         return
 
-    if isfile(shipfile):
+    if pathlib.Path.is_file(shipfile):
         __make_backup(shipfile)
 
     with open(shipfile, 'w', newline='\n') as csvfile:

--- a/commodity.py
+++ b/commodity.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import time
-from os.path import join
+from pathlib import Path
 
 from config import config
 from edmc_data import commodity_bracketmap as bracketmap
@@ -29,7 +29,7 @@ def export(data, kind=COMMODITY_DEFAULT, filename=None) -> None:
         filename_time = time.strftime('%Y-%m-%dT%H.%M.%S', time.localtime(querytime))
         filename_kind = 'csv'
         filename = f'{filename_system}.{filename_starport}.{filename_time}.{filename_kind}'
-        filename = join(config.get_str('outdir'), filename)
+        filename = Path(config.get_str('outdir')) / filename
 
     if kind == COMMODITY_CSV:
         sep = ';'  # BUG: for fixing later after cleanup

--- a/companion.py
+++ b/companion.py
@@ -1204,7 +1204,7 @@ def fixup(data: CAPIData) -> CAPIData:  # noqa: C901, CCR001 # Can't be usefully
     if not commodity_map:
         # Lazily populate
         for f in ('commodity.csv', 'rare_commodity.csv'):
-            if not (Path(config.app_dir_path) / 'FDevIDs' / f).is_file():
+            if not (config.app_dir_path / 'FDevIDs' / f).is_file():
                 logger.warning(f'FDevID file {f} not found! Generating output without these commodity name rewrites.')
                 continue
             with open(config.app_dir_path / 'FDevIDs' / f, 'r') as csvfile:

--- a/companion.py
+++ b/companion.py
@@ -27,6 +27,7 @@ import tkinter as tk
 import urllib.parse
 import webbrowser
 from email.utils import parsedate
+from pathlib import Path
 from queue import Queue
 from typing import TYPE_CHECKING, Any, Mapping, TypeVar
 import requests
@@ -1135,7 +1136,7 @@ class Session:
 
     def dump_capi_data(self, data: CAPIData) -> None:
         """Dump CAPI data to file for examination."""
-        if os.path.isdir('dump'):
+        if Path('dump').is_dir():
             file_name: str = ""
             if data.source_endpoint == self.FRONTIER_CAPI_PATH_FLEETCARRIER:
                 file_name += f"FleetCarrier.{data['name']['callsign']}"
@@ -1203,7 +1204,7 @@ def fixup(data: CAPIData) -> CAPIData:  # noqa: C901, CCR001 # Can't be usefully
     if not commodity_map:
         # Lazily populate
         for f in ('commodity.csv', 'rare_commodity.csv'):
-            if not os.path.isfile(config.app_dir_path / 'FDevIDs/' / f):
+            if not (Path(config.app_dir_path) / 'FDevIDs' / f).is_file():
                 logger.warning(f'FDevID file {f} not found! Generating output without these commodity name rewrites.')
                 continue
             with open(config.app_dir_path / 'FDevIDs' / f, 'r') as csvfile:

--- a/docs/examples/plugintest/load.py
+++ b/docs/examples/plugintest/load.py
@@ -3,10 +3,10 @@
 """Plugin that tests that modules we bundle for plugins are present and working."""
 
 import logging
-import os
 import shutil
 import sqlite3
 import zipfile
+from pathlib import Path
 
 import semantic_version
 from SubA import SubA
@@ -14,7 +14,7 @@ from SubA import SubA
 from config import appname, appversion, config
 
 # This could also be returned from plugin_start3()
-plugin_name = os.path.basename(os.path.dirname(__file__))
+plugin_name = Path(__file__).resolve().parent.name
 
 # Logger per found plugin, so the folder name is included in
 # the logging format.
@@ -49,17 +49,17 @@ class PluginTest:
 
     def __init__(self, directory: str):
         logger.debug(f'directory = "{directory}')
-        dbfile = os.path.join(directory, this.DBFILE)
+        dbfile = Path(directory) / this.DBFILE
 
         # Test 'import zipfile'
-        with zipfile.ZipFile(dbfile + '.zip', 'w') as zip:
-            if os.path.exists(dbfile):
+        with zipfile.ZipFile(str(dbfile) + '.zip', 'w') as zip:
+            if dbfile.exists():
                 zip.write(dbfile)
         zip.close()
 
         # Testing 'import shutil'
-        if os.path.exists(dbfile):
-            shutil.copyfile(dbfile, dbfile + '.bak')
+        if dbfile.exists():
+            shutil.copyfile(dbfile, str(dbfile) + '.bak')
 
         # Testing 'import sqlite3'
         self.sqlconn = sqlite3.connect(dbfile)

--- a/installer.py
+++ b/installer.py
@@ -5,23 +5,23 @@ Copyright (c) EDCD, All Rights Reserved
 Licensed under the GNU General Public License.
 See LICENSE file.
 """
-import os
 import subprocess
+from pathlib import Path
 from build import build
 
 
-def run_inno_setup_installer(iss_path: str) -> None:
+def run_inno_setup_installer(iss_path: Path) -> None:
     """Run the Inno installer, building the installation exe."""
     # Get the path to the Inno Setup compiler (iscc.exe) (Currently set to default path)
-    inno_setup_compiler_path: str = "C:\\Program Files (x86)\\Inno Setup 6\\ISCC.exe"
+    inno_setup_compiler_path = Path("C:\\Program Files (x86)\\Inno Setup 6\\ISCC.exe")
 
     # Check if the Inno Setup compiler executable exists
-    if not os.path.isfile(inno_setup_compiler_path):
+    if not inno_setup_compiler_path.exists():
         print(f"Error: Inno Setup compiler not found at '{inno_setup_compiler_path}'.")
         return
 
     # Check if the provided .iss file exists
-    if not os.path.isfile(iss_file_path):
+    if not iss_file_path.exists():
         print(f"Error: The provided .iss file '{iss_path}' not found.")
         return
 
@@ -40,6 +40,6 @@ def run_inno_setup_installer(iss_path: str) -> None:
 if __name__ == "__main__":
     build()
     # Add the ISS Template File
-    iss_file_path: str = "./EDMC_Installer_Config.iss"
+    iss_file_path = Path("./EDMC_Installer_Config.iss")
     # Build the ISS file
     run_inno_setup_installer(iss_file_path)

--- a/l10n.py
+++ b/l10n.py
@@ -17,10 +17,9 @@ import re
 import sys
 import warnings
 from contextlib import suppress
-from os import listdir, sep, makedirs
-from os.path import basename, dirname, isdir, join, abspath, exists
+from os import listdir, sep
 from typing import TYPE_CHECKING, Iterable, TextIO, cast
-
+import pathlib
 from config import config
 from EDMCLogging import get_main_logger
 
@@ -35,7 +34,7 @@ logger = get_main_logger()
 
 # Language name
 LANGUAGE_ID = '!Language'
-LOCALISATION_DIR = 'L10n'
+LOCALISATION_DIR: pathlib.Path = pathlib.Path('L10n')
 
 if sys.platform == 'win32':
     import ctypes
@@ -119,10 +118,10 @@ class Translations:
 
         self.translations = {None: self.contents(cast(str, lang))}
         for plugin in listdir(config.plugin_dir_path):
-            plugin_path = join(config.plugin_dir_path, plugin, LOCALISATION_DIR)
-            if isdir(plugin_path):
+            plugin_path = config.plugin_dir_path / plugin / LOCALISATION_DIR
+            if pathlib.Path.is_dir(plugin_path):
                 try:
-                    self.translations[plugin] = self.contents(cast(str, lang), str(plugin_path))
+                    self.translations[plugin] = self.contents(cast(str, lang), plugin_path)
 
                 except UnicodeDecodeError as e:
                     logger.warning(f'Malformed file {lang}.strings in plugin {plugin}: {e}')
@@ -133,7 +132,7 @@ class Translations:
         # DEPRECATED: Migrate to translations.translate or tr.tl. Will remove in 6.0 or later.
         builtins.__dict__['_'] = self.translate
 
-    def contents(self, lang: str, plugin_path: str | None = None) -> dict[str, str]:
+    def contents(self, lang: str, plugin_path: pathlib.Path | None = None) -> dict[str, str]:
         """Load all the translations from a translation file."""
         assert lang in self.available()
         translations = {}
@@ -173,12 +172,12 @@ class Translations:
         :return: The translated string
         """
         plugin_name: str | None = None
-        plugin_path: str | None = None
+        plugin_path: pathlib.Path | None = None
 
         if context:
             # TODO: There is probably a better way to go about this now.
             plugin_name = context[len(config.plugin_dir)+1:].split(sep)[0]
-            plugin_path = join(config.plugin_dir_path, plugin_name, LOCALISATION_DIR)
+            plugin_path = pathlib.Path(config.plugin_dir_path / plugin_name / LOCALISATION_DIR)
 
         if lang:
             contents: dict[str, str] = self.contents(lang=lang, plugin_path=plugin_path)
@@ -225,17 +224,17 @@ class Translations:
 
         return names
 
-    def respath(self) -> str:
+    def respath(self) -> pathlib.Path:
         """Path to localisation files."""
         if getattr(sys, 'frozen', False):
-            return abspath(join(dirname(sys.executable), LOCALISATION_DIR))
+            return pathlib.Path(sys.executable).parent.joinpath(LOCALISATION_DIR).resolve()
 
         if __file__:
-            return abspath(join(dirname(__file__), LOCALISATION_DIR))
+            return pathlib.Path(__file__).parent.joinpath(LOCALISATION_DIR).resolve()
 
-        return abspath(LOCALISATION_DIR)
+        return pathlib.Path(LOCALISATION_DIR).resolve()
 
-    def file(self, lang: str, plugin_path: str | None = None) -> TextIO | None:
+    def file(self, lang: str, plugin_path: pathlib.Path | None = None) -> TextIO | None:
         """
         Open the given lang file for reading.
 
@@ -244,8 +243,8 @@ class Translations:
         :return: the opened file (Note: This should be closed when done)
         """
         if plugin_path:
-            file_path = join(plugin_path, f'{lang}.strings')
-            if not exists(file_path):
+            file_path = plugin_path / f"{lang}.strings"
+            if not file_path.exists():
                 return None
 
             try:
@@ -253,7 +252,7 @@ class Translations:
             except OSError:
                 logger.exception(f'could not open {file_path}')
 
-        res_path = join(self.respath(), f'{lang}.strings')
+        res_path = self.respath() / f'{lang}.strings'
         return open(res_path, encoding='utf-8')
 
 
@@ -382,9 +381,10 @@ Translations: Translations = translations  # type: ignore
 if __name__ == "__main__":
     regexp = re.compile(r'''_\([ur]?(['"])(((?<!\\)\\\1|.)+?)\1\)[^#]*(#.+)?''')  # match a single line python literal
     seen: dict[str, str] = {}
+    plugin_dir = pathlib.Path('plugins')
     for f in (
         sorted(x for x in listdir('.') if x.endswith('.py')) +
-        sorted(join('plugins', x) for x in (listdir('plugins') if isdir('plugins') else []) if x.endswith('.py'))
+        sorted(plugin_dir.glob('*.py')) if plugin_dir.is_dir() else []
     ):
         with open(f, encoding='utf-8') as h:
             lineno = 0
@@ -393,11 +393,11 @@ if __name__ == "__main__":
                 match = regexp.search(line)
                 if match and not seen.get(match.group(2)):  # only record first commented instance of a string
                     seen[match.group(2)] = (
-                        (match.group(4) and (match.group(4)[1:].strip()) + '. ' or '') + f'[{basename(f)}]'
+                            (match.group(4) and (match.group(4)[1:].strip()) + '. ' or '') + f'[{pathlib.Path(f).name}]'
                     )
     if seen:
-        target_path = join(LOCALISATION_DIR, 'en.template.new')
-        makedirs(dirname(target_path), exist_ok=True)
+        target_path = pathlib.Path(LOCALISATION_DIR / 'en.template.new')
+        pathlib.Path(target_path).parent.mkdir(parents=True, exist_ok=True)
         with open(target_path, 'w', encoding='utf-8') as target_file:
             target_file.write(f'/* Language name */\n"{LANGUAGE_ID}" = "English";\n\n')
             for thing in sorted(seen, key=str.lower):

--- a/l10n.py
+++ b/l10n.py
@@ -232,7 +232,7 @@ class Translations:
         if __file__:
             return pathlib.Path(__file__).parent.joinpath(LOCALISATION_DIR).resolve()
 
-        return pathlib.Path(LOCALISATION_DIR).resolve()
+        return LOCALISATION_DIR.resolve()
 
     def file(self, lang: str, plugin_path: pathlib.Path | None = None) -> TextIO | None:
         """
@@ -396,8 +396,8 @@ if __name__ == "__main__":
                             (match.group(4) and (match.group(4)[1:].strip()) + '. ' or '') + f'[{pathlib.Path(f).name}]'
                     )
     if seen:
-        target_path = pathlib.Path(LOCALISATION_DIR / 'en.template.new')
-        pathlib.Path(target_path).parent.mkdir(parents=True, exist_ok=True)
+        target_path = LOCALISATION_DIR / 'en.template.new'
+        target_path.parent.mkdir(parents=True, exist_ok=True)
         with open(target_path, 'w', encoding='utf-8') as target_file:
             target_file.write(f'/* Language name */\n"{LANGUAGE_ID}" = "English";\n\n')
             for thing in sorted(seen, key=str.lower):

--- a/l10n.py
+++ b/l10n.py
@@ -177,7 +177,7 @@ class Translations:
         if context:
             # TODO: There is probably a better way to go about this now.
             plugin_name = context[len(config.plugin_dir)+1:].split(sep)[0]
-            plugin_path = pathlib.Path(config.plugin_dir_path / plugin_name / LOCALISATION_DIR)
+            plugin_path = config.plugin_dir_path / plugin_name / LOCALISATION_DIR
 
         if lang:
             contents: dict[str, str] = self.contents(lang=lang, plugin_path=plugin_path)

--- a/loadout.py
+++ b/loadout.py
@@ -11,7 +11,7 @@ import json
 import re
 import time
 from os import listdir
-from os.path import join
+from pathlib import Path
 import companion
 import util_ships
 from config import config
@@ -45,7 +45,7 @@ def export(data: companion.CAPIData, requested_filename: str | None = None) -> N
     regexp = re.compile(re.escape(ship) + r'\.\d\d\d\d-\d\d-\d\dT\d\d\.\d\d\.\d\d\.txt')
     oldfiles = sorted([x for x in listdir(config.get_str('outdir')) if regexp.match(x)])
     if oldfiles:
-        with open(join(config.get_str('outdir'), oldfiles[-1]), 'rU') as h:
+        with open(Path(config.get_str('outdir')) / Path(oldfiles[-1]), 'rU') as h:
             if h.read() == string:
                 return  # same as last time - don't write
 
@@ -55,7 +55,7 @@ def export(data: companion.CAPIData, requested_filename: str | None = None) -> N
 
     output_directory = config.get_str('outdir')
     ship_time = time.strftime('%Y-%m-%dT%H.%M.%S', time.localtime(query_time))
-    file_path = join(output_directory, f"{ship}.{ship_time}.txt")
+    file_path = output_directory / Path(f"{ship}.{ship_time}.txt")
 
     with open(file_path, 'wt') as h:
         h.write(string)

--- a/loadout.py
+++ b/loadout.py
@@ -53,9 +53,9 @@ def export(data: companion.CAPIData, requested_filename: str | None = None) -> N
 
     # Write
 
-    output_directory = config.get_str('outdir')
+    output_directory = Path(config.get_str('outdir'))
     ship_time = time.strftime('%Y-%m-%dT%H.%M.%S', time.localtime(query_time))
-    file_path = output_directory / Path(f"{ship}.{ship_time}.txt")
+    file_path = output_directory / f"{ship}.{ship_time}.txt"
 
     with open(file_path, 'wt') as h:
         h.write(string)

--- a/plug.py
+++ b/plug.py
@@ -189,12 +189,12 @@ def _load_found_plugins():
     # The intent here is to e.g. have EDMC-Overlay load before any plugins
     # that depend on it.
 
-    plugin_files = sorted(Path(config.plugin_dir_path).iterdir(), key=lambda p: (
+    plugin_files = sorted(config.plugin_dir_path.iterdir(), key=lambda p: (
         not (p / '__init__.py').is_file(), p.name.lower()))
 
     for plugin_file in plugin_files:
         name = plugin_file.name
-        if not (Path(config.plugin_dir_path) / name).is_dir() or name.startswith(('.', '_')):
+        if not (config.plugin_dir_path / name).is_dir() or name.startswith(('.', '_')):
             pass
         elif name.endswith('.disabled'):
             name, discard = name.rsplit('.', 1)
@@ -202,7 +202,7 @@ def _load_found_plugins():
         else:
             try:
                 # Add plugin's folder to load path in case plugin has internal package dependencies
-                sys.path.append(str(Path(config.plugin_dir_path) / name))
+                sys.path.append(str(config.plugin_dir_path / name))
 
                 import EDMCLogging
                 # Create a logger for this 'found' plugin.  Must be before the load.py is loaded.

--- a/plug.py
+++ b/plug.py
@@ -14,6 +14,7 @@ import operator
 import os
 import sys
 import tkinter as tk
+from pathlib import Path
 from tkinter import ttk
 from typing import Any, Mapping, MutableMapping
 
@@ -47,7 +48,7 @@ last_error = LastError()
 class Plugin:
     """An EDMC plugin."""
 
-    def __init__(self, name: str, loadfile: str | None, plugin_logger: logging.Logger | None):  # noqa: CCR001
+    def __init__(self, name: str, loadfile: Path | None, plugin_logger: logging.Logger | None):  # noqa: CCR001
         """
         Load a single plugin.
 
@@ -73,7 +74,7 @@ class Plugin:
                     sys.modules[module.__name__] = module
                     spec.loader.exec_module(module)
                     if getattr(module, 'plugin_start3', None):
-                        newname = module.plugin_start3(os.path.dirname(loadfile))
+                        newname = module.plugin_start3(Path(loadfile).resolve().parent)
                         self.name = str(newname) if newname else self.name
                         self.module = module
                     elif getattr(module, 'plugin_start', None):
@@ -171,7 +172,9 @@ def _load_internal_plugins():
     for name in sorted(os.listdir(config.internal_plugin_dir_path)):
         if name.endswith('.py') and name[0] not in ('.', '_'):
             try:
-                plugin = Plugin(name[:-3], os.path.join(config.internal_plugin_dir_path, name), logger)
+                plugin_name = name[:-3]
+                plugin_path = config.internal_plugin_dir_path / name
+                plugin = Plugin(plugin_name, plugin_path, logger)
                 plugin.folder = None
                 internal.append(plugin)
             except Exception:
@@ -186,9 +189,12 @@ def _load_found_plugins():
     # The intent here is to e.g. have EDMC-Overlay load before any plugins
     # that depend on it.
 
-    for name in sorted(os.listdir(config.plugin_dir_path), key=lambda n: (
-            not os.path.isfile(os.path.join(config.plugin_dir_path, n, '__init__.py')), n.lower())):
-        if not os.path.isdir(os.path.join(config.plugin_dir_path, name)) or name[0] in ('.', '_'):
+    plugin_files = sorted(Path(config.plugin_dir_path).iterdir(), key=lambda p: (
+        not (p / '__init__.py').is_file(), p.name.lower()))
+
+    for plugin_file in plugin_files:
+        name = plugin_file.name
+        if not (Path(config.plugin_dir_path) / name).is_dir() or name.startswith(('.', '_')):
             pass
         elif name.endswith('.disabled'):
             name, discard = name.rsplit('.', 1)
@@ -196,12 +202,12 @@ def _load_found_plugins():
         else:
             try:
                 # Add plugin's folder to load path in case plugin has internal package dependencies
-                sys.path.append(os.path.join(config.plugin_dir_path, name))
+                sys.path.append(str(Path(config.plugin_dir_path) / name))
 
                 import EDMCLogging
                 # Create a logger for this 'found' plugin.  Must be before the load.py is loaded.
                 plugin_logger = EDMCLogging.get_plugin_logger(name)
-                found.append(Plugin(name, os.path.join(config.plugin_dir_path, name, 'load.py'), plugin_logger))
+                found.append(Plugin(name, config.plugin_dir_path / name / 'load.py', plugin_logger))
             except Exception:
                 PLUGINS_broken.append(Plugin(name, None, logger))
                 logger.exception(f'Failure loading found Plugin "{name}"')

--- a/prefs.py
+++ b/prefs.py
@@ -41,7 +41,7 @@ def help_open_log_folder() -> None:
     """Open the folder logs are stored in."""
     warnings.warn('prefs.help_open_log_folder is deprecated, use open_log_folder instead. '
                   'This function will be removed in 6.0 or later', DeprecationWarning, stacklevel=2)
-    open_folder(pathlib.Path(config.app_dir_path / 'logs'))
+    open_folder(Path(config.app_dir_path / 'logs'))
 
 
 def open_folder(file: Path) -> None:
@@ -322,7 +322,7 @@ class PreferencesDialog(tk.Toplevel):
                 self.geometry(f"+{position.left}+{position.top}")
 
         # Set Log Directory
-        self.logfile_loc = pathlib.Path(config.app_dir_path / 'logs')
+        self.logfile_loc = Path(config.app_dir_path / 'logs')
 
         # Set minimum size to prevent content cut-off
         self.update_idletasks()  # Update "requested size" from geometry manager
@@ -1299,8 +1299,8 @@ class PreferencesDialog(tk.Toplevel):
         if self.plugdir.get() != config.get('plugin_dir'):
             config.set(
                 'plugin_dir',
-                join(config.home_path, self.plugdir.get()[2:]) if self.plugdir.get().startswith(
-                    '~') else self.plugdir.get()
+                str(Path(config.home_path, self.plugdir.get()[2:])) if self.plugdir.get().startswith('~') else
+                str(Path(self.plugdir.get()))
             )
             self.req_restart = True
 

--- a/prefs.py
+++ b/prefs.py
@@ -58,7 +58,7 @@ def open_folder(file: Path) -> None:
 
 def help_open_system_profiler(parent) -> None:
     """Open the EDMC System Profiler."""
-    profiler_path = Path(config.respath_path)
+    profiler_path = config.respath_path
     try:
         if getattr(sys, 'frozen', False):
             profiler_path /= 'EDMCSystemProfiler.exe'

--- a/prefs.py
+++ b/prefs.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 import contextlib
 import logging
-import pathlib
+from os.path import expandvars
+from pathlib import Path
 import subprocess
 import sys
 import tempfile
 import tkinter as tk
 import warnings
 from os import system
-from os.path import expanduser, expandvars, join, normpath
 from tkinter import colorchooser as tkColorChooser  # type: ignore # noqa: N812
 from tkinter import ttk
 from types import TracebackType
@@ -43,10 +43,10 @@ def help_open_log_folder() -> None:
     """Open the folder logs are stored in."""
     warnings.warn('prefs.help_open_log_folder is deprecated, use open_log_folder instead. '
                   'This function will be removed in 6.0 or later', DeprecationWarning, stacklevel=2)
-    open_folder(pathlib.Path(tempfile.gettempdir()) / appname)
+    open_folder(Path(tempfile.gettempdir()) / appname)
 
 
-def open_folder(file: pathlib.Path) -> None:
+def open_folder(file: Path) -> None:
     """Open the given file in the OS file explorer."""
     if sys.platform.startswith('win'):
         # On Windows, use the "start" command to open the folder
@@ -58,7 +58,7 @@ def open_folder(file: pathlib.Path) -> None:
 
 def help_open_system_profiler(parent) -> None:
     """Open the EDMC System Profiler."""
-    profiler_path = pathlib.Path(config.respath_path)
+    profiler_path = Path(config.respath_path)
     try:
         if getattr(sys, 'frozen', False):
             profiler_path /= 'EDMCSystemProfiler.exe'
@@ -323,7 +323,7 @@ class PreferencesDialog(tk.Toplevel):
                 self.geometry(f"+{position.left}+{position.top}")
 
         # Set Log Directory
-        self.logfile_loc = pathlib.Path(tempfile.gettempdir()) / appname
+        self.logfile_loc = Path(tempfile.gettempdir()) / appname
 
         # Set minimum size to prevent content cut-off
         self.update_idletasks()  # Update "requested size" from geometry manager
@@ -1066,7 +1066,7 @@ class PreferencesDialog(tk.Toplevel):
         import tkinter.filedialog
         directory = tkinter.filedialog.askdirectory(
             parent=self,
-            initialdir=expanduser(pathvar.get()),
+            initialdir=Path(pathvar.get()).expanduser(),
             title=title,
             mustexist=tk.TRUE
         )
@@ -1088,7 +1088,7 @@ class PreferencesDialog(tk.Toplevel):
         if sys.platform == 'win32':
             start = len(config.home.split('\\')) if pathvar.get().lower().startswith(config.home.lower()) else 0
             display = []
-            components = normpath(pathvar.get()).split('\\')
+            components = Path(pathvar.get()).resolve().parts
             buf = ctypes.create_unicode_buffer(MAX_PATH)
             pidsRes = ctypes.c_int()  # noqa: N806 # Windows convention
             for i in range(start, len(components)):
@@ -1233,7 +1233,7 @@ class PreferencesDialog(tk.Toplevel):
 
         config.set(
             'outdir',
-            join(config.home_path, self.outdir.get()[2:]) if self.outdir.get().startswith('~') else self.outdir.get()
+            str(config.home_path / self.outdir.get()[2:]) if self.outdir.get().startswith('~') else self.outdir.get()
         )
 
         logdir = self.logdir.get()

--- a/theme.py
+++ b/theme.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 
 import os
 import sys
+from pathlib import Path
 import tkinter as tk
-from os.path import join
 from tkinter import font as tk_font
 from tkinter import ttk
 from typing import Callable
@@ -38,7 +38,8 @@ if sys.platform == 'win32':
     AddFontResourceEx.restypes = [LPCWSTR, DWORD, LPCVOID]  # type: ignore
     FR_PRIVATE = 0x10
     FR_NOT_ENUM = 0x20
-    AddFontResourceEx(join(config.respath, 'EUROCAPS.TTF'), FR_PRIVATE, 0)
+    font_path = Path(config.respath) / 'EUROCAPS.TTF'
+    AddFontResourceEx(str(font_path), FR_PRIVATE, 0)
 
 elif sys.platform == 'linux':
     # pyright: reportUnboundVariable=false

--- a/theme.py
+++ b/theme.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import os
 import sys
-from pathlib import Path
 import tkinter as tk
 from tkinter import font as tk_font
 from tkinter import ttk
@@ -38,7 +37,7 @@ if sys.platform == 'win32':
     AddFontResourceEx.restypes = [LPCWSTR, DWORD, LPCVOID]  # type: ignore
     FR_PRIVATE = 0x10
     FR_NOT_ENUM = 0x20
-    font_path = Path(config.respath) / 'EUROCAPS.TTF'
+    font_path = config.respath_path / 'EUROCAPS.TTF'
     AddFontResourceEx(str(font_path), FR_PRIVATE, 0)
 
 elif sys.platform == 'linux':

--- a/ttkHyperlinkLabel.py
+++ b/ttkHyperlinkLabel.py
@@ -28,7 +28,6 @@ from tkinter import font as tk_font
 from tkinter import ttk
 from typing import Any
 import plug
-from os import path
 from config import config, logger
 from l10n import translations as tr
 from monitor import monitor
@@ -96,7 +95,7 @@ class HyperlinkLabel(tk.Label or ttk.Label):  # type: ignore
         else:
             # Avoid file length limits if possible
             target = plug.invoke(url, 'EDSY', 'shipyard_url', loadout, monitor.is_beta)
-            file_name = path.join(config.app_dir_path, "last_shipyard.html")
+            file_name = config.app_dir_path / "last_shipyard.html"
 
             with open(file_name, 'w') as f:
                 f.write(SHIPYARD_HTML_TEMPLATE.format(


### PR DESCRIPTION
# Description
<!-- What does this PR Do? -->
This PR hands over the majority of os.path related functionality to the more modern pathlib environment. This change is designed to unify filesystem operations and not split EDMC across two different libraries. Every effort has been made to maintain compatibility, with the hopes that this is a seamless handover.

# Type of Change
<!-- What type of change is this? New Feature? Enhancement to Existing Feature? Bug Fix? Translation Update? -->
Enhancement

# How Tested
<!-- How have you tested this change to ensure it works and doesn't cause new issues -->
Tested to ensure as seamless a transition as possible is performed. Tested in builds and installer runs. 

# Notes
<!-- Does this resolve any open issues? Was this PR discussed internally somewhere off GitHub? -->
Resolves #2114 