### PR TITLE
[748] Allow Custom Plugins Directory

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -1862,7 +1862,7 @@ class AppWindow:
             )
             exit_thread.start()
 
-    def onexit(self, event=None, restart: bool=False) -> None:
+    def onexit(self, event=None, restart: bool = False) -> None:
         """Application shutdown procedure."""
         if sys.platform == 'win32':
             shutdown_thread = threading.Thread(

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -1926,7 +1926,7 @@ class AppWindow:
 
         logger.info('Done.')
         if restart:
-            return os.execv(sys.executable, ['python'] + sys.argv)
+            os.execv(sys.executable, ['python'] + sys.argv)
 
     def drag_start(self, event) -> None:
         """Initiate dragging the window."""

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -849,9 +849,10 @@ class AppWindow:
                 if stable_popup:
                     webbrowser.open("https://github.com/edCD/eDMarketConnector/releases/latest")
         if postargs.get('Restart_Req'):
+            # LANG: Text of Notification Popup for EDMC Restart
             restart_msg = tr.tl('A restart of EDMC is required. EDMC will now shut down.')
             restart_box = tk.messagebox.Message(
-                title=tr.tl('Restart Required'),
+                title=tr.tl('Restart Required'),  # LANG: Title of Notification Popup for EDMC Restart
                 message=restart_msg,
                 type=tk.messagebox.OK
             )

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -847,7 +847,7 @@ class AppWindow:
                 update_msg = update_msg.replace('\\r', '\r')
                 stable_popup = tk.messagebox.askyesno(title=title, message=update_msg)
                 if stable_popup:
-                    webbrowser.open("https://github.com/edCD/eDMarketConnector/releases/latest")
+                    webbrowser.open("https://github.com/EDCD/eDMarketConnector/releases/latest")
         if postargs.get('Restart_Req'):
             # LANG: Text of Notification Popup for EDMC Restart
             restart_msg = tr.tl('A restart of EDMC is required. EDMC will now restart.')

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -845,9 +845,19 @@ class AppWindow:
                 )
                 update_msg = update_msg.replace('\\n', '\n')
                 update_msg = update_msg.replace('\\r', '\r')
-                stable_popup = tk.messagebox.askyesno(title=title, message=update_msg, parent=postargs.get('Parent'))
+                stable_popup = tk.messagebox.askyesno(title=title, message=update_msg)
                 if stable_popup:
                     webbrowser.open("https://github.com/edCD/eDMarketConnector/releases/latest")
+        if postargs.get('Restart_Req'):
+            restart_msg = tr.tl('A restart of EDMC is required. EDMC will now shut down.')
+            restart_box = tk.messagebox.Message(
+                title=tr.tl('Restart Required'),
+                message=restart_msg,
+                type=tk.messagebox.OK
+            )
+            restart_box.show()
+            if restart_box:
+                app.onexit()
 
     def set_labels(self):
         """Set main window labels, e.g. after language change."""

--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -850,7 +850,7 @@ class AppWindow:
                     webbrowser.open("https://github.com/edCD/eDMarketConnector/releases/latest")
         if postargs.get('Restart_Req'):
             # LANG: Text of Notification Popup for EDMC Restart
-            restart_msg = tr.tl('A restart of EDMC is required. EDMC will now shut down.')
+            restart_msg = tr.tl('A restart of EDMC is required. EDMC will now restart.')
             restart_box = tk.messagebox.Message(
                 title=tr.tl('Restart Required'),  # LANG: Title of Notification Popup for EDMC Restart
                 message=restart_msg,
@@ -858,7 +858,7 @@ class AppWindow:
             )
             restart_box.show()
             if restart_box:
-                app.onexit()
+                app.onexit(restart=True)
 
     def set_labels(self):
         """Set main window labels, e.g. after language change."""
@@ -1862,7 +1862,7 @@ class AppWindow:
             )
             exit_thread.start()
 
-    def onexit(self, event=None) -> None:
+    def onexit(self, event=None, restart: bool=False) -> None:
         """Application shutdown procedure."""
         if sys.platform == 'win32':
             shutdown_thread = threading.Thread(
@@ -1925,6 +1925,8 @@ class AppWindow:
         self.w.destroy()
 
         logger.info('Done.')
+        if restart:
+            return os.execv(sys.executable, ['python'] + sys.argv)
 
     def drag_start(self, event) -> None:
         """Initiate dragging the window."""

--- a/L10n/en.template
+++ b/L10n/en.template
@@ -814,7 +814,7 @@
 "Restart Required" = "Restart Required";
 
 /* EDMarketConnector.py: Text of Notification Popup for EDMC Restart; */
-"A restart of EDMC is required. EDMC will now shut down." = "A restart of EDMC is required. EDMC will now shut down.";
+"A restart of EDMC is required. EDMC will now restart." = "A restart of EDMC is required. EDMC will now restart.";
 
 /* myNotebook.py: Can't Paste Images or Files in Text; */
 "Cannot paste non-text content." = "Cannot paste non-text content.";

--- a/L10n/en.template
+++ b/L10n/en.template
@@ -468,8 +468,11 @@
 /* prefs.py: Label for location of third-party plugins folder; In files: prefs.py:908; */
 "Plugins folder" = "Plugins folder";
 
-/* prefs.py: Label on button used to open a filesystem folder; In files: prefs.py:915; */
-"Open" = "Open";
+/* prefs.py: Label on button used to open the Plugin Folder; */
+"Open Plugins Folder" = "Open Plugins Folder";
+
+/* prefs.py: Selecting the Location of the Plugin Directory on the Filesystem; */
+"Plugin Directory Location" = "Plugin Directory Location";
 
 /* prefs.py: Tip/label about how to disable plugins; In files: prefs.py:923; */
 "Tip: You can disable a plugin by{CR}adding '{EXT}' to its folder name" = "Tip: You can disable a plugin by{CR}adding '{EXT}' to its folder name";
@@ -804,9 +807,14 @@
 /* EDMarketConnector.py: Inform the user the Update Track has changed; */
 "Update Track Changed to {TRACK}" = "Update Track Changed to {TRACK}";
 
-
 /* EDMarketConnector.py: Inform User of Beta -> Stable Transition Risks; */
 "Update track changed to Stable from Beta. You will no longer receive Beta updates. You will stay on your current Beta version until the next Stable release.\r\n\r\nYou can manually revert to the latest Stable version. To do so, you must download and install the latest Stable version manually. Note that this may introduce bugs or break completely if downgrading between major versions with significant changes.\r\n\r\nDo you want to open GitHub to download the latest release?" = "Update track changed to Stable from Beta. You will no longer receive Beta updates. You will stay on your current Beta version until the next Stable release.\r\n\r\nYou can manually revert to the latest Stable version. To do so, you must download and install the latest Stable version manually. Note that this may introduce bugs or break completely if downgrading between major versions with significant changes.\r\n\r\nDo you want to open GitHub to download the latest release?";
+
+/* EDMarketConnector.py: Title of Notification Popup for EDMC Restart; */
+"Restart Required" = "Restart Required";
+
+/* EDMarketConnector.py: Text of Notification Popup for EDMC Restart; */
+"A restart of EDMC is required. EDMC will now shut down." = "A restart of EDMC is required. EDMC will now shut down.";
 
 /* myNotebook.py: Can't Paste Images or Files in Text; */
 "Cannot paste non-text content." = "Cannot paste non-text content.";

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -189,6 +189,7 @@ class AbstractConfig(abc.ABC):
 
     app_dir_path: pathlib.Path
     plugin_dir_path: pathlib.Path
+    default_plugin_dir_path: pathlib.Path
     internal_plugin_dir_path: pathlib.Path
     respath_path: pathlib.Path
     home_path: pathlib.Path
@@ -278,6 +279,11 @@ class AbstractConfig(abc.ABC):
     def plugin_dir(self) -> str:
         """Return a string version of plugin_dir."""
         return str(self.plugin_dir_path)
+
+    @property
+    def default_plugin_dir(self) -> str:
+        """Return a string version of plugin_dir."""
+        return str(self.default_plugin_dir_path)
 
     @property
     def internal_plugin_dir(self) -> str:

--- a/config/linux.py
+++ b/config/linux.py
@@ -32,12 +32,6 @@ class LinuxConfig(AbstractConfig):
         self.app_dir_path.mkdir(exist_ok=True, parents=True)
 
         self.default_plugin_dir_path = self.app_dir_path / 'plugins'
-        if (plugdir_str := self.get_str('plugin_dir')) is None or not pathlib.Path(plugdir_str).is_dir():
-            self.set("plugin_dir", str(self.default_plugin_dir_path))
-            plugdir_str = self.default_plugin_dir
-        self.plugin_dir_path = pathlib.Path(plugdir_str)
-        self.plugin_dir_path.mkdir(exist_ok=True)
-
         self.respath_path = pathlib.Path(__file__).parent.parent
 
         self.internal_plugin_dir_path = self.respath_path / 'plugins'
@@ -65,6 +59,12 @@ class LinuxConfig(AbstractConfig):
                 (self.filename.parent / f'{appname}.ini.backup').write_bytes(self.filename.read_bytes())
 
             self.config.add_section(self.SECTION)
+
+        if (plugdir_str := self.get_str('plugin_dir')) is None or not pathlib.Path(plugdir_str).is_dir():
+            self.set("plugin_dir", str(self.default_plugin_dir_path))
+            plugdir_str = self.default_plugin_dir
+        self.plugin_dir_path = pathlib.Path(plugdir_str)
+        self.plugin_dir_path.mkdir(exist_ok=True)
 
         if (outdir := self.get_str('outdir')) is None or not pathlib.Path(outdir).is_dir():
             self.set('outdir', self.home)

--- a/config/linux.py
+++ b/config/linux.py
@@ -31,7 +31,11 @@ class LinuxConfig(AbstractConfig):
         self.app_dir_path = xdg_data_home / appname
         self.app_dir_path.mkdir(exist_ok=True, parents=True)
 
-        self.plugin_dir_path = self.app_dir_path / 'plugins'
+        self.default_plugin_dir_path = self.app_dir_path / 'plugins'
+        if (plugdir_str := self.get_str('plugin_dir')) is None or not pathlib.Path(plugdir_str).is_dir():
+            self.set("plugin_dir", str(self.default_plugin_dir_path))
+            plugdir_str = self.default_plugin_dir
+        self.plugin_dir_path = pathlib.Path(plugdir_str)
         self.plugin_dir_path.mkdir(exist_ok=True)
 
         self.respath_path = pathlib.Path(__file__).parent.parent

--- a/prefs.py
+++ b/prefs.py
@@ -239,6 +239,7 @@ class PreferencesDialog(tk.Toplevel):
 
         self.parent = parent
         self.callback = callback
+        self.req_restart = False
         # LANG: File > Settings (macOS)
         self.title(tr.tl('Settings'))
 
@@ -1274,19 +1275,22 @@ class PreferencesDialog(tk.Toplevel):
         config.set('dark_highlight', self.theme_colors[1])
         theme.apply(self.parent)
 
-        # Send to the Post Config if we updated the update branch
-        post_flags = {
-            'Update': True if self.curr_update_track != self.update_paths.get() else False,
-            'Track': self.update_paths.get(),
-            'Parent': self
-        }
         # Notify
         if self.callback:
-            self.callback(**post_flags)
+            self.callback()
 
         plug.notify_prefs_changed(monitor.cmdr, monitor.is_beta)
 
         self._destroy()
+        # Send to the Post Config if we updated the update branch or need to restart
+        post_flags = {
+            'Update': True if self.curr_update_track != self.update_paths.get() else False,
+            'Track': self.update_paths.get(),
+            'Parent': self,
+            'Restart_Req': True if self.req_restart else False
+        }
+        if self.callback:
+            self.callback(**post_flags)
 
     def _destroy(self) -> None:
         """widget.destroy wrapper that does some extra cleanup."""


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
<!-- What does this PR Do? -->
This PR enables the ability for users to customize their plugin directory away from the default directory's "plugins" folder. This allows users to swap between multiple different plugin "profiles". This does require a restart, so also adds an ability for EDMC to forcefully shut down and restart itself. 

Additionally, this updates the post_args callback to not force the settings window to be half-rendered during the callback. This is done by performing two callback operations at various stages with different payloads. While this is slightly duplicative, the impact is negligible. The loading of the Windows config also happens sooner in the program start-up, simply to allow the config to load the new customizable location sooner. This key is created at runtime if it does not exist.

# Images
![image](https://github.com/EDCD/EDMarketConnector/assets/26337384/f348b0c9-390d-47a7-a036-9bc21e5f0d1a)


# Type of Change
<!-- What type of change is this? New Feature? Enhancement to Existing Feature? Bug Fix? Translation Update? -->
Enhancement

# How Tested
<!-- How have you tested this change to ensure it works and doesn't cause new issues -->
Tested with various builds and configuration points on Windows builds. Linux has not yet been tested. 

# Notes
<!-- Does this resolve any open issues? Was this PR discussed internally somewhere off GitHub? -->
Resolves #748 