### PR TITLE
pass Horizons/Odyssey flags in NavRoute

### DIFF
--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -1416,15 +1416,6 @@ class EDDN:
         #######################################################################
         # Elisions
         #######################################################################
-        # WORKAROUND WIP EDDN schema | 2021-10-17: This will reject with the Odyssey or Horizons flags present
-        if 'odyssey' in entry:
-            del entry['odyssey']
-
-        if 'horizons' in entry:
-            del entry['horizons']
-
-        # END WORKAROUND
-
         # In case Frontier ever add any
         entry = filter_localised(entry)
         #######################################################################


### PR DESCRIPTION
# Description
The old workaround appears to be not needed anymore. EDDN accepts NavRoute with Horizons/Odyssey flags now.
EDDiscovery, EDO Materials Helper and others also set these flags.

# Type of Change
Removed workaround code from when EDDN did not accept these flags in NavRoute events.

# How Tested
I built and installed a release, produced NavRoute events and watched them come through the EDDN gateway.

# Notes
Mentioned in #1310 