### PR TITLE
[#2348] Remove WiX Check

### DIFF
--- a/resources/EDMC_Installer_Config_template.txt
+++ b/resources/EDMC_Installer_Config_template.txt
@@ -54,50 +54,6 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: de
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
 
-;Check if a WiX-based installation exists. If so, kill it with fire.
-[Code]
-function EndsWith(SubText, Text: AnsiString): Boolean;
-var
-  EndStr: string;
-begin
-  Log('Starting');
-  EndStr := Copy(Text, Length(Text) - Length(SubText) + 1, Length(SubText));
-  Log(EndStr);
-  { Use SameStr, if you need a case-sensitive comparison }
-  Result := SameText(SubText, EndStr);
-end;
-
-// EDMC didn't keep a consistant GUID during previous history. Due to that, we have to do this tomfoolery.
-procedure CurStepChanged(CurStep: TSetupStep);
-var
-  ResultCode: Integer;
-  Uninstall: String;
-  OldWiX: Boolean;
-  S: AnsiString;
-  PowerShellOutputFile: String;
-begin
-  if (CurStep = ssInstall) then
-  begin
-  PowerShellOutputFile := ExpandConstant('{tmp}\PowershellOutput.txt');
-  // Construct the PowerShell command and capture output to a file
-  Exec('powershell.exe', '-NoProfile -Command "Get-WmiObject -Class Win32_Product | where Name -eq ''Elite Dangerous Market Connector'' | select-object -expandproperty IdentifyingNumber" | Out-File -Encoding ASCII "' + PowerShellOutputFile + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
-    begin
-    if LoadStringFromFile(PowerShellOutputFile, S) then
-    S:= Trim(S);
-    Log(S);
-      begin
-      OldWiX:=EndsWith('}', S);
-      if (OldWiX = True) then
-        begin
-        MsgBox('Warning: an old version of EDMC is installed! Please close EDMC while we remove the old version!', mbInformation, MB_OK);
-        Uninstall := '/x ' + S;
-        Exec('MsiExec.exe', Uninstall, '', SW_SHOW, ewWaitUntilTerminated, ResultCode);
-        end;
-      end;
-    end;
-  end;
-end;
-
 [Registry]
 ; Create the main registry key under HKCR
 Root: HKCR; Subkey: "edmc"; Flags: uninsdeletekey


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
This PR removes the PowerShell check in the Inno Setup installer, which checks for previous versions of EDMC that used the WiX setup via MSI compared to the current "Inno Setup"-powered exe files. EDMC has used Inno since 5.9.1 (over a year and a half ago). 

The vast majority of users (over 99%) have already updated to a version later than 5.9.0. Any user still on those versions is likely intentionally holding to that version. Any user on those versions would need to manually remove the old version, but the installer wouldn't hand-hold them anymore. 

For most users, this will greatly improve the speed of the installer and can fix some side issues if a user has a very restricted PowerShell permission set. This will also reduce the chance of an AV engine flagging for anomalous PowerShell.

# Type of Change
Installer Change

# How Tested
Installer test files ran without the command embedded, and ran successfully. 

# Notes
Resolves #2348 