### PR TITLE
[Bugfix] Fix EDDN queue not processing at startup

### DIFF
--- a/plugins/eddn.py
+++ b/plugins/eddn.py
@@ -183,7 +183,7 @@ class EDDNSender:
             f"First queue run scheduled for {self.eddn.REPLAY_STARTUP_DELAY}ms from now"
         )
         if not os.getenv("EDMC_NO_UI"):
-            self.eddn.parent.after(self.eddn.REPLAY_STARTUP_DELAY, self.queue_check_and_send, True)
+            self.eddn.parent.winfo_toplevel().after(self.eddn.REPLAY_STARTUP_DELAY, self.queue_check_and_send, True)
 
     def sqlite_queue_v1(self) -> sqlite3.Connection:
         """


### PR DESCRIPTION
# Description
Workaround the `.after()` queue being cleared (or invalidated) when the widget that call was made through is destroyed after that call is made, which in this case resulted in the EDDN queue not being processed until some other action re-triggered processing of the EDDN queue.

# Type of Change
Bug Fix

# How Tested
rinkulu in #2484 confirmed this small fix resulted in the EDDN queue being processed on startup

# Notes
Fixes #2484
