### PR TITLE
[Bugfix] Fix System Profiler button on Linux

### DIFF
--- a/prefs.py
+++ b/prefs.py
@@ -63,7 +63,7 @@ def help_open_system_profiler(parent) -> None:
             profiler_path /= 'EDMCSystemProfiler.exe'
             subprocess.run(profiler_path, check=True)
         else:
-            subprocess.run(['python', "EDMCSystemProfiler.py"], shell=True, check=True)
+            subprocess.run(['python', "EDMCSystemProfiler.py"], shell=False, check=True)
     except Exception as err:
         parent.status["text"] = tr.tl("Error in System Profiler")  # LANG: Catch & Record Profiler Errors
         logger.exception(err)


### PR DESCRIPTION
# Description
On Linux when clicking the `Open System Profiler` button you get thrown to a shell when launched from the shell, when launched from the application menu nothing happens. This is fixed by setting `shell` to `False`.
Might make sense to restrict the max line length or wrap it in a new line.

# Example Images
<img width="1762" height="674" alt="Bildschirmfoto_20251113_122459" src="https://github.com/user-attachments/assets/ac5b94d0-a93c-4732-b696-526cc319acf1" />
<img width="1740" height="830" alt="Bildschirmfoto_20251113_122527" src="https://github.com/user-attachments/assets/a61d22eb-faa2-4f8f-bf98-eea837efab01" />


# Type of Change
Bug fix

# How Tested
Tested locally on my Fedora machine. Can somebody test this on Windows? If `shell=True` is needed there we need to add a condition here I think.

# Notes
<!-- Does this resolve any open issues? Was this PR discussed internally somewhere off GitHub? -->
