### PR TITLE
[#2668] Refactor Winsparkle Code

### DIFF
--- a/update.py
+++ b/update.py
@@ -18,7 +18,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from tkinter import messagebox
 from traceback import print_exc
-from typing import TYPE_CHECKING, cast, Any
+from typing import TYPE_CHECKING
 from xml.etree import ElementTree
 import requests
 import semantic_version
@@ -28,6 +28,9 @@ from l10n import translations as tr
 
 if TYPE_CHECKING:
     import tkinter as tk
+
+if sys.platform == "win32":
+    import winsparkle
 
 logger = get_main_logger()
 
@@ -220,11 +223,11 @@ class Updater:
         self.root: tk.Tk | None = tkroot
         self.provider: str = provider
         self.thread: threading.Thread | None = None
-        self.updater: Any | None = None  # ensure attribute exists
 
         if not self.use_internal() and sys.platform == 'win32':
             self._init_winsparkle()
-            self.set_automatic_updates_check(config.get_bool("core_updater_disable_in_game", default=False))
+            disable_in_game = config.get_bool("core_updater_disable_in_game", default=False)
+            winsparkle.set_automatic_check_for_updates(disable_in_game)
 
     def start_check_thread(self) -> None:
         """Start the background update worker thread safely."""
@@ -236,8 +239,8 @@ class Updater:
             )
             self.thread.start()
         else:
-            if sys.platform == 'win32' and self.updater:
-                self.updater.win_sparkle_check_update_with_ui()
+            if sys.platform == 'win32':
+                winsparkle.check_update_with_ui()
 
         # Always trigger FDEV checks here too
         check_for_fdev_updates()
@@ -257,30 +260,20 @@ class Updater:
         return self.provider == 'internal'
 
     def _init_winsparkle(self) -> None:
-        """Initialize WinSparkle updater for Windows."""
-        import ctypes
+        """Initialize WinSparkle updater for Windows using the winsparkle module."""
         try:
-            self.updater = cast(ctypes.CDLL, ctypes.cdll.WinSparkle)
-            self.updater.win_sparkle_set_appcast_url(get_update_feed().encode())  # Set the appcast URL
+            # Set appversion without build metadata, WinSparkle doesn't do full SemVer Checks.
+            # Does support pre-release due to splitting and string comparison.
+            # https://github.com/vslavik/winsparkle/issues/214
+            winsparkle.set_appcast_url(get_update_feed())
+            winsparkle.set_app_build_version(str(appversion_nobuild()))
+            winsparkle.set_shutdown_request_callback(self.shutdown_request)
 
-            # Set the appversion *without* build metadata, as WinSparkle
-            # doesn't do proper Semantic Version checks.
-            # NB: It 'accidentally' supports pre-release due to how it
-            # splits and compares strings:
-            # <https://github.com/vslavik/winsparkle/issues/214>
-            self.updater.win_sparkle_set_app_build_version(str(appversion_nobuild()))
-
-            # set up shutdown callback
-            self.callback_t = ctypes.CFUNCTYPE(None)  # keep reference
-            self.callback_fn = self.callback_t(self.shutdown_request)
-            self.updater.win_sparkle_set_shutdown_request_callback(self.callback_fn)
-
-            # Get WinSparkle running
-            self.updater.win_sparkle_init()
+            # Fire up the engine
+            winsparkle.init()
 
         except Exception:
             print_exc()
-            self.updater = None
             msg = "Updater Failed to Initialize. Please file a bug report!"
             if not os.getenv("EDMC_NO_UI"):
                 messagebox.showerror(title=appname, message=msg)
@@ -295,17 +288,16 @@ class Updater:
         """
         if self.use_internal():
             return
-
-        if sys.platform == 'win32' and self.updater:
-            self.updater.win_sparkle_set_automatic_check_for_updates(onoroff)
+        if sys.platform == 'win32':
+            winsparkle.set_automatic_check_for_updates(onoroff)
 
     def check_for_updates(self) -> None:
         """Trigger the requisite method to check for an update."""
         if self.use_internal():
             self.thread = threading.Thread(target=self.worker, name='update worker', daemon=True)
             self.thread.start()
-        elif sys.platform == 'win32' and self.updater:
-            self.updater.win_sparkle_check_update_with_ui()
+        elif sys.platform == 'win32':
+            winsparkle.check_update_with_ui()
 
         check_for_fdev_updates()
         check_for_datafile_updates()
@@ -318,7 +310,6 @@ class Updater:
         running version.
         :return: EDMCVersion or None if no newer version found
         """
-        newversion = None
         items = {}
         try:
             request = requests.get(get_update_feed(), timeout=10)
@@ -380,11 +371,15 @@ class Updater:
         status['text'] = tr.tl("{NEWVER} is available").format(NEWVER=newver_title)
         self.root.update_idletasks()
 
-    def get_update_check(self):
-        """Check the current value of the WinSparkle Registry Key."""
-        if sys.platform == 'win32' and self.updater:
-            return self.updater.win_sparkle_set_automatic_check_for_updates()
-        return False
+    def get_update_check(self) -> int:
+        """
+        Check the current value of the WinSparkle Registry Key.
+
+        Guarantees an int return (1 or 0) to keep TOML configuration safe on all platforms.
+        """
+        if sys.platform == 'win32':
+            return winsparkle.get_automatic_check_for_updates()
+        return 0  # Safe integer fallback for Linux/macOS source runs
 
     def close(self) -> None:
         """

--- a/winsparkle.py
+++ b/winsparkle.py
@@ -1,0 +1,100 @@
+"""
+winsparkle.py - Ctypes wrapper for WinSparkle.
+
+Copyright (c) EDCD, All Rights Reserved
+Licensed under the GNU General Public License v2 or later.
+See LICENSE file.
+"""
+import ctypes
+import sys
+from typing import Callable, Any
+
+_dll: Any = None
+
+
+def load_dll() -> bool:
+    """Load the WinSparkle DLL if running on Windows."""
+    global _dll
+    if _dll is not None:
+        return True
+    if sys.platform != 'win32':
+        return False
+    try:
+        # Standard WinSparkle binding
+        _dll = ctypes.cdll.WinSparkle
+        return True
+    except Exception:
+        return False
+
+
+def init() -> None:
+    """Initialize WinSparkle and start update checks."""
+    if load_dll():
+        _dll.win_sparkle_init.restype = None
+        _dll.win_sparkle_init()
+
+
+def set_appcast_url(url: str) -> None:
+    """Set the URL for the application's appcast feed."""
+    if load_dll():
+        _dll.win_sparkle_set_appcast_url.restype = None
+        _dll.win_sparkle_set_appcast_url.argtypes = [ctypes.c_char_p]
+        _dll.win_sparkle_set_appcast_url(url.encode())
+
+
+def set_app_build_version(build_number: str) -> None:
+    """Set the application build version number (without metadata)."""
+    if load_dll():
+        _dll.win_sparkle_set_app_build_version.restype = None
+        _dll.win_sparkle_set_app_build_version.argtypes = [ctypes.c_wchar_p]
+        _dll.win_sparkle_set_app_build_version(build_number)
+
+
+def set_automatic_check_for_updates(state: bool) -> None:
+    """Enable or disable automatic background update checks."""
+    if load_dll():
+        _dll.win_sparkle_set_automatic_check_for_updates.restype = None
+        _dll.win_sparkle_set_automatic_check_for_updates.argtypes = [ctypes.c_int64]
+        _dll.win_sparkle_set_automatic_check_for_updates(1 if state else 0)
+
+
+def get_automatic_check_for_updates() -> int:
+    """
+    Get the current automatic update checking state from the registry.
+
+    Returns 1 if updates are checked automatically, 0 otherwise.
+    """
+    if load_dll():
+        _dll.win_sparkle_get_automatic_check_for_updates.restype = ctypes.c_int64
+        _dll.win_sparkle_get_automatic_check_for_updates.argtypes = None
+
+        # Return the 1 or 0 integer straight from the C DLL
+        return int(_dll.win_sparkle_get_automatic_check_for_updates())
+    return 0
+
+
+def check_update_with_ui() -> None:
+    """Trigger an explicit update check and display the WinSparkle UI."""
+    if load_dll():
+        _dll.win_sparkle_check_update_with_ui.restype = None
+        _dll.win_sparkle_check_update_with_ui()
+
+
+def set_shutdown_request_callback(app_callback: Callable[[], None]) -> None:
+    """
+    Set the callback triggered when WinSparkle needs the app to close for installation.
+
+    Uses function-attribute storage to prevent Python garbage collection.
+    """
+    if not load_dll():
+        return
+
+    prototype = ctypes.CFUNCTYPE(None)
+    ffi_callback = prototype(app_callback)
+
+    # Safely anchor the callback to this function's attributes to prevent GC crashes
+    set_shutdown_request_callback.preserved_callback = ffi_callback  # type: ignore
+
+    _dll.win_sparkle_set_shutdown_request_callback.restype = None
+    _dll.win_sparkle_set_shutdown_request_callback.argtypes = [prototype]
+    _dll.win_sparkle_set_shutdown_request_callback(ffi_callback)


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
Refactors update.py's communication with WinSparkle's DLL on Windows installs. This removes the direct ctypes calls and bindings to their own file. This will make the modules easier to maintain and easier to transport WinSparkle's code to other projects. 

Fixes a bug in the garbage collection of WinSparkle by removing some lower-level memory persistence logic away from the core updater class. 

# Type of Change
<!-- What type of change is this? New Feature? Enhancement to Existing Feature? Bug Fix? Translation Update? -->
Enhancement

# Notes
Resolves #2668 