### PR TITLE
Guard against workflow shell execution vulnerabilities

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,7 +19,7 @@ jobs:
 
     # Debug show the info we have to work with
     - name: Show github context
-      run: cat $GITHUB_EVENT_PATH
+      run: cat "$GITHUB_EVENT_PATH"
 
     ####################################################################
     # Checkout the necessary commits
@@ -44,9 +44,9 @@ jobs:
         echo "BASE_REPO_URL: ${BASE_REPO_URL}"
         echo "BASE_REPO_OWNER: ${BASE_REPO_OWNER}"
         # Add the 'base' repo as a new remote
-        git remote add ${BASE_REPO_OWNER} ${BASE_REPO_URL}
+        git remote add "${BASE_REPO_OWNER}" "${BASE_REPO_URL}"
         # And then fetch its references
-        git fetch ${BASE_REPO_OWNER}
+        git fetch "${BASE_REPO_OWNER}"
     ####################################################################
     
     ####################################################################

--- a/.github/workflows/push-checks.yml
+++ b/.github/workflows/push-checks.yml
@@ -43,7 +43,7 @@ jobs:
       env:
         ROOT_SHA: ${{github.base_ref}}
       run: |
-        DATA=$(jq --raw-output .before $GITHUB_EVENT_PATH)
+        DATA=$(jq --raw-output .before "$GITHUB_EVENT_PATH")
 
         echo "DATA: ${DATA}"
         #######################################################################

--- a/.github/workflows/submodule-update.yml
+++ b/.github/workflows/submodule-update.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Create submodules changes branch
         if: steps.check_for_changes.outputs.changes == 'true'
         run: |
-          git checkout -b "submodule-change/$GITHUB_RUN_ID" $CHECKOUT_BRANCH
+          git checkout -b "submodule-change/$GITHUB_RUN_ID" "$CHECKOUT_BRANCH"
           git commit -am "updating submodules"
           git push --set-upstream origin "submodule-change/$GITHUB_RUN_ID"
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -39,7 +39,7 @@ jobs:
           # For 'tar' we can only specify filename/glob exclusions, not any
           # directory location
           tar -c -v -z \
-              -f ../EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.tar.gz \
+              -f "../EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.tar.gz" \
               -C .. \
               --exclude=EDMarketConnector-release-*.* \
               --exclude=.editorconfig \
@@ -59,7 +59,7 @@ jobs:
               --exclude=scripts \
               --exclude=tests \
               EDMarketConnector
-            mv ../EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.tar.gz .
+            mv "../EDMarketConnector-release-${{ needs.variables.outputs.sem_ver }}.tar.gz" .
 
       - name: Upload build files
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This is in reaction to what happened ref: <https://www.wiz.io/blog/ultralytics-ai-library-hacked-via-github-for-cryptomining>

I think I caught all the instances.  I'd double-check the `windows-build.yml` changes as the variable references are github-workflow style rather than shell.  If what I did doesn't work you might have to explicitly assign the values to shell variables then use those **with the `"..."` quoting**.