### PR TITLE
Fixes #2360: Translate Elements MaterialReward as Raw

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -1688,6 +1688,8 @@ class EDLogs(FileSystemEventHandler):
                     if 'Category' in reward:  # Category not present in E:D 3.0
                         category = self.category(reward['Category'])
                         material = self.canonicalise(reward['Name'])
+                        if category == 'Elements':
+                            category = 'Raw'
                         self.state[category][material] += reward.get('Count', 1)
 
             elif event_type == 'engineercontribution':


### PR DESCRIPTION
# Description
Fixes #2360
I'm not saying that this is exactly how the fix should look like but it displays the issue. Raw material reward is named `Elements` in journal, when on startup the collection of Raw mats is named `Raw`

# Type of Change
Bugfix proposal/POC

# How Tested
I turned in a few Raw mats rewards