### PR TITLE
[#1775] Retire Usage of Assert

### DIFF
--- a/config/linux.py
+++ b/config/linux.py
@@ -13,7 +13,8 @@ import sys
 from configparser import ConfigParser
 from config import AbstractConfig, appname, logger
 
-assert sys.platform == 'linux'
+if sys.platform != 'linux':
+    raise EnvironmentError("This file is for Linux only.")
 
 
 class LinuxConfig(AbstractConfig):

--- a/config/windows.py
+++ b/config/windows.py
@@ -16,7 +16,8 @@ from typing import Literal
 from config import AbstractConfig, applongname, appname, logger
 from win32comext.shell import shell
 
-assert sys.platform == 'win32'
+if sys.platform != 'win32':
+    raise EnvironmentError("This file is for Windows only.")
 
 REG_RESERVED_ALWAYS_ZERO = 0
 

--- a/coriolis-update-files.py
+++ b/coriolis-update-files.py
@@ -20,12 +20,15 @@ import sys
 import outfitting
 from edmc_data import coriolis_ship_map, ship_name_map
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # noqa: C901
 
     def add(modules, name, attributes) -> None:
         """Add the given module to the modules dict."""
-        assert name not in modules or modules[name] == attributes, f'{name}: {modules.get(name)} != {attributes}'
-        assert name not in modules, name
+        if name in modules and modules[name] != attributes:
+            raise ValueError(f'{name}: {modules.get(name)} != {attributes}')
+        if name in modules:
+            raise ValueError(f'{name} already exists in modules')
+
         modules[name] = attributes
 
     try:
@@ -50,7 +53,8 @@ if __name__ == "__main__":
     # Ship and armour masses
     for m in list(data['Ships'].values()):
         name = coriolis_ship_map.get(m['properties']['name'], str(m['properties']['name']))
-        assert name in reverse_ship_map, name
+        if name not in reverse_ship_map:
+            raise ValueError(f'Unknown ship: {name}')
         ships[name] = {'hullMass': m['properties']['hullMass'],
                        'reserveFuelCapacity': m['properties']['reserveFuelCapacity']}
         for i, bulkhead in enumerate(bulkheads):
@@ -64,7 +68,8 @@ if __name__ == "__main__":
     for cat in list(data['Modules'].values()):
         for grp, mlist in list(cat.items()):
             for m in mlist:
-                assert 'symbol' in m, m
+                if 'symbol' not in m:
+                    raise ValueError(f'No symbol in {m}')
                 key = str(m['symbol'].lower())
                 if grp == 'fsd':
                     modules[key] = {

--- a/edshipyard.py
+++ b/edshipyard.py
@@ -128,7 +128,7 @@ def export(data, filename=None) -> None:  # noqa: C901, CCR001
                 elif not slot.lower().startswith('planetaryapproachsuite'):
                     logger.debug(f'EDShipyard: Unknown slot {slot}')
 
-        except AssertionError as e:
+        except ValueError as e:
             logger.debug(f'EDShipyard: {e!r}')
             continue  # Silently skip unrecognized modules
 
@@ -161,8 +161,11 @@ def export(data, filename=None) -> None:  # noqa: C901, CCR001
     string += f'---\nCargo : {cargo} T\nFuel  : {fuel} T\n'
 
     # Add mass and range
-    assert data['ship']['name'].lower() in ship_name_map, data['ship']['name']
-    assert ship_name_map[data['ship']['name'].lower()] in ships, ship_name_map[data['ship']['name'].lower()]
+    ship_name = data['ship']['name'].lower()
+    if ship_name not in ship_name_map:
+        raise ValueError(f"Ship name '{data['ship']['name']}' not found in ship_name_map")
+    if ship_name_map[ship_name] not in ships:
+        raise ValueError(f"Mapped ship name '{ship_name_map[ship_name]}' not found in ships")
 
     try:
         mass += ships[ship_name_map[data['ship']['name'].lower()]]['hullMass']

--- a/hotkey/linux.py
+++ b/hotkey/linux.py
@@ -5,7 +5,8 @@ import sys
 from EDMCLogging import get_main_logger
 from hotkey import AbstractHotkeyMgr
 
-assert sys.platform == 'linux'
+if sys.platform != 'linux':
+    raise EnvironmentError("This file is for Linux only.")
 
 logger = get_main_logger()
 

--- a/hotkey/windows.py
+++ b/hotkey/windows.py
@@ -17,7 +17,8 @@ from config import config
 from EDMCLogging import get_main_logger
 from hotkey import AbstractHotkeyMgr
 
-assert sys.platform == 'win32'
+if sys.platform != 'win32':
+    raise EnvironmentError("This file is for Windows only.")
 
 logger = get_main_logger()
 

--- a/killswitch.py
+++ b/killswitch.py
@@ -275,7 +275,8 @@ class KillSwitchSet:
             return True, data
 
         if TYPE_CHECKING:  # pyright, mypy, please -_-
-            assert res.kill is not None
+            if res.kill is None:
+                raise ValueError('Killswitch has rules but no kill data')
 
         try:
             new_data = res.kill.apply_rules(deepcopy(data))

--- a/l10n.py
+++ b/l10n.py
@@ -133,7 +133,8 @@ class Translations:
 
     def contents(self, lang: str, plugin_path: pathlib.Path | None = None) -> dict[str, str]:
         """Load all the translations from a translation file."""
-        assert lang in self.available()
+        if lang not in self.available():
+            raise KeyError(f'Language {lang} not available')
         translations = {}
 
         h = self.file(lang, plugin_path)

--- a/monitor.py
+++ b/monitor.py
@@ -311,7 +311,8 @@ class EDLogs(FileSystemEventHandler):
         if self.observed:
             logger.debug('self.observed: Calling unschedule_all()')
             self.observed = None
-            assert self.observer is not None, 'Observer was none but it is in use?'
+            if self.observer is None:
+                raise RuntimeError("Observer was None but it is in use?")
             self.observer.unschedule_all()
             logger.debug('Done')
 
@@ -416,7 +417,8 @@ class EDLogs(FileSystemEventHandler):
         # Watchdog thread -- there is a way to get this by using self.observer.emitters and checking for an attribute:
         # watch, but that may have unforseen differences in behaviour.
         if self.observed:
-            assert self.observer is not None, 'self.observer is None but also in use?'
+            if self.observer is None:
+                raise RuntimeError("Observer was None but is it in use?")
             # Note: Uses undocumented attribute
             emitter = self.observed and self.observer._emitter_for_watch[self.observed]
 
@@ -555,7 +557,8 @@ class EDLogs(FileSystemEventHandler):
         try:
             # Preserve property order because why not?
             entry: MutableMapping[str, Any] = json.loads(line)
-            assert 'timestamp' in entry, "Timestamp does not exist in the entry"
+            if 'timestamp' not in entry:
+                raise KeyError("Timestamp does not exist in the entry")
 
             self.__navroute_retry()
 
@@ -1658,7 +1661,8 @@ class EDLogs(FileSystemEventHandler):
                                 self.state[category].pop(material)
 
                 module = self.state['Modules'][entry['Slot']]
-                assert module['Item'] == self.canonicalise(entry['Module'])
+                if module['Item'] != self.canonicalise(entry['Module']):
+                    raise ValueError(f"Module {entry['Slot']} is not {entry['Module']}")
                 module['Engineering'] = {
                     'Engineer':      entry['Engineer'],
                     'EngineerID':    entry['EngineerID'],

--- a/plug.py
+++ b/plug.py
@@ -113,20 +113,16 @@ class Plugin:
                 appitem = plugin_app(parent)
                 if appitem is None:
                     return None
-
                 if isinstance(appitem, tuple):
                     if (
                         len(appitem) != 2
                         or not isinstance(appitem[0], tk.Widget)
                         or not isinstance(appitem[1], tk.Widget)
                     ):
-                        raise AssertionError
-
+                        raise TypeError("Expected a tuple of two tk.Widget instances from plugin_app")
                 elif not isinstance(appitem, tk.Widget):
-                    raise AssertionError
-
+                    raise TypeError("Expected a tk.Widget or tuple of two tk.Widgets from plugin_app")
                 return appitem
-
             except Exception:
                 logger.exception(f'Failed for Plugin "{self.name}"')
 
@@ -148,7 +144,7 @@ class Plugin:
                 frame = plugin_prefs(parent, cmdr, is_beta)
                 if isinstance(frame, nb.Frame):
                     return frame
-                raise AssertionError
+                raise TypeError(f'Expected nb.Frame from plugin_prefs, got {type(frame).__name__}')
             except Exception:
                 logger.exception(f'Failed for Plugin "{self.name}"')
         return None
@@ -249,7 +245,8 @@ def invoke(
     for plugin in PLUGINS:
         if plugin.name == fallback:
             plugin_func = plugin._get_func(fn_name)
-            assert plugin_func, plugin.name  # fallback plugin should provide the function
+            if not plugin_func:
+                raise ValueError(f"Fallback plugin '{plugin.name}' does not provide the function '{fn_name}'")
             return plugin_func(*args)
 
     return None

--- a/protocol.py
+++ b/protocol.py
@@ -67,7 +67,8 @@ if (config.auth_force_edmc_protocol  # noqa: C901
                 and not config.auth_force_localserver
         )):
     # This could be false if you use auth_force_edmc_protocol, but then you get to keep the pieces
-    assert sys.platform == 'win32'
+    if sys.platform != 'win32':
+        raise EnvironmentError("This code is for Windows only.")
     # spell-checker: words HBRUSH HICON WPARAM wstring WNDCLASS HMENU HGLOBAL
     from ctypes import (  # type: ignore
         windll, POINTER, WINFUNCTYPE, Structure, byref, c_long, c_void_p, create_unicode_buffer, wstring_at

--- a/scripts/find_localised_strings.py
+++ b/scripts/find_localised_strings.py
@@ -260,7 +260,8 @@ def generate_lang_template(data: dict[pathlib.Path, list[ast.Call]]) -> str:
 """
     print(f"Done Deduping entries {len(entries)=}  {len(deduped)=}", file=sys.stderr)
     for entry in deduped:
-        assert len(entry.comments) == len(entry.locations)
+        if len(entry.comments) != len(entry.locations):
+            raise ValueError("Mismatch: 'comments' and 'locations' must have the same length.")
 
         comment_set = set()
         for comment, loc in zip(entry.comments, entry.locations):

--- a/shipyard.py
+++ b/shipyard.py
@@ -13,9 +13,12 @@ def export(data: companion.CAPIData, filename: str) -> None:
     :param filename: Optional filename to write to.
     :return:
     """
-    assert data['lastSystem'].get('name')
-    assert data['lastStarport'].get('name')
-    assert data['lastStarport'].get('ships')
+    if not data['lastSystem'].get('name'):
+        raise ValueError("Missing 'name' in 'lastSystem'")
+    if not data['lastStarport'].get('name'):
+        raise ValueError("Missing 'name' in 'lastStarport'")
+    if not data['lastStarport'].get('ships'):
+        raise ValueError("Missing 'ships' in 'lastStarport'")
 
     with open(filename, 'w', newline='') as f:
         c = csv.writer(f)

--- a/theme.py
+++ b/theme.py
@@ -146,7 +146,8 @@ class _Theme:
     def register(self, widget: tk.Widget | tk.BitmapImage) -> None:  # noqa: CCR001, C901
         # Note widget and children for later application of a theme. Note if
         # the widget has explicit fg or bg attributes.
-        assert isinstance(widget, (tk.BitmapImage, tk.Widget)), widget
+        if not isinstance(widget, (tk.Widget, tk.BitmapImage)):
+            raise TypeError(f'Expected widget, got {type(widget)}')
         if not self.defaults:
             # Can't initialise this til window is created       # Windows
             self.defaults = {
@@ -301,7 +302,8 @@ class _Theme:
         Also, register it for future updates.
         :param widget: Target widget.
         """
-        assert isinstance(widget, (tk.BitmapImage, tk.Widget)), widget
+        if not isinstance(widget, (tk.Widget, tk.BitmapImage)):
+            raise TypeError(f'Expected widget, got {type(widget)}')
         if not self.current:
             return  # No need to call this for widgets created in plugin_app()
 
@@ -325,7 +327,7 @@ class _Theme:
                 w_keys = []
 
             assert_str = f'{w_class} {widget} "{"text" in w_keys and widget["text"]}"'
-            raise AssertionError(assert_str)
+            raise ValueError(assert_str)
 
         attribs: set = self.widgets.get(widget, set())
 


### PR DESCRIPTION

<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
<!-- What does this PR Do? -->
This PR removes the `assert` statement from EDMC non-test code where present, paving the way to enable -OO code. Assert is not really a good idea to use in live code, and should not be used outside of tests and debugging. This PR attempts to cleanly hand over all assert and assert-like statements to other exception types. 

# Type of Change
<!-- What type of change is this? New Feature? Enhancement to Existing Feature? Bug Fix? Translation Update? -->

# Notes
Resolves #1287. Related to #1775.
