### PR TITLE
Fix Timechecker on develop

### DIFF
--- a/plug.py
+++ b/plug.py
@@ -14,7 +14,7 @@ import operator
 import os
 import sys
 import tkinter as tk
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from tkinter import ttk
 from typing import Any, Mapping, MutableMapping
@@ -335,8 +335,8 @@ def notify_journal_entry(
 
     if "timestamp" in entry and not config.skip_timecheck:
         # Check that timestamp is recent enough
-        dt = datetime.strptime(entry["timestamp"], "%Y-%m-%dT%H:%M:%SZ")
-        if dt > datetime.utcnow() - timedelta(minutes=60):
+        dt = datetime.strptime(entry["timestamp"], "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+        if dt < datetime.now(timezone.utc) - timedelta(minutes=60):
             error = f"Event at {entry['timestamp']} beyond Time Delta of 60 minutes. Skipping."
             return error
 


### PR DESCRIPTION
# Description
Fixes timechecker on develop.
EDMC as it is on the develop branch right now skips every event for me.
(unless of course I started it with --skip-timecheck)

Flipped the comparison operator in plug.py so that the error message gets shown and skip happens when:

dt (which is the datetime object from the timestamp in UTC+0).
is lower (or longer ago)
than 60 minutes lower (or before) the time right now in UTC+0.

Also made all the datetime objects timezone aware to be able to compare with `datetime.now(timezone.utc)` avoid using `utcnow()`
See big red warning in python docs to datetime.utcnow: https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow
Additionally utcnow() is deprecated from python 3.12 onwards.

# Type of Change
Bug fix

# How Tested
Temporarily used logging to show me each of the datetime objects and verified that they were in fact UTC+0 (the calls to the logger are is not reflected in the change.)
Also made sure that dt does not change its time before and after the replace call and just becomes timezone aware so that it can be compared with the datetime object that `datetime.now(timezone.utc)` returns
Also used the !pad <number> command for the Landing Pad plugin to check if it would show up now with the timechecker active. Since I stumbled upon this through trying that specific command for LandindPad on develop first without then with --skip-timecheck.

If you want to be extra paranoid because of potential timezone shenanigans try it on a different timezone than mine (UTC+1)

# Notes
There is no issue that was created to this but I asked on Discord.