### PR TITLE
Include 'missing?' Loadout event properties in 'state'

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -655,6 +655,10 @@ Content of `state` (updated to the current journal entry):
 | `ShipType`            |            `str`            | Internal name for the current ship type                                                                         |
 | `HullValue`           |            `int`            | Current ship value, excluding modules                                                                           |
 | `ModulesValue`        |            `int`            | Value of the current ship's modules                                                                             |
+| `UnladenMass`         |           `float`           | Unladen mass of current ship                                                                                    |
+| `CargoCapacity`       |            `int`            | Max cargo capacity of current ship                                                                              |
+| `MaxJumpRange`        |           `float`           | Unladen jump range of current ship                                                                              |
+| `FuelCapacity`        |      `dict[str,float]`      | Current max capacity of Main & Reserve tanks                                                                    |
 | `Rebuy`               |            `int`            | Current ship's rebuy cost                                                                                       |
 | `Modules`             |           `dict`            | Currently fitted modules                                                                                        |
 | `NavRoute`            |           `dict`            | Last plotted multi-hop route[1]                                                                                 |

--- a/monitor.py
+++ b/monitor.py
@@ -141,6 +141,10 @@ class EDLogs(FileSystemEventHandler):
             'ShipType':           None,
             'HullValue':          None,
             'ModulesValue':       None,
+            'UnladenMass':        None,
+            'CargoCapacity':      None,
+            'MaxJumpRange':       None,
+            'FuelCapacity':       None,
             'Rebuy':              None,
             'Modules':            None,
             'CargoJSON':          None,  # The raw data from the last time cargo.json was read
@@ -680,6 +684,12 @@ class EDLogs(FileSystemEventHandler):
                 self.state['ShipType'] = self.canonicalise(entry['Ship'])
                 self.state['HullValue'] = entry.get('HullValue')  # not present on exiting Outfitting
                 self.state['ModulesValue'] = entry.get('ModulesValue')  # not present on exiting Outfitting
+                self.state['UnladenMass'] = entry.get('UnladenMass')
+                self.state['CargoCapacity'] = entry.get('CargoCapacity')
+                self.state['MaxJumpRange'] = entry.get('MaxJumpRange')
+                self.state['FuelCapacity'] = {}
+                self.state['FuelCapacity']['Main'] = entry.get('FuelCapacity')['Main']
+                self.state['FuelCapacity']['Reserve'] = entry.get('FuelCapacity')['Reserve']
                 self.state['Rebuy'] = entry.get('Rebuy')
                 # Remove spurious differences between initial Loadout event and subsequent
                 self.state['Modules'] = {}


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
<!-- What does this PR Do? -->
Adds the following stats which are present in the 'Loadout' event to the 'state' for journal_update:
```
"UnladenMass": float,
"CargoCapacity": int,
"MaxJumpRange": float,
"FuelCapacity": {
	"Main": float, //could probably be int?
	"Reserve": float
}
```
Also updates the Plugins Readme to match the changes.

# Type of Change
Enhancement to existing 'state' tracking feature.

# How Tested
First submission so no serious regression testing, thanks in advance for the review.

Tested that any permanent changes to these properties should be accompanied by another 'Loadout' event, meaning adding them should never result in odd desyncs with the actual game state, please correct me if I'm wrong.

Compiled EDMC with changes and verified `state` properly contains the new values when I dump state:
```
{
    "ShipID": 17,
    "ShipIdent": "--x5--",
    "ShipName": "purposeless",
    "ShipType": "krait_light",
    "HullValue": 31422965,
    "ModulesValue": 62399627,
    "UnladenMass": 511.5,
    "CargoCapacity": 32,
    "MaxJumpRange": 52.789223,
    "FuelCapacity": {
        "Main": 32.0,
        "Reserve": 0.63
    }
}
```

# Notes
briefly discussed in EDCD Discord's edmc-plugins channel, couldn't find any open issues referencing this.
This PR may be completely unnecessary, but I couldn't find any other way of accessing these in a tracked state within EDMC, and they are very useful to have for a variety of funcitons, the cargo-manifest plugin is a good example of something that could be greatly simplified and future-proofed with this.
If these stats are otherwise accessible or should not be tracked in this manner for some reason please let me know and I'll update the plugins readme instead, as it currently claims:

>  In this case you won't receive initial events such as "LoadGame", "Rank", "Location", etc. However, the state dictionary will reflect the cumulative effect of these missed events.

And already tracks the majority of stats within Loadout, with this only the 'HullHealth' and 'Hot' values would inaccessible from state, and both are probably better sourced from other events, and are more prone to desync.

TIA for the response!