### PR TITLE
[579] Add EDMC CMDR Iteration

### DIFF
--- a/EDMC.py
+++ b/EDMC.py
@@ -191,10 +191,11 @@ def main() -> None:  # noqa: C901, CCR001
 
         log_locale('Initial Locale')
         if args.refresh_all:
-            logger.info("Refreshing all known CMDRs")
+            # Attempt to refresh all known CMDRs. This MAY cause additional output if a token is invalid.
+            logger.debug("Refreshing all known CMDRs")
             cmdrs = config.get_list('cmdrs', default=[])
             for cmdr in cmdrs:
-                logger.info(f'Attempting to use commander "{cmdr}"')
+                logger.debug(f'Attempting to use commander "{cmdr}"')
                 try:
                     companion.session.login(cmdr, monitor.is_beta)
                     logger.debug("Succeeded!")

--- a/EDMC.py
+++ b/EDMC.py
@@ -126,6 +126,12 @@ def main() -> None:  # noqa: C901, CCR001
             action='store_true'
         )
 
+        parser.add_argument(
+            '--refresh-all',
+            help='Iterate over all known CMDRs to try and refresh access tokens',
+            action='store_true',
+        )
+
         parser.add_argument('-a', metavar='FILE', help='write ship loadout to FILE in Companion API json format')
         parser.add_argument('-e', metavar='FILE', help='write ship loadout to FILE in E:D Shipyard plain text format')
         parser.add_argument('-l', metavar='FILE', help='write ship locations to FILE in CSV format')
@@ -184,6 +190,16 @@ def main() -> None:  # noqa: C901, CCR001
                 logger.info(f'marked {d} for TRACE')
 
         log_locale('Initial Locale')
+        if args.refresh_all:
+            logger.info("Refreshing all known CMDRs")
+            cmdrs = config.get_list('cmdrs', default=[])
+            for cmdr in cmdrs:
+                logger.info(f'Attempting to use commander "{cmdr}"')
+                try:
+                    companion.session.login(cmdr, monitor.is_beta)
+                    logger.debug("Succeeded!")
+                except AttributeError:
+                    logger.debug(f"Unable to refresh CMDR {cmdr}.")
 
         if args.j:
             logger.debug('Import and collate from JSON dump')


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
This PR adds an option to the EDMC command line to iterate over all known CMDRs and poke CAPI to keep the access and token live. This will reduce the number of re-authorizations that users need to perform if they make this a scheduled action. 

# Type of Change
Enhancement

# How Tested
Tested with various permutations of working tokens, invalid tokens, expired tokens, etc across 3 CMDRs.

# Notes
Resolves #579 
