### PR TITLE
Localize authentication success message

### DIFF
--- a/L10n/en.template
+++ b/L10n/en.template
@@ -33,6 +33,12 @@
 /* companion.py: Failed to get Access Token from Frontier Auth service; In files: companion.py:508; */
 "Error: unable to get token" = "Error: unable to get token";
 
+/* companion.py: Messagebox title authentication successful; In files: companion.py:672; */
+"Authentication Successful" = "Authentication Successful";
+
+/* companion.py: Messagebox body after successful CAPI authentication; In files: companion.py:676; */
+"Authentication with cAPI Successful.{CR}You may now close the Frontier login tab if it is still open." = "Authentication with cAPI Successful.{CR}You may now close the Frontier login tab if it is still open.";
+
 /* EDMarketConnector.py: EDMC Critical Error Notification; */
 "EDMC encountered a critical error, and cannot recover. EDMC is shutting down for its own protection!" = "EDMC encountered a critical error, and cannot recover. EDMC is shutting down for its own protection!";
 

--- a/companion.py
+++ b/companion.py
@@ -668,9 +668,13 @@ class Session:
             self.auth = None
             raise  # Bad thing happened
         if IS_FROZEN:
-            tk.messagebox.showinfo(title="Authentication Successful",  # type: ignore
-                                   message="Authentication with cAPI Successful.\n"
-                                           "You may now close the Frontier login tab if it is still open.")
+            tk.messagebox.showinfo(  # type: ignore
+                title=tr.tl("Authentication Successful"),
+                message=tr.tl(
+                    "Authentication with cAPI Successful.{CR}"
+                    "You may now close the Frontier login tab if it is still open."
+                ).format(CR="\n")
+            )
 
     def close(self) -> None:
         """Close the `request.Session()."""

--- a/companion.py
+++ b/companion.py
@@ -669,11 +669,11 @@ class Session:
             raise  # Bad thing happened
         if IS_FROZEN:
             tk.messagebox.showinfo(  # type: ignore
-                title=tr.tl("Authentication Successful"),
+                title=tr.tl("Authentication Successful"),  # LANG: Messagebox title authentication successful
                 message=tr.tl(
                     "Authentication with cAPI Successful.{CR}"
                     "You may now close the Frontier login tab if it is still open."
-                ).format(CR="\n")
+                ).format(CR="\n")  # LANG: Messagebox body after successful CAPI authentication
             )
 
     def close(self) -> None:


### PR DESCRIPTION
# Description

This PR replaces hardcoded English strings in the Frontier authentication success dialog with translatable strings using the existing `l10n` translation system. The authentication message shown after successful CAPI authorization (`companion.py` line ~670) will now be properly localized based on the user's language preference.

**Key changes:**
- Replaced hardcoded `title` and `message` strings with `tr.tl()` calls
- Implemented a `{CR}` placeholder for the newline character, allowing translators to position line breaks appropriately for their language
- Applied PEP8 formatting standards with proper indentation and comment placement

**Technical approach:**
The translation key contains `{CR}` as a placeholder, which is replaced with `\n` after translation using `.format()`. This ensures:
1. Translation keys remain clean without escape sequences
2. Translators can reposition the line break as needed for different languages
3. The translation system correctly matches keys in `.strings` files

# Example Images

*N/A - This is a localization change with no visual modifications to the UI layout or styling.*

# Type of Change

**Translation Update / Localization Enhancement**

This enables existing UI elements to be properly localized without altering functionality or behavior.

# How Tested

**Code verification:**
- ✅ Confirmed `tr` (translations module) is imported at line 36 of `companion.py`
- ✅ Verified the pattern follows existing `tr.tl()` usage throughout the codebase (error messages, warnings, etc.)
- ✅ Validated that `.format(CR="\n")` correctly substitutes the placeholder after translation
- ✅ Checked PEP8 compliance: proper indentation (4 spaces), line length (<120 chars), comment placement

**Fallback behavior:**
- The `l10n` system automatically falls back to English if translations are missing, ensuring zero breaking changes for existing users
- Translation keys are structured to work with the existing `.strings` file format used by EDMC

**Pattern consistency:**
- Reviewed similar translation implementations in `companion.py` (lines with `tr.tl("Error: ...")`)
- Verified `{CR}` placeholder approach is compatible with Python's `.format()` method
- Confirmed type hint comment `# type: ignore` placement matches project conventions

# Notes

**Translation keys added:**
```
"Authentication Successful"
"Authentication with cAPI Successful.{CR}You may now close the Frontier login tab if it is still open."
```

**For translators:**
- The `{CR}` placeholder represents a line break and should be preserved in translations
- Translators can reposition `{CR}` as appropriate for their language's sentence structure
- Example Italian translation:
  ```
  "Authentication with cAPI Successful.{CR}You may now close the Frontier login tab if it is still open." = "Autenticazione con cAPI riuscita.{CR}Ora puoi chiudere la scheda di login Frontier se è ancora aperta.";
  ```

**Compatibility:**
- ✅ Backward compatible: Users without language-specific translations will see the original English text
- ✅ No dependencies added: Uses existing `l10n` infrastructure
- ✅ No logic changes: Only affects display strings, not authentication flow

**Future work:**
Translation maintainers will need to add corresponding entries to language-specific `.strings` files (e.g., `it.strings`, `de.strings`, `fr.strings`, etc.) to provide localized versions of these messages.

---

The change was committed to the correct source branch (GLWine\develop), and the pull request was opened against the correct target branch (EDCD\develop). The old PR #2614 has been closed in favor of this one.

---

Attention: @Rixxan