### PR TITLE
[Bugfix] Prefer loadout fuel capacity if valid

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -719,11 +719,18 @@ class EDLogs(FileSystemEventHandler):
                 data_dict = {}
                 for module in entry['Modules']:
                     if module.get('Slot') == 'FuelTank':
-                        cap = module['Item'].split('size')
-                        cap = cap[1].split('_')
-                        cap = 2 ** int(cap[0])
-                        ship = ship_name_map[entry["Ship"]]
-                        fuel = {'Main': cap, 'Reserve': ships[ship]['reserveFuelCapacity']}
+                        fuel = self.state["FuelCapacity"]
+
+                        if fuel["Main"] is None or fuel["Reserve"] is None:
+                            cap = module['Item'].split('size')
+                            cap = cap[1].split('_')
+                            cap = 2 ** int(cap[0])
+                            ship = ship_name_map.get(entry["Ship"])
+                            fuel = {
+                                'Main': cap,
+                                'Reserve': ships.get(ship, {}).get('reserveFuelCapacity', 0.25)
+                            }
+
                         data_dict.update({"FuelCapacity": fuel})
                 data_dict.update({
                     'Ship': entry["Ship"],


### PR DESCRIPTION
# Description
Uses the `FuelCapacity` from the `Loadout` event in the stored SLEF, falling back to calculating the main capacity and taking the reserve capacity if the ship is known.
Fixes a key error when processing the `Loadout` event from the journal when the ship in the loadout is not in the `ship_name_map`

# Type of Change
Bug fix

# Notes
Fixes errors such as those in #2500 when new ships are added to Elite Dangerous, until the new data for these ships are added to EDMC.