### PR TITLE
[#1805/#2389] Fix Hotkey and Reduce Ctypes

### DIFF
--- a/hotkey/windows.py
+++ b/hotkey/windows.py
@@ -8,7 +8,7 @@ import sys
 import threading
 import tkinter as tk
 import winsound
-from ctypes.wintypes import DWORD, LONG, MSG, ULONG, WORD, HWND, BOOL, UINT
+from ctypes.wintypes import DWORD, LONG, MSG, ULONG, WORD, UINT
 import pywintypes
 import win32api
 import win32gui
@@ -20,10 +20,6 @@ from hotkey import AbstractHotkeyMgr
 assert sys.platform == 'win32'
 
 logger = get_main_logger()
-
-UnregisterHotKey = ctypes.windll.user32.UnregisterHotKey  # TODO: Coming Soon
-UnregisterHotKey.argtypes = [HWND, ctypes.c_int]
-UnregisterHotKey.restype = BOOL
 
 MOD_NOREPEAT = 0x4000
 WM_SND_GOOD = win32con.WM_APP + 1
@@ -191,7 +187,7 @@ class WindowsHotkeyMgr(AbstractHotkeyMgr):
 
         msg = MSG()
         logger.debug('Entering GetMessage() loop...')
-        while win32gui.GetMessage(ctypes.byref(msg), None, 0, 0) != 0:
+        while win32gui.GetMessage(None, 0, 0) != 0:
             logger.debug('Got message')
             if msg.message == win32con.WM_HOTKEY:
                 logger.debug('WM_HOTKEY')
@@ -206,7 +202,7 @@ class WindowsHotkeyMgr(AbstractHotkeyMgr):
 
                 else:
                     logger.debug('Passing key on')
-                    UnregisterHotKey(None, 1)
+                    win32gui.UnregisterHotKey(None, 1)
                     SendInput(1, fake, ctypes.sizeof(INPUT))
                     try:
                         win32gui.RegisterHotKey(None, 1, modifiers | MOD_NOREPEAT, keycode)
@@ -228,7 +224,7 @@ class WindowsHotkeyMgr(AbstractHotkeyMgr):
                 win32gui.DispatchMessage(ctypes.byref(msg))
 
         logger.debug('Exited GetMessage() loop.')
-        UnregisterHotKey(None, 1)
+        win32gui.UnregisterHotKey(None, 1)
         self.thread = None  # type: ignore
         logger.debug('Done.')
 
@@ -282,7 +278,7 @@ class WindowsHotkeyMgr(AbstractHotkeyMgr):
         # See if the keycode is usable and available
         try:
             win32gui.RegisterHotKey(None, 2, modifiers | MOD_NOREPEAT, keycode)
-            UnregisterHotKey(None, 2)
+            win32gui.UnregisterHotKey(None, 2)
             return keycode, modifiers
         except pywintypes.error:
             winsound.MessageBeep()

--- a/hotkey/windows.py
+++ b/hotkey/windows.py
@@ -2,17 +2,15 @@
 from __future__ import annotations
 
 import atexit
-import ctypes
 import pathlib
 import sys
 import threading
 import tkinter as tk
 import winsound
-from ctypes.wintypes import DWORD, LONG, MSG, ULONG, WORD, UINT
-import pywintypes
 import win32api
-import win32gui
 import win32con
+import win32gui
+import pywintypes
 from config import config
 from EDMCLogging import get_main_logger
 from hotkey import AbstractHotkeyMgr
@@ -21,18 +19,14 @@ assert sys.platform == 'win32'
 
 logger = get_main_logger()
 
+# Constants
 MOD_NOREPEAT = 0x4000
 WM_SND_GOOD = win32con.WM_APP + 1
 WM_SND_BAD = win32con.WM_APP + 2
 VK_OEM_MINUS = 0xbd
 
 # VirtualKey mapping values
-# <https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-mapvirtualkeyexa>
-MAPVK_VK_TO_VSC = 0
-MAPVK_VSC_TO_VK = 1
 MAPVK_VK_TO_CHAR = 2
-MAPVK_VSC_TO_VK_EX = 3
-MAPVK_VK_TO_VSC_EX = 4
 
 
 def window_title(h) -> str:
@@ -45,69 +39,6 @@ def window_title(h) -> str:
     if h:
         return win32gui.GetWindowText(h)
     return ''
-
-
-class MOUSEINPUT(ctypes.Structure):
-    """Mouse Input structure."""
-
-    _fields_ = [
-        ('dx', LONG),
-        ('dy', LONG),
-        ('mouseData', DWORD),
-        ('dwFlags', DWORD),
-        ('time', DWORD),
-        ('dwExtraInfo', ctypes.POINTER(ULONG))
-    ]
-
-
-class KEYBDINPUT(ctypes.Structure):
-    """Keyboard Input structure."""
-
-    _fields_ = [
-        ('wVk', WORD),
-        ('wScan', WORD),
-        ('dwFlags', DWORD),
-        ('time', DWORD),
-        ('dwExtraInfo', ctypes.POINTER(ULONG))
-    ]
-
-
-class HARDWAREINPUT(ctypes.Structure):
-    """Hardware Input structure."""
-
-    _fields_ = [
-        ('uMsg', DWORD),
-        ('wParamL', WORD),
-        ('wParamH', WORD)
-    ]
-
-
-class INPUTUNION(ctypes.Union):
-    """Input union."""
-
-    _fields_ = [
-        ('mi', MOUSEINPUT),
-        ('ki', KEYBDINPUT),
-        ('hi', HARDWAREINPUT)
-    ]
-
-
-class INPUT(ctypes.Structure):
-    """Input structure."""
-
-    _fields_ = [
-        ('type', DWORD),
-        ('union', INPUTUNION)
-    ]
-
-
-SendInput = ctypes.windll.user32.SendInput
-SendInput.argtypes = [ctypes.c_uint, ctypes.POINTER(INPUT), ctypes.c_int]
-SendInput.restype = UINT
-
-INPUT_MOUSE = 0
-INPUT_KEYBOARD = 1
-INPUT_HARDWARE = 2
 
 
 class WindowsHotkeyMgr(AbstractHotkeyMgr):
@@ -158,7 +89,6 @@ class WindowsHotkeyMgr(AbstractHotkeyMgr):
     def unregister(self) -> None:
         """Unregister the hotkey handling."""
         thread = self.thread
-
         if thread:
             logger.debug('Thread is/was running')
             self.thread = None  # type: ignore
@@ -169,13 +99,11 @@ class WindowsHotkeyMgr(AbstractHotkeyMgr):
 
         else:
             logger.debug('No thread')
-
         logger.debug('Done.')
 
     def worker(self, keycode, modifiers) -> None:  # noqa: CCR001
         """Handle hotkeys."""
         logger.debug('Begin...')
-        # Hotkey must be registered by the thread that handles it
         try:
             win32gui.RegisterHotKey(None, 1, modifiers | MOD_NOREPEAT, keycode)
         except pywintypes.error:
@@ -183,45 +111,63 @@ class WindowsHotkeyMgr(AbstractHotkeyMgr):
             self.thread = None  # type: ignore
             return
 
-        fake = INPUT(INPUT_KEYBOARD, INPUTUNION(ki=KEYBDINPUT(keycode, keycode, 0, 0, None)))
-
-        msg = MSG()
         logger.debug('Entering GetMessage() loop...')
-        while win32gui.GetMessage(None, 0, 0) != 0:
-            logger.debug('Got message')
-            if msg.message == win32con.WM_HOTKEY:
-                logger.debug('WM_HOTKEY')
+        while True:
+            try:
+                result = win32gui.GetMessage(None, 0, 0)
+                if result[0] == 0:  # WM_QUIT
+                    break
 
-                if (
-                        config.get_int('hotkey_always')
-                        or window_title(win32gui.GetForegroundWindow()).startswith('Elite - Dangerous')
-                ):
-                    if not config.shutting_down:
-                        logger.debug('Sending event <<Invoke>>')
-                        self.root.event_generate('<<Invoke>>', when="tail")
+                msg_hwnd, msg_id, wparam, lparam, msg_time, msg_point = result[1]
+
+                if msg_id == win32con.WM_HOTKEY:
+                    logger.debug('WM_HOTKEY')
+                    if (config.get_int('hotkey_always') or
+                            window_title(win32gui.GetForegroundWindow()).startswith('Elite - Dangerous')):
+                        if not config.shutting_down:
+                            logger.debug('Sending event <<Invoke>>')
+                            self.root.event_generate('<<Invoke>>', when="tail")
+                    else:
+                        logger.debug('Passing key on')
+                        win32gui.UnregisterHotKey(None, 1)
+
+                        # Simulate key press
+                        win32api.keybd_event(
+                            keycode,
+                            win32api.MapVirtualKey(keycode, 0),
+                            0,
+                            0
+                        )
+                        # Simulate key release
+                        win32api.keybd_event(
+                            keycode,
+                            win32api.MapVirtualKey(keycode, 0),
+                            win32con.KEYEVENTF_KEYUP,
+                            0
+                        )
+
+                        try:
+                            win32gui.RegisterHotKey(None, 1, modifiers | MOD_NOREPEAT, keycode)
+                        except pywintypes.error:
+                            logger.exception("Failed to re-register hotkey")
+                            break
+
+                elif msg_id == WM_SND_GOOD:
+                    logger.debug('WM_SND_GOOD')
+                    winsound.PlaySound(self.snd_good, winsound.SND_MEMORY)
+
+                elif msg_id == WM_SND_BAD:
+                    logger.debug('WM_SND_BAD')
+                    winsound.PlaySound(self.snd_bad, winsound.SND_MEMORY)
 
                 else:
-                    logger.debug('Passing key on')
-                    win32gui.UnregisterHotKey(None, 1)
-                    SendInput(1, fake, ctypes.sizeof(INPUT))
-                    try:
-                        win32gui.RegisterHotKey(None, 1, modifiers | MOD_NOREPEAT, keycode)
-                    except pywintypes.error:
-                        logger.exception("We aren't registered for this ?")
-                        break
+                    # Use win32gui for message processing
+                    win32gui.TranslateMessage(result[1])
+                    win32gui.DispatchMessage(result[1])
 
-            elif msg.message == WM_SND_GOOD:
-                logger.debug('WM_SND_GOOD')
-                winsound.PlaySound(self.snd_good, winsound.SND_MEMORY)  # synchronous
-
-            elif msg.message == WM_SND_BAD:
-                logger.debug('WM_SND_BAD')
-                winsound.PlaySound(self.snd_bad, winsound.SND_MEMORY)  # synchronous
-
-            else:
-                logger.debug('Something else')
-                win32gui.TranslateMessage(ctypes.byref(msg))
-                win32gui.DispatchMessage(ctypes.byref(msg))
+            except Exception as e:
+                logger.exception(f"Error in message loop: {e}")
+                break
 
         logger.debug('Exited GetMessage() loop.')
         win32gui.UnregisterHotKey(None, 1)
@@ -254,25 +200,24 @@ class WindowsHotkeyMgr(AbstractHotkeyMgr):
             | ((win32api.GetKeyState(win32con.VK_RWIN) & 0x8000) and win32con.MOD_WIN)
         keycode = event.keycode
 
-        if keycode in (win32con.VK_SHIFT, win32con.VK_CONTROL, win32con.VK_MENU, win32con.VK_LWIN, win32con.VK_RWIN):
+        if keycode in (win32con.VK_SHIFT, win32con.VK_CONTROL, win32con.VK_MENU,
+                       win32con.VK_LWIN, win32con.VK_RWIN):
             return 0, modifiers
 
         if not modifiers:
             if keycode == win32con.VK_ESCAPE:  # Esc = retain previous
                 return False
 
-            if keycode in (win32con.VK_BACK, win32con.VK_DELETE,
-                           win32con.VK_CLEAR, win32con.VK_OEM_CLEAR):  # BkSp, Del, Clear = clear hotkey
+            if (keycode in (win32con.VK_BACK, win32con.VK_DELETE, win32con.VK_CLEAR, win32con.VK_OEM_CLEAR) or
+                    keycode in (win32con.VK_RETURN, win32con.VK_SPACE, VK_OEM_MINUS) or
+                    ord('A') <= keycode <= ord(
+                        'Z')):  # BkSp, Del, Clear = clear hotkey, or don't allow keys needed for typing
+                if keycode not in (win32con.VK_BACK, win32con.VK_DELETE, win32con.VK_CLEAR, win32con.VK_OEM_CLEAR):
+                    winsound.MessageBeep()  # Only beep for typing keys, not for clear hotkey
                 return None
 
-            if (
-                    keycode in (win32con.VK_RETURN, win32con.VK_SPACE, VK_OEM_MINUS) or ord('A') <= keycode <= ord('Z')
-            ):  # don't allow keys needed for typing in System Map
-                winsound.MessageBeep()
-                return None
-
-            if (keycode in (win32con.VK_NUMLOCK, win32con.VK_SCROLL, win32con.VK_PROCESSKEY)
-                    or win32con.VK_CAPITAL <= keycode <= win32con.VK_MODECHANGE):  # ignore unmodified mode switch keys
+            if (keycode in (win32con.VK_NUMLOCK, win32con.VK_SCROLL, win32con.VK_PROCESSKEY) or
+                    win32con.VK_CAPITAL <= keycode <= win32con.VK_MODECHANGE):  # ignore unmodified mode switch keys
                 return 0, modifiers
 
         # See if the keycode is usable and available
@@ -295,13 +240,10 @@ class WindowsHotkeyMgr(AbstractHotkeyMgr):
         text = ''
         if modifiers & win32con.MOD_WIN:
             text += '❖+'
-
         if modifiers & win32con.MOD_CONTROL:
             text += 'Ctrl+'
-
         if modifiers & win32con.MOD_ALT:
             text += 'Alt+'
-
         if modifiers & win32con.MOD_SHIFT:
             text += '⇧+'
 
@@ -310,21 +252,16 @@ class WindowsHotkeyMgr(AbstractHotkeyMgr):
 
         if not keycode:
             pass
-
         elif win32con.VK_F1 <= keycode <= win32con.VK_F24:
             text += f'F{keycode + 1 - win32con.VK_F1}'
-
-        elif keycode in WindowsHotkeyMgr.DISPLAY:  # specials
-            text += WindowsHotkeyMgr.DISPLAY[keycode]
-
+        elif keycode in self.DISPLAY:
+            text += self.DISPLAY[keycode]
         else:
             c = win32api.MapVirtualKey(keycode, MAPVK_VK_TO_CHAR)
             if not c:  # oops not printable
                 text += '⁈'
-
             elif c < 0x20:  # control keys
                 text += chr(c + 0x40)
-
             else:
                 text += chr(c).upper()
 

--- a/l10n.py
+++ b/l10n.py
@@ -37,7 +37,6 @@ LANGUAGE_ID = '!Language'
 LOCALISATION_DIR: pathlib.Path = pathlib.Path('L10n')
 
 if sys.platform == 'win32':
-    import ctypes
     import win32api
 
 
@@ -165,14 +164,13 @@ class Translations:
         if lang:
             contents: dict[str, str] = self.contents(lang=lang, plugin_path=plugin_path)
 
-            if not contents or type(contents) is not dict:
+            if not contents or not isinstance(contents, dict):
                 logger.debug(f'Failure loading translations for overridden language {lang!r}')
                 return self.translate(x)
-            elif x not in contents.keys():
+            if x not in contents:
                 logger.debug(f'Missing translation: {x!r} for overridden language {lang!r}')
                 return self.translate(x)
-            else:
-                return contents.get(x) or self.translate(x)
+            return contents.get(x) or self.translate(x)
 
         if plugin_name:
             if self.translations[None] and plugin_name not in self.translations:
@@ -289,16 +287,6 @@ class _Locale:
             return locale.atof(string)
 
         return None
-
-    def wszarray_to_list(self, array):
-        offset = 0
-        while offset < len(array):
-            sz = ctypes.wstring_at(ctypes.addressof(array) + offset * 2)  # type: ignore
-            if sz:
-                yield sz
-                offset += len(sz) + 1
-            else:
-                break
 
     def preferred_languages(self) -> Iterable[str]:
         """

--- a/l10n.py
+++ b/l10n.py
@@ -307,14 +307,12 @@ class _Locale:
         else:
             current_locale = win32api.GetUserDefaultLangID()
             lang = locale.windows_locale[current_locale]
-            print(lang)
         # HACK: <n/a> | 2021-12-11: OneSky calls "Chinese Simplified" "zh-Hans"
         #    in the name of the file, but that will be zh-CN in terms of
         #    locale.  So map zh-CN -> zh-Hans
         languages = [lang.replace('_', '-')] if lang else []
         languages = ['zh-Hans' if lang == 'zh-CN' else lang for lang in languages]
-        print(languages)
-        return ['en-US']
+        return languages
 
 
 # singletons

--- a/l10n.py
+++ b/l10n.py
@@ -18,7 +18,7 @@ import sys
 import warnings
 from contextlib import suppress
 from os import listdir, sep
-from typing import TYPE_CHECKING, Iterable, TextIO, cast
+from typing import Iterable, TextIO, cast
 import pathlib
 from config import config
 from EDMCLogging import get_main_logger
@@ -38,23 +38,7 @@ LOCALISATION_DIR: pathlib.Path = pathlib.Path('L10n')
 
 if sys.platform == 'win32':
     import ctypes
-    from ctypes.wintypes import BOOL, DWORD, LPCVOID, LPCWSTR, LPWSTR
-    if TYPE_CHECKING:
-        import ctypes.windll  # type: ignore # Magic to make linters not complain that windll is special
-
-    # https://msdn.microsoft.com/en-us/library/windows/desktop/dd318124%28v=vs.85%29.aspx
-    MUI_LANGUAGE_ID = 4
-    MUI_LANGUAGE_NAME = 8
-    GetUserPreferredUILanguages = ctypes.windll.kernel32.GetUserPreferredUILanguages
-    GetUserPreferredUILanguages.argtypes = [
-        DWORD, ctypes.POINTER(ctypes.c_ulong), LPCVOID, ctypes.POINTER(ctypes.c_ulong)
-    ]
-    GetUserPreferredUILanguages.restype = BOOL
-
-    LOCALE_NAME_USER_DEFAULT = None
-    GetNumberFormatEx = ctypes.windll.kernel32.GetNumberFormatEx
-    GetNumberFormatEx.argtypes = [LPCWSTR, DWORD, LPCWSTR, LPCVOID, LPWSTR, ctypes.c_int]
-    GetNumberFormatEx.restype = ctypes.c_int
+    import win32api
 
 
 class Translations:
@@ -332,28 +316,17 @@ class _Locale:
         if sys.platform != 'win32':
             # POSIX
             lang = locale.getlocale()[0]
-            languages = [lang.replace('_', '-')] if lang else []
-
         else:
-            num = ctypes.c_ulong()
-            size = ctypes.c_ulong(0)
-            languages = []
-            if GetUserPreferredUILanguages(
-                MUI_LANGUAGE_NAME, ctypes.byref(num), None, ctypes.byref(size)
-            ) and size.value:
-                buf = ctypes.create_unicode_buffer(size.value)
-
-                if GetUserPreferredUILanguages(
-                    MUI_LANGUAGE_NAME, ctypes.byref(num), ctypes.byref(buf), ctypes.byref(size)
-                ):
-                    languages = self.wszarray_to_list(buf)
-
+            current_locale = win32api.GetUserDefaultLangID()
+            lang = locale.windows_locale[current_locale]
+            print(lang)
         # HACK: <n/a> | 2021-12-11: OneSky calls "Chinese Simplified" "zh-Hans"
         #    in the name of the file, but that will be zh-CN in terms of
         #    locale.  So map zh-CN -> zh-Hans
+        languages = [lang.replace('_', '-')] if lang else []
         languages = ['zh-Hans' if lang == 'zh-CN' else lang for lang in languages]
-
-        return languages
+        print(languages)
+        return ['en-US']
 
 
 # singletons

--- a/prefs.py
+++ b/prefs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
-from os.path import expandvars, join, normpath
+from os.path import join, normpath
 from pathlib import Path
 import subprocess
 import sys
@@ -185,10 +185,10 @@ class AutoInc(contextlib.AbstractContextManager):
 
 
 if sys.platform == 'win32':
-    import ctypes
     import winreg
-    from ctypes.wintypes import LPCWSTR, LPWSTR, MAX_PATH, POINT, RECT, SIZE, UINT, BOOL
     import win32api
+    from win32com.shell import shell, shellcon
+    import pythoncom
     is_wine = False
     try:
         WINE_REGISTRY_KEY = r'HKEY_LOCAL_MACHINE\Software\Wine'
@@ -199,30 +199,51 @@ if sys.platform == 'win32':
     except OSError:  # Assumed to be 'path not found', i.e. not-wine
         pass
 
-    CalculatePopupWindowPosition = None
-    if not is_wine:
-        try:
-            CalculatePopupWindowPosition = ctypes.windll.user32.CalculatePopupWindowPosition
-            CalculatePopupWindowPosition.argtypes = [POINT, SIZE, UINT, RECT, RECT]
-            CalculatePopupWindowPosition.restype = BOOL
+    def get_localized_path(path: str, config_home: str) -> str:
+        """
+        Get the localized display path for a Windows file system path.
+        Shows only drive letters without labels.
 
-        except AttributeError as e:
-            logger.error(
-                'win32 and not is_wine, but ctypes.windll.user32.CalculatePopupWindowPosition invalid',
-                exc_info=e
-            )
+        Args:
+            path: The path to localize
+            config_home: The home directory path
+        Returns:
+            Localized path as string
+        """
+        if not path:
+            return path
 
-        else:
-            CalculatePopupWindowPosition.argtypes = [
-                ctypes.POINTER(POINT),
-                ctypes.POINTER(SIZE),
-                UINT,
-                ctypes.POINTER(RECT),
-                ctypes.POINTER(RECT)
-            ]
+        # Determine start index based on if path starts with home directory
+        start_idx = len(config_home.split('\\')) if path.lower().startswith(config_home.lower()) else 0
 
-    SHGetLocalizedName = ctypes.windll.shell32.SHGetLocalizedName
-    SHGetLocalizedName.argtypes = [LPCWSTR, LPWSTR, UINT, ctypes.POINTER(ctypes.c_int)]
+        # Split path into components
+        components = normpath(path).split('\\')
+        display_components = []
+
+        # Process each path component
+        for i in range(start_idx, len(components)):
+            current_path = '\\'.join(components[:i + 1])
+
+            # Handle drive letter specially
+            if i == 0 and ':' in components[i]:
+                display_components.append(components[i])
+                continue
+
+            try:
+                # Get localized name info using shell API
+                pidl = shell.SHParseDisplayName(current_path, 0)[0]
+                name_info = shell.SHGetNameFromIDList(pidl, shellcon.SIGDN_NORMALDISPLAY)
+
+                if name_info:
+                    display_components.append(name_info)
+                else:
+                    display_components.append(components[i])
+
+            except (pythoncom.com_error, win32api.error):
+                # Fall back to original component name if localization fails
+                display_components.append(components[i])
+
+        return '\\'.join(display_components)
 
 
 class PreferencesDialog(tk.Toplevel):
@@ -1099,27 +1120,9 @@ class PreferencesDialog(tk.Toplevel):
         entryfield['state'] = tk.NORMAL  # must be writable to update
         entryfield.delete(0, tk.END)
         if sys.platform == 'win32':
-            start = len(config.home.split('\\')) if pathvar.get().lower().startswith(config.home.lower()) else 0
-            display = []
-            components = normpath(pathvar.get()).split('\\')
-            buf = ctypes.create_unicode_buffer(MAX_PATH)
-            pidsRes = ctypes.c_int()  # noqa: N806 # Windows convention
-            for i in range(start, len(components)):
-                try:
-                    if (not SHGetLocalizedName('\\'.join(components[:i+1]), buf, MAX_PATH, ctypes.byref(pidsRes)) and
-                            win32api.LoadString(ctypes.WinDLL(expandvars(buf.value))._handle,
-                                                pidsRes.value, buf, MAX_PATH)):
-                        display.append(buf.value)
-
-                    else:
-                        display.append(components[i])
-
-                except Exception:
-                    display.append(components[i])
-
-            entryfield.insert(0, '\\'.join(display))
-
-        #                                                   None if path doesn't exist
+            localized_path = get_localized_path(pathvar.get(), config.home)
+            entryfield.insert(0, localized_path)
+        # None if path doesn't exist
         else:
             if pathvar.get().startswith(config.home):
                 entryfield.insert(0, '~' + pathvar.get()[len(config.home):])
@@ -1290,14 +1293,14 @@ class PreferencesDialog(tk.Toplevel):
         config.set('ui_transparency', self.transparency.get())
         config.set('always_ontop', self.always_ontop.get())
         config.set('minimize_system_tray', self.minimize_system_tray.get())
-        if self.disable_system_tray.get() != config.get('no_systray'):
+        if self.disable_system_tray.get() != config.get_int('no_systray'):
             self.req_restart = True
         config.set('no_systray', self.disable_system_tray.get())
         config.set('theme', self.theme.get())
         config.set('dark_text', self.theme_colors[0])
         config.set('dark_highlight', self.theme_colors[1])
         theme.apply(self.parent)
-        if self.plugdir.get() != config.get('plugin_dir'):
+        if self.plugdir.get() != config.get_str('plugin_dir'):
             config.set(
                 'plugin_dir',
                 join(config.home_path, self.plugdir.get()[2:]) if self.plugdir.get().startswith(

--- a/protocol.py
+++ b/protocol.py
@@ -12,7 +12,6 @@ import sys
 import threading
 from urllib import parse
 from typing import TYPE_CHECKING, Type
-
 from config import config
 from constants import appname, protocolhandler_redirect
 from EDMCLogging import get_main_logger
@@ -25,13 +24,7 @@ logger = get_main_logger()
 is_wine = False
 
 if sys.platform == 'win32':
-    from ctypes import windll  # type: ignore
-
-    try:
-        if windll.ntdll.wine_get_version:
-            is_wine = True
-    except Exception:
-        pass
+    is_wine = bool(os.getenv('WINEPREFIX'))
 
 
 class GenericProtocolHandler:


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
This PR hands off more ctype calls to pywin32, which helps ensure more pythonic, error-safe, and simpler code can be used instead of home-rolling our own code for interacting with the Windows API. Additionally, this fixes a bug in the Hotkeys module which broke a segment of the hotkey functionality on Windows hosts. 

* Removes a dependency on windll and ctypes.create_unicode_buffer in EDMarketConnector.py
* Removes a duplicate check for CalculatePopupWindowPosition in favor of pywin32's win32api.MonitorFromWindow in common_utils.py. 
* Completely revamps the hotkey module for Windows to use pywin32 code.
* Removes some unused l10n.py ctypes calls that were not used anywhere
* Improves the language selection to utilize locale and pywin32 on Windows
* Removes some unused code from prefs.py
* Updates protocol.py to avoid ctypes where possible


Additionally, minor other improvements are included: 
* Updates some statements in l10n.py to be more pythonic
* Updates some config calls to use the proper get values
* Improves WINE detection without relying on ctypes

# Type of Change
Enhancement and Bug Fix

# How Tested
Tested with multiple frozen and script builds and situations locally

# Notes
Resolves #2389, related to #1805 
