### PR TITLE
[#2277] Best-Effort CAPI Horizons Detection

### DIFF
--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -636,11 +636,13 @@ class EDDN:
             return
 
         modules, ships = self.safe_modules_and_ships(data)
-        horizons: bool = capi_is_horizons(
+        horizons_1 = bool(data['commander']['capabilities']['Horizons'])
+        horizons_2: bool = capi_is_horizons(
             data['lastStarport'].get('economies', {}),
             modules,
             ships
         )
+        horizons = bool(horizons_1 or horizons_2)
         commodities: list[dict[str, Any]] = []
         for commodity in data['lastStarport'].get('commodities') or []:
             # Check 'marketable' and 'not prohibited'
@@ -771,13 +773,14 @@ class EDDN:
         modules, ships = self.safe_modules_and_ships(data)
 
         # Horizons flag - will hit at least Int_PlanetApproachSuite other than at engineer bases ("Colony"),
-        # prison or rescue Megaships, or under Pirate Attack etc
-        horizons: bool = capi_is_horizons(
+        # prison or rescue Megaships, or under Pirate Attack etc)
+        horizons_1 = bool(data['commander']['capabilities']['Horizons'])
+        horizons_2: bool = capi_is_horizons(
             data['lastStarport'].get('economies', {}),
             modules,
             ships
         )
-
+        horizons = bool(horizons_1 or horizons_2)
         to_search: Iterator[Mapping[str, Any]] = filter(
             lambda m: self.MODULE_RE.search(m['name']) and m.get('sku') in (None, HORIZONS_SKU)
                                                        and m['name'] != 'Int_PlanetApproachSuite',  # noqa: E131
@@ -837,13 +840,13 @@ class EDDN:
             return
 
         modules, ships = self.safe_modules_and_ships(data)
-
-        horizons: bool = capi_is_horizons(
+        horizons_1 = bool(data['commander']['capabilities']['Horizons'])
+        horizons_2: bool = capi_is_horizons(
             data['lastStarport'].get('economies', {}),
             modules,
             ships
         )
-
+        horizons = bool(horizons_1 or horizons_2)
         shipyard: list[Mapping[str, Any]] = sorted(
             itertools.chain(
                 (ship['name'].lower() for ship in (ships['shipyard_list'] or {}).values()),


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
This PR adds additional best-effort checks to detect if a CAPI message is being sent with Horizons. EDDN Docs state that the only reliable source is Journal events, but, and this is very important, you can't assume that CAPI data retrieved for an in-game player is going to match the state of the Journals for that session.

There are some indicators in CAPI data which can (when in game) provide useful hints. This includes the "Horizons" flag in CMDR->capabilities in the CAPI Data. This can also be a false negative sometimes, particularly if the query is run when the game is not open or the CMDR is not in-universe. However, this will catch the on-carrier events as described in #2277. Additional determination beyond this is down to consumers of CAPI data. 

# Type of Change
<!-- What type of change is this? New Feature? Enhancement to Existing Feature? Bug Fix? Translation Update? -->
Minor Bug Fix

# How Tested
Tested both in- and out-of-game on various permutations by forcing CAPI updates and viewing the resulting detections. Resolves the initial report, but is not comprehensive and cannot be comprehensive due to the issues with CAPI data. 

# Notes
<!-- Does this resolve any open issues? Was this PR discussed internally somewhere off GitHub? -->
Resolves #2277 
