### PR TITLE
Fix preference dialog not detecting tab change events

### DIFF
--- a/myNotebook.py
+++ b/myNotebook.py
@@ -14,6 +14,7 @@ import tkinter as tk
 from tkinter import ttk, messagebox
 from PIL import ImageGrab
 from l10n import translations as tr
+from typing import Callable
 
 if sys.platform == 'win32':
     PAGEFG = 'SystemWindowText'
@@ -171,6 +172,7 @@ class ScrollableNotebook(Notebook):
         self,
         master: ttk.Frame | None = None,
         tabmenu: bool = False,
+        on_tab_change: Callable | None = None,
         *args,
         **kwargs
     ) -> None:
@@ -191,6 +193,8 @@ class ScrollableNotebook(Notebook):
         self.notebookTab: ttk.Notebook = ttk.Notebook(self, **kwargs)
         self.notebookTab.place(x=0, y=0)
         self.notebookTab.bind("<<NotebookTabChanged>>", self._tab_changer)
+        if on_tab_change:
+            self.notebookTab.bind("<<NotebookTabChanged>>", on_tab_change, add='+')
 
         # Sliding frame and controls
         slide_frame: ttk.Frame = ttk.Frame(self)

--- a/prefs.py
+++ b/prefs.py
@@ -276,8 +276,7 @@ class PreferencesDialog(tk.Toplevel):
         frame.rowconfigure(0, weight=1)
         frame.rowconfigure(1, weight=0)
 
-        notebook: nb.ScrollableNotebook = nb.ScrollableNotebook(frame, tabmenu=True)
-        notebook.bind('<<NotebookTabChanged>>', self.tabchanged)  # Recompute on tab change
+        notebook: nb.ScrollableNotebook = nb.ScrollableNotebook(frame, tabmenu=True, on_tab_change=self.tabchanged)
 
         self.PADX = 10
         self.BUTTONX = 12  # indent Checkbuttons and Radiobuttons


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
Fix the detection of tab changes in the settings dialog, and makes the journal/output directory paths display again.

# Type of Change
Bugfix. Fixes #2541.

# How Tested
Restarted the app and opened the dialog several times. Ran linters and pytest.