### PR TITLE
[Bugfix] Fix race starting journal monitor

### DIFF
--- a/EDMarketConnector.py
+++ b/EDMarketConnector.py
@@ -754,7 +754,7 @@ class AppWindow:
         config.delete('username', suppress=True)
         config.delete('password', suppress=True)
         config.delete('logdir', suppress=True)
-        self.postprefs(False)  # Companion login happens in callback from monitor
+        self.w.after_idle(lambda: self.postprefs(False))  # Companion login happens in callback from monitor
         self.toggle_suit_row(visible=False)
         if args.start_min:
             logger.warning("Trying to start minimized")


### PR DESCRIPTION
# Description
Fixes a race identified where long plugin initialization times can result in the following error being thrown in the journal worker thread, requiring a preferences reload to have journals continuing to be processed:

```
Exception in thread Journal worker:
Traceback (most recent call last):
  File "/home/testing/.pyenv/versions/3.11.9/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
    self.run()
  File "/home/testing/.pyenv/versions/3.11.9/lib/python3.11/threading.py", line 982, in run
    self._target(*self._args, **self._kwargs)
  File "/home/testing/gitstuff/EDMarketConnector/monitor.py", line 461, in worker
    self.root.event_generate('<<JournalEvent>>', when="tail")
  File "/home/testing/.pyenv/versions/3.11.9/lib/python3.11/tkinter/__init__.py", line 1933, in event_generate
    self.tk.call(args)
RuntimeError: main thread is not in main loop
```

# Type of Change
Bug fix

# How Tested
Tested locally to ensure journal events start being processed after entering main loop.
Original reporter appears to report that the issue no longer occurs with this fix.

# Notes
Discussed in EDMC channel on EDCD discord.
Fixes: #2486
