### PR TITLE
Update powerplay tracking to account for new journal events

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -1852,6 +1852,12 @@ class EDLogs(FileSystemEventHandler):
                 self.state['Powerplay']['Merits'] = entry.get('Merits', 0)
                 self.state['Powerplay']['Votes'] = entry.get('Votes', 0)
                 self.state['Powerplay']['TimePledged'] = entry.get('TimePledged', 0)
+            
+            elif event_type == 'powerplaymerits':
+                self.state['Powerplay']['Merits'] = entry.get('TotalMerits', 0)
+
+            elif event_type == 'powerplayrank':
+                self.state['Powerplay']['Rank'] = entry.get('Rank', 0)
 
             return entry
 

--- a/monitor.py
+++ b/monitor.py
@@ -1852,7 +1852,7 @@ class EDLogs(FileSystemEventHandler):
                 self.state['Powerplay']['Merits'] = entry.get('Merits', 0)
                 self.state['Powerplay']['Votes'] = entry.get('Votes', 0)
                 self.state['Powerplay']['TimePledged'] = entry.get('TimePledged', 0)
-            
+
             elif event_type == 'powerplaymerits':
                 self.state['Powerplay']['Merits'] = entry.get('TotalMerits', 0)
 

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -553,7 +553,8 @@ def journal_entry(  # noqa: C901, CCR001
                 new_add_event('setCommanderRankPower', entry['timestamp'], power_data)
 
             elif event_name == 'PowerplayMerits':
-                power_data = {'powerName': state["Powerplay"]["Power"], 'rankValue': state["Powerplay"]["Rank"], 'meritsValue': entry["TotalMerits"]}
+                power_data = {'powerName': state["Powerplay"]["Power"], 'rankValue': state["Powerplay"]["Rank"],
+                              'meritsValue': entry["TotalMerits"]}
                 new_add_event('setCommanderRankPower', entry['timestamp'], power_data)
 
             elif event_name == 'PowerplayRank':

--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -552,6 +552,14 @@ def journal_entry(  # noqa: C901, CCR001
                 power_data = {'powerName': entry["Power"], 'rankValue': entry["Rank"], 'meritsValue': entry["Merits"]}
                 new_add_event('setCommanderRankPower', entry['timestamp'], power_data)
 
+            elif event_name == 'PowerplayMerits':
+                power_data = {'powerName': state["Powerplay"]["Power"], 'rankValue': state["Powerplay"]["Rank"], 'meritsValue': entry["TotalMerits"]}
+                new_add_event('setCommanderRankPower', entry['timestamp'], power_data)
+
+            elif event_name == 'PowerplayRank':
+                power_data = {'powerName': entry["Power"], 'rankValue': entry["Rank"]}
+                new_add_event('setCommanderRankPower', entry['timestamp'], power_data)
+
             # Ship change
             if event_name == 'Loadout' and this.shipswap:
                 this.loadout = make_loadout(state)


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
<!-- What does this PR Do? -->
Adds more Powerplay rank/merit tracking using the new journal entries

# Type of Change
<!-- What type of change is this? New Feature? Enhancement to Existing Feature? Bug Fix? Translation Update? -->
Enhancement

# How Tested
<!-- How have you tested this change to ensure it works and doesn't cause new issues -->
Ran the code with changes and monitored my Inara to see the changes reflected.

# Notes
<!-- Does this resolve any open issues? Was this PR discussed internally somewhere off GitHub? -->
This is a followup to my last Powerplay PR that added tracking in the first place. I think we're okay to catch these specific events as they only concern individual commanders. The overall state of a system is covered in other location events.
