### PR TITLE
Fix mypy linting issues

### DIFF
--- a/common_utils.py
+++ b/common_utils.py
@@ -29,23 +29,22 @@ def ensure_on_screen(self, parent: tk.Tk):
     :param self: The calling class instance of tk.TopLevel
     :param parent: The parent window
     """
-    if sys.platform != 'win32':
-        return
-    try:
-        # Get monitor info for the monitor containing the parent window
-        monitor = win32api.MonitorFromWindow(parent.winfo_id(), win32con.MONITOR_DEFAULTTONEAREST)
-        monitor_info = win32api.GetMonitorInfo(monitor)
-        work_area = monitor_info['Work']  # Gets the working area (excludes taskbar)
+    if sys.platform == 'win32':
+        try:
+            # Get monitor info for the monitor containing the parent window
+            monitor = win32api.MonitorFromWindow(parent.winfo_id(), win32con.MONITOR_DEFAULTTONEAREST)
+            monitor_info = win32api.GetMonitorInfo(monitor)
+            work_area = monitor_info['Work']  # Gets the working area (excludes taskbar)
 
-        # Calculate optimal position
-        x = max(work_area[0], min(parent.winfo_rootx(), work_area[2] - self.winfo_width()))
-        y = max(work_area[1], min(parent.winfo_rooty(), work_area[3] - self.winfo_height()))
+            # Calculate optimal position
+            x = max(work_area[0], min(parent.winfo_rootx(), work_area[2] - self.winfo_width()))
+            y = max(work_area[1], min(parent.winfo_rooty(), work_area[3] - self.winfo_height()))
 
-        # Update window position
-        self.geometry(f"+{x}+{y}")
+            # Update window position
+            self.geometry(f"+{x}+{y}")
 
-    except Exception as e:
-        logger.debug(f"Failed to ensure window is on screen: {e}")
+        except Exception as e:
+            logger.debug(f"Failed to ensure window is on screen: {e}")
 
 
 def log_locale(prefix: str) -> None:

--- a/config/linux.py
+++ b/config/linux.py
@@ -75,7 +75,7 @@ class LinuxConfigMinimal:
 
     def close(self) -> None:
         """Release resources (stub)."""
-        self.config = None
+        del self.config
 
 
 def linux_helper(config: Config) -> Config:

--- a/myNotebook.py
+++ b/myNotebook.py
@@ -50,10 +50,18 @@ class Label(ttk.Label):
     """Custom ttk.Label class to fix some display issues."""
 
     def __init__(self, master: ttk.Frame | None = None, **kw):
-        kw['foreground'] = kw.pop('foreground', PAGEFG if sys.platform == 'win32'
-                                  else ttk.Style().lookup('TLabel', 'foreground'))
-        kw['background'] = kw.pop('background', PAGEBG if sys.platform == 'win32'
-                                  else ttk.Style().lookup('TLabel', 'background'))
+        if sys.platform == 'win32':
+            fg_color = PAGEFG
+        else:
+            fg_color = ttk.Style().lookup('TLabel', 'foreground')
+
+        if sys.platform == 'win32':
+            bg_color = PAGEBG
+        else:
+            bg_color = ttk.Style().lookup('TLabel', 'background')
+
+        kw['foreground'] = kw.pop('foreground', fg_color)
+        kw['background'] = kw.pop('background', bg_color)
         super().__init__(master, **kw)
 
 

--- a/prefs.py
+++ b/prefs.py
@@ -310,6 +310,11 @@ class PreferencesDialog(tk.Toplevel):
         self.cmdrchanged()
         self.themevarchanged()
 
+        # Init hotkey attributes to avoid linter errors
+        self.hotkey_text: ttk.Entry
+        self.hotkey_only_btn: nb.Checkbutton
+        self.hotkey_play_btn: nb.Checkbutton
+
         # disable hotkey for the duration
         hotkeymgr.unregister()
 

--- a/util_ships.py
+++ b/util_ships.py
@@ -6,6 +6,7 @@ Licensed under the GNU General Public License.
 See LICENSE file.
 """
 import os
+import sys
 from pathlib import Path
 from edmc_data import ship_name_map
 
@@ -18,7 +19,7 @@ def ship_file_name(ship_name: str, ship_type: str) -> str:
     name = Path(name).with_suffix("").name
 
     # Check if the name is a reserved filename
-    if os.path.isreserved(name):
+    if sys.platform == 'win32' and os.path.isreserved(name):
         name += "_"
 
     return name.translate(


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
Fix some linting errors, particularly when developing on linux.

Using the mypy linter as described in Contributing.md reported several issues. They mostly seem to be related to things only defined on win32 platforms, so I've adjusted the `if sys.platform == 'win32'` logic in a few places so that these issues no longer prevent using the pre-commit hook.

# Type of Change
Bugfix, but only affects developers.

# How Tested
I've been running EDMC with these changes for a few days, and all appears fine. Changes are minor and should only affect linting, with the exception of the change to `util_ships.py`, which prevents an error caused by `os.path.isreserved()` not existing on posix systems.