### PR TITLE
Deprecate obsolete timeout_session

### DIFF
--- a/plugins/inara.py
+++ b/plugins/inara.py
@@ -38,9 +38,8 @@ import edmc_data
 import killswitch
 import myNotebook as nb  # noqa: N813
 import plug
-import timeout_session
 from companion import CAPIData
-from config import applongname, appname, appversion, config, debug_senders
+from config import applongname, appname, appversion, config, debug_senders, user_agent
 from EDMCLogging import get_main_logger
 from monitor import monitor
 from ttkHyperlinkLabel import HyperlinkLabel
@@ -84,7 +83,8 @@ class This:
     """Holds module globals."""
 
     def __init__(self):
-        self.session = timeout_session.new_session()
+        self.session = requests.Session()
+        self.session.headers.setdefault("User-Agent", user_agent)
         self.thread: Thread
         self.parent: tk.Tk
 

--- a/tests/test_timeout_session.py
+++ b/tests/test_timeout_session.py
@@ -3,6 +3,7 @@
 """Test timeout session system."""
 
 from unittest.mock import MagicMock, patch
+import pytest
 from requests import Session
 import timeout_session
 
@@ -11,7 +12,9 @@ class TestTimeoutSession:
 
     def test_adapter_injects_default_timeout(self):
         """Verify the adapter sets the timeout if none is provided in the send call."""
-        adapter = timeout_session.TimeoutAdapter(timeout=42)
+        # Wrap in pytest.warns to assert the deprecation warning is thrown
+        with pytest.warns(DeprecationWarning):
+            adapter = timeout_session.TimeoutAdapter(timeout=42)
 
         # We mock the parent HTTPAdapter.send method
         with patch("requests.adapters.HTTPAdapter.send") as mock_send:
@@ -24,7 +27,8 @@ class TestTimeoutSession:
 
     def test_adapter_respects_explicit_timeout(self):
         """Verify the adapter doesn't override a timeout if the user explicitly provided one."""
-        adapter = timeout_session.TimeoutAdapter(timeout=42)
+        with pytest.warns(DeprecationWarning):
+            adapter = timeout_session.TimeoutAdapter(timeout=42)
 
         with patch("requests.adapters.HTTPAdapter.send") as mock_send:
             # User explicitly wants 5 seconds
@@ -36,7 +40,10 @@ class TestTimeoutSession:
     def test_new_session_configuration(self):
         """Verify that new_session correctly mounts the adapter and sets headers."""
         custom_timeout = 15
-        session = timeout_session.new_session(timeout=custom_timeout)
+
+        # Expecting DeprecationWarnings from both new_session and TimeoutAdapter init
+        with pytest.warns(DeprecationWarning):
+            session = timeout_session.new_session(timeout=custom_timeout)
 
         # Check User-Agent
         assert "User-Agent" in session.headers
@@ -52,7 +59,8 @@ class TestTimeoutSession:
         existing_session = Session()
         existing_session.headers["X-Test"] = "Existing"
 
-        wrapped_session = timeout_session.new_session(session=existing_session)
+        with pytest.warns(DeprecationWarning):
+            wrapped_session = timeout_session.new_session(session=existing_session)
 
         assert wrapped_session.headers["X-Test"] == "Existing"
         assert isinstance(

--- a/timeout_session.py
+++ b/timeout_session.py
@@ -16,7 +16,11 @@ REQUEST_TIMEOUT = 10  # Kept for backwards compatibility
 
 
 class TimeoutAdapter(HTTPAdapter):
-    """DEPRECATED: An HTTP Adapter that enforces an overridable default timeout on HTTP requests."""
+    """
+    DEPRECATED: An HTTP Adapter that enforces an overridable default timeout on HTTP requests.
+
+    This will be removed in a future version (6.3 or later).
+    """
 
     def __init__(self, timeout: int, *args, **kwargs):
         warnings.warn(

--- a/timeout_session.py
+++ b/timeout_session.py
@@ -7,39 +7,43 @@ See LICENSE file.
 """
 from __future__ import annotations
 
+import warnings
 from requests import Session, Response
 from requests.adapters import HTTPAdapter
 from config import user_agent
 
-REQUEST_TIMEOUT = 10  # reasonable timeout that all HTTP requests should use
+REQUEST_TIMEOUT = 10  # Kept for backwards compatibility
 
 
 class TimeoutAdapter(HTTPAdapter):
-    """An HTTP Adapter that enforces an overridable default timeout on HTTP requests."""
+    """DEPRECATED: An HTTP Adapter that enforces an overridable default timeout on HTTP requests."""
 
     def __init__(self, timeout: int, *args, **kwargs):
+        warnings.warn(
+            "TimeoutAdapter is deprecated and will be removed in a future release.",
+            category=DeprecationWarning,
+            stacklevel=2
+        )
         self.default_timeout = timeout
-        if kwargs.get("timeout") is not None:
-            del kwargs["timeout"]
-
+        kwargs.pop("timeout", None)
         super().__init__(*args, **kwargs)
 
     def send(self, *args, **kwargs) -> Response:
         """Send, but with a timeout always set."""
-        if kwargs["timeout"] is None:
+        if kwargs.get("timeout") is None:
             kwargs["timeout"] = self.default_timeout
-
         return super().send(*args, **kwargs)
 
 
 def new_session(timeout: int = REQUEST_TIMEOUT, session: Session | None = None) -> Session:
-    """
-    Create a new requests.Session and override the default HTTPAdapter with a TimeoutAdapter.
+    """DEPRECATED: Create a new requests.Session."""
+    warnings.warn(
+        "timeout_session.new_session() is deprecated and will be removed. "
+        "Use requests.Session() directly and pass explicit timeouts to request methods.",
+        category=DeprecationWarning,
+        stacklevel=2
+    )
 
-    :param timeout: the timeout to set the TimeoutAdapter to, defaults to REQUEST_TIMEOUT
-    :param session: the Session object to attach the Adapter to, defaults to a new session
-    :return: The created Session
-    """
     session = session or Session()
     session.headers.setdefault("User-Agent", user_agent)
 


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
This PR deprecates the existing `timeout_session.py` module. This module isn't realistically needed, and only adds boilerplate that isn't needed for our current implementations. 

The timeout_session module was first added in the mid-2020s as a workaround to `Requests` library's intentional lack of global or session-level default timeout configurations. Thus, the `TimeoutAdapter(HTTPAdapter)` class was implemented to intercept and enforce a 10-second fallback. 

This code, however, was never really in true use. The legacy worker thread loop and current `send_data()` functions have always passed `_TIMEOUT` explicitly, as part of the `post()` calls. Because it was always there, the `if kwargs["timeout"] is None:` condition has always evaluated to False, and the adapter's fallback has never been triggered. This makes the module effectively obsolete. 

The deprecated code will be removed in 6.3 or later.

# Type of Change
<!-- What type of change is this? New Feature? Enhancement to Existing Feature? Bug Fix? Translation Update? -->
Refactor
