### PR TITLE
[2431] Reimplement Ctypes LongLang Check

### DIFF
--- a/L10n/tr.strings
+++ b/L10n/tr.strings
@@ -2,8 +2,7 @@
 "Error: Frontier CAPI data out of sync" = "Frontier CAPI datası senkronize değil";
 
 /* prefs.py: Appearance option for Windows "Disable Systray"; */
-"Disable Systray" = "Sistem tepsisi ikonunu devre dışı bırak
-";
+"Disable Systray" = "Sistem tepsisi ikonunu devre dışı bırak";
 
 /* edsm.py:Settings>EDSM - Label on checkbox for 'send data'; In files: edsm.py:316; */
 "Send flight log and CMDR status to EDSM" = "Uçuş günlüğünü ve CMDR durumunu EDSM'e gönder";

--- a/modules.json
+++ b/modules.json
@@ -104,6 +104,21 @@
     "cobramkiv_armour_reactive": {
         "mass": 27
     },
+    "cobramkv_armour_grade1": {
+        "mass": 0
+    },
+    "cobramkv_armour_grade2": {
+        "mass": 14
+    },
+    "cobramkv_armour_grade3": {
+        "mass": 27
+    },
+    "cobramkv_armour_mirrored": {
+        "mass": 27
+    },
+    "cobramkv_armour_reactive": {
+        "mass": 27
+    },
     "cutter_armour_grade1": {
         "mass": 0
     },
@@ -604,6 +619,9 @@
     },
     "hpt_heatsinklauncher_turret_tiny": {
         "mass": 1.3
+    },
+    "hpt_human_extraction_fixed_medium": {
+        "mass": 4
     },
     "hpt_minelauncher_fixed_medium": {
         "mass": 4

--- a/ships.json
+++ b/ships.json
@@ -39,6 +39,10 @@
         "hullMass": 210,
         "reserveFuelCapacity": 0.51
     },
+    "Cobra MkV": {
+        "hullMass": 150,
+        "reserveFuelCapacity": 0.49
+    },
     "Diamondback Explorer": {
         "hullMass": 260,
         "reserveFuelCapacity": 0.52


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
This PR restores a simplified and logic-enhanced version of the CTYPES Localization Check for Windows. 

The version of the localization system for Windows implemented in 5.13.0 broke edge cases where the user's localization was not a traditional English speaking location, but the user had set their system to English. (See: en-nl) This caused an error as en-nl could not be matched in Python's localization module. This edge case was missed by the Beta. 

The CTypes legacy detection has been re-implemented, but with fewer defined ctypes declarations for a smoother experience. 

# Type of Change
Bugfix

# How Tested
Legacy code reimplementation, tested with different forced detection of languages. 

# Notes
Fixes #2433
Fixes #2431 
