### PR TITLE
Download & Install from plugins browser

### DIFF
--- a/plugin_browser.py
+++ b/plugin_browser.py
@@ -26,6 +26,7 @@ from EDMCLogging import get_main_logger
 from l10n import translations as tr
 from ttkHyperlinkLabel import HyperlinkLabel
 import semantic_version
+import shutil
 
 logger = get_main_logger()
 
@@ -89,17 +90,26 @@ class PluginBrowserMixIn:
     def dev_install_plugin(self, plugin) -> None:
         """Downloads a plugin from the URL at pluginZip and extracts it to the EDMC plugin folder"""
         # print("Install", plugin.get("pluginName")) # replace this with a user popup?
-        plugin_filename = plugin.get("pluginZip").split("/")[-1]
-        logger.info(f"Downloading {plugin.get("pluginName")} to {plugin_filename}")
+        plugin_name = plugin.get("pluginName")
+        plugin_zipname = plugin.get("pluginZip").split("/")[-1]
+        plugin_zip_destination = f"{config.plugin_dir}/{plugin_zipname}"
+        plugin_files_destination = f"{config.plugin_dir}/{plugin_name}"
+
+        logger.info(f"Downloading {plugin_name} to {plugin_zipname}")
+
         with requests.get(plugin.get("pluginZip"), stream=True) as r:
             r.raise_for_status() # needs to be an EDMC error handler
-            with open(f"{config.plugin_dir}/{plugin_filename}", "wb") as f:
+            with open(f"{config.plugin_dir}/{plugin_zipname}", "wb") as f:
                 for chunk in r.iter_content(chunk_size=8192): 
+                    #Save to file in chunks, avoids loading the whole thing into memory
                     f.write(chunk)
-        logger.info(f"Download complete for {plugin_filename}, installing...")
 
+        #Extract to folder
+        logger.info(f"Download complete for {plugin_zipname}, installing...")
+        shutil.unpack_archive(plugin_zip_destination, plugin_files_destination)
+        logger.info(f"Unpacked plugin to {plugin_files_destination}, restart EDMC to enable it.")
 
-    #
+    
     # def dev_uninstall_plugin(self, plugin) -> None:
     #     """TEMP."""
     #     print("Uninstall", plugin.get("pluginName"))

--- a/plugin_browser.py
+++ b/plugin_browser.py
@@ -86,9 +86,19 @@ class PluginBrowserMixIn:
         self.selected_plugin: dict | None = None
         self._plugin_last_tested_label: nb.Label | None = None
 
-    # def dev_install_plugin(self, plugin) -> None:
-    #     """TEMP."""
-    #     print("Install", plugin.get("pluginName"))
+    def dev_install_plugin(self, plugin) -> None:
+        """Downloads a plugin from the URL at pluginZip and extracts it to the EDMC plugin folder"""
+        # print("Install", plugin.get("pluginName")) # replace this with a user popup?
+        plugin_filename = plugin.get("pluginZip").split("/")[-1]
+        logger.info(f"Downloading {plugin.get("pluginName")} to {plugin_filename}")
+        with requests.get(plugin.get("pluginZip"), stream=True) as r:
+            r.raise_for_status() # needs to be an EDMC error handler
+            with open(f"{config.plugin_dir}/{plugin_filename}", "wb") as f:
+                for chunk in r.iter_content(chunk_size=8192): 
+                    f.write(chunk)
+        logger.info(f"Download complete for {plugin_filename}, installing...")
+
+
     #
     # def dev_uninstall_plugin(self, plugin) -> None:
     #     """TEMP."""
@@ -297,6 +307,10 @@ class PluginBrowserMixIn:
                 # LANG: Open Plugin Repo
                 tr.tl("Open Plugin Repository"),
                 open_plugin_main,
+            ),
+            (
+                "Download",
+                self.dev_install_plugin
             ),
             # ("Install", self.dev_install_plugin),  # Upcoming Feature
             # ("Uninstall", self.dev_uninstall_plugin),  # Upcoming Feature

--- a/plugin_browser.py
+++ b/plugin_browser.py
@@ -98,18 +98,19 @@ class PluginBrowserMixIn:
         logger.info(f"Downloading {plugin_name} to {plugin_zipname}")
 
         with requests.get(plugin.get("pluginZip"), stream=True) as r:
-            r.raise_for_status() # needs to be an EDMC error handler
+            r.raise_for_status()  # needs to be an EDMC error handler
             with open(f"{config.plugin_dir}/{plugin_zipname}", "wb") as f:
-                for chunk in r.iter_content(chunk_size=8192): 
-                    #Save to file in chunks, avoids loading the whole thing into memory
+                for chunk in r.iter_content(chunk_size=8192):
+                    # Save to file in chunks, avoids loading the whole thing into memory
                     f.write(chunk)
 
-        #Extract to folder
-        logger.info(f"Download complete for {plugin_zipname}, installing...")
+        # Extract to folder
+        logger.info(f"Download complete for '{plugin_zipname}', installing...")
         shutil.unpack_archive(plugin_zip_destination, plugin_files_destination)
-        logger.info(f"Unpacked plugin to {plugin_files_destination}, restart EDMC to enable it.")
+        logger.info(
+            f"Unpacked plugin to '{plugin_files_destination}', restart EDMC to enable it."
+        )
 
-    
     # def dev_uninstall_plugin(self, plugin) -> None:
     #     """TEMP."""
     #     print("Uninstall", plugin.get("pluginName"))
@@ -195,9 +196,11 @@ class PluginBrowserMixIn:
         )
 
         # Configure row height to prevent text clipping
-        row_font = tkfont.Font(family='TkDefaultFont')
+        row_font = tkfont.Font(family="TkDefaultFont")
         style = ttk.Style()
-        style.configure("Treeview", rowheight=int(row_font.metrics()['linespace'] * 1.1))
+        style.configure(
+            "Treeview", rowheight=int(row_font.metrics()["linespace"] * 1.1)
+        )
 
         self.plugins_tree.heading(
             "name",
@@ -318,10 +321,7 @@ class PluginBrowserMixIn:
                 tr.tl("Open Plugin Repository"),
                 open_plugin_main,
             ),
-            (
-                "Download",
-                self.dev_install_plugin
-            ),
+            ("Download", self.dev_install_plugin),
             # ("Install", self.dev_install_plugin),  # Upcoming Feature
             # ("Uninstall", self.dev_uninstall_plugin),  # Upcoming Feature
             # ("Update", self.dev_update_plugin),  # Upcoming Feature


### PR DESCRIPTION
Added `dev_install_plugin` in `plugin_browser.py`, that downloads the .ZIP file provided by the plugin registry to the user plugins folder.
Still needs a few things tweaking (I think you have a standard requests object? and more user visible logging would be good) but this is just a first past. 
