### PR TITLE
Add code to track PP2.0 rank, merits, etc

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -688,6 +688,7 @@ Content of `state` (updated to the current journal entry):
 | `StationName`[3]      |       `Optional[str]`       | Name of the station we're docked at, if applicable                                                              |
 | `MarketID`[3]         |       `Optional[str]`       | MarketID of the station we're docked at, if applicable                                                          |
 | `StationType`[3]      |       `Optional[str]`       | Type of the station we're docked at, if applicable                                                              |
+| `Powerplay`           |           `dict`            | `dict` of information on Powerplay
 
 [1] - Contents of `NavRoute` not changed if a `NavRouteClear` event is seen,
 but plugins will see the `NavRouteClear` event.
@@ -835,6 +836,12 @@ documentation above for some caveats.  Do not just blindly use this data, or
 the 'Body' name value.
 
 `StationName`, `MarketID`, and `StationType` added to the `state` dictionary.
+
+New in version 5.13.0:
+
+`state` now has `Powerplay`, a `dict` including `Rank`, `Merits`, `Power`,
+`TimePledged`, and `Votes`. `Votes` should only be populated if playing in
+legacy mode, as it is no longer a concept in the current version of the game.
 
 ___
 

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -842,7 +842,6 @@ New in version 5.13.0:
 `state` now has `Powerplay`, a `dict` including `Rank`, `Merits`, `Power`,
 `TimePledged`, and `Votes`. `Votes` should only be populated if playing in
 legacy mode, as it is no longer a concept in the current version of the game.
-
 ___
 
 ##### Synthetic Events

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -842,6 +842,7 @@ New in version 5.13.0:
 `state` now has `Powerplay`, a `dict` including `Rank`, `Merits`, `Power`,
 `TimePledged`, and `Votes`. `Votes` should only be populated if playing in
 legacy mode, as it is no longer a concept in the current version of the game.
+
 ___
 
 ##### Synthetic Events

--- a/monitor.py
+++ b/monitor.py
@@ -179,6 +179,13 @@ class EDLogs(FileSystemEventHandler):
             'StationName':        None,
 
             'NavRoute':           None,
+            'Powerplay':      {
+                'Power':          None,
+                'Rank':           None,
+                'Merits':         None,
+                'Votes':          None,
+                'TimePledged':    None,
+            },
         }
 
     def start(self, root: 'tkinter.Tk') -> bool:  # noqa: CCR001
@@ -1838,6 +1845,13 @@ class EDLogs(FileSystemEventHandler):
 
                 # There should be a `Backpack` event as you 'come to' in the
                 # new location, so no need to zero out BackPack here.
+
+            elif event_type == 'powerplay':
+                self.state['Powerplay']['Power'] = entry.get('Power', '')
+                self.state['Powerplay']['Rank'] = entry.get('Rank', 0)
+                self.state['Powerplay']['Merits'] = entry.get('Merits', 0)
+                self.state['Powerplay']['Votes'] = entry.get('Votes', 0)
+                self.state['Powerplay']['TimePledged'] = entry.get('TimePledged', 0)
 
             return entry
 

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -548,6 +548,10 @@ def journal_entry(  # noqa: C901, CCR001
                 power_defect_data = {'powerName': entry["ToPower"], 'rankValue': 1}
                 new_add_event('setCommanderRankPower', entry['timestamp'], power_defect_data)
 
+            elif event_name == 'Powerplay':
+                power_data = {'powerName': entry["Power"], 'rankValue': entry["Rank"], 'meritsValue': entry["Merits"]}
+                new_add_event('setCommanderRankPower', entry['timestamp'], power_data)
+
             # Ship change
             if event_name == 'Loadout' and this.shipswap:
                 this.loadout = make_loadout(state)


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
<!-- What does this PR Do? -->
Adds some code to `monitor.py` as well as the Inara plugin to track Powerplay 2.0 rank, merits, and more

# Example Images
<!-- Only if relevant. Remove if irrelevant. -->

# Type of Change
<!-- What type of change is this? New Feature? Enhancement to Existing Feature? Bug Fix? Translation Update? -->
New Feature

# How Tested
<!-- How have you tested this change to ensure it works and doesn't cause new issues -->
Ran EDMC with some debug code to make sure that `monitor.py` would pick up on the PP event. Inara also tested and confirmed working, I was able to refresh my profile and see the new up to date rank and merit count on starting the game.

# Notes
<!-- Does this resolve any open issues? Was this PR discussed internally somewhere off GitHub? -->
Fixes #2371
