### PR TITLE
[610] Improved process_iter

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -2156,12 +2156,11 @@ class EDLogs(FileSystemEventHandler):
                 # Process likely expired
                 self.running_process = None
         if not self.running_process:
-            edmc_process = psutil.Process()
-            edmc_user = edmc_process.username()
             try:
-                for pid in psutil.pids():
-                    proc = psutil.Process(pid)
-                    if 'EliteDangerous' in proc.name() and proc.username() == edmc_user:
+                edmc_process = psutil.Process()
+                edmc_user = edmc_process.username()
+                for proc in psutil.process_iter(['name', 'username']):
+                    if 'EliteDangerous' in proc.info['name'] and proc.info['username'] == edmc_user:
                         self.running_process = proc
                         return True
             except psutil.NoSuchProcess:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ simplesystray==0.1.0; sys_platform == 'win32'
 semantic-version==2.10.0
 # For manipulating folder permissions and the like.
 pywin32==306; sys_platform == 'win32'
-psutil==5.9.8
+psutil==6.0.0


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
<!-- What does this PR Do? -->
`psutils` 6.0 added a new change to process_iter which improves performance substantially to the point where it is now actually worth using. The function `no longer checks whether each yielded process PID has been reused` per PSUtils docs, which generates an ~20x speed-up to use, which actually makes it worth using versus iterating through functions. This shaves almost half a second off of my testing, meaning less app freezes and a better working check. 

# Type of Change
<!-- What type of change is this? New Feature? Enhancement to Existing Feature? Bug Fix? Translation Update? -->
Enhancement

# How Tested
<!-- How have you tested this change to ensure it works and doesn't cause new issues -->
Tested and timed on my system running from source

# Notes
<!-- Does this resolve any open issues? Was this PR discussed internally somewhere off GitHub? -->
https://github.com/giampaolo/psutil/issues/2396