### PR TITLE
Hand off custom journal lock to filelock package

### DIFF
--- a/journal_lock.py
+++ b/journal_lock.py
@@ -7,6 +7,7 @@ See LICENSE file.
 """
 from __future__ import annotations
 
+import os
 import pathlib
 import sys
 import tkinter as tk
@@ -14,6 +15,7 @@ from enum import Enum
 from os import getpid as os_getpid
 from tkinter import ttk
 from collections.abc import Callable
+from filelock import FileLock, Timeout
 from l10n import translations as tr
 from config import config
 from EDMCLogging import get_main_logger
@@ -32,7 +34,7 @@ class JournalLockResult(Enum):
 
 
 class JournalLock:
-    """Handle locking of journal directory."""
+    """Handle locking of journal directory using python-filelock."""
 
     def __init__(self) -> None:
         """Initialise where the journal directory and lock file are."""
@@ -40,37 +42,18 @@ class JournalLock:
         self.journal_dir_path: pathlib.Path | None = None
         self.set_path_from_journaldir()
         self.journal_dir_lockfile_name: pathlib.Path | None = None
-        # We never test truthiness of this, so let it be defined when first assigned.  Avoids type hint issues.
-        # self.journal_dir_lockfile: Optional[IO] = None
+        self.lock: FileLock | None = None
         self.locked = False
 
-    def set_path_from_journaldir(self):
+    def set_path_from_journaldir(self) -> None:
         """Set self.journal_dir_path from self.journal_dir."""
         if self.journal_dir is None:
             self.journal_dir_path = None
-
         else:
             try:
                 self.journal_dir_path = pathlib.Path.expanduser(pathlib.Path(self.journal_dir))
-
             except Exception:  # pragma: no cover
                 logger.exception("Couldn't make pathlib.Path from journal_dir")
-
-    def open_journal_dir_lockfile(self) -> bool:
-        """Open journal_dir lockfile ready for locking."""
-        self.journal_dir_lockfile_name = self.journal_dir_path / 'edmc-journal-lock.txt'  # type: ignore
-        logger.trace_if('journal-lock', f'journal_dir_lockfile_name = {self.journal_dir_lockfile_name!r}')
-        try:
-            self.journal_dir_lockfile = open(self.journal_dir_lockfile_name, mode='w+', encoding='utf-8')
-
-        # Linux CIFS read-only mount throws: OSError(30, 'Read-only file system')
-        # Linux no-write-perm directory throws: PermissionError(13, 'Permission denied')
-        except Exception as e:  # For remote FS this could be any of a wide range of exceptions
-            logger.warning(f"Couldn't open \"{self.journal_dir_lockfile_name}\" for \"w+\""
-                           f" Aborting duplicate process checks: {e!r}")
-            return False
-
-        return True
 
     def obtain_lock(self) -> JournalLockResult:
         """
@@ -81,60 +64,31 @@ class JournalLock:
         if self.journal_dir_path is None:
             return JournalLockResult.JOURNALDIR_IS_NONE
 
-        if not self.open_journal_dir_lockfile():
+        self.journal_dir_lockfile_name = self.journal_dir_path / 'edmc-journal-lock.txt'
+        logger.trace_if('journal-lock', f'journal_dir_lockfile_name = {self.journal_dir_lockfile_name!r}')
+
+        # Instantiate filelock engine (abstracts win32/fcntl natively)
+        self.lock = FileLock(self.journal_dir_lockfile_name)
+
+        try:
+            # Immediately fail if another process holds the lock
+            self.lock.acquire(timeout=0)
+
+            # Write PID metadata into the lockfile for transparency
+            with open(self.journal_dir_lockfile_name, mode='w', encoding='utf-8') as f:
+                f.write(f"Path: {self.journal_dir}\nPID: {os_getpid()}\n")
+
+            logger.trace_if('journal-lock', 'Done')
+            self.locked = True
+            return JournalLockResult.LOCKED
+
+        except Timeout:
+            logger.info(f"Couldn't lock journal directory \"{self.journal_dir}\", assuming another process running.")
+            return JournalLockResult.ALREADY_LOCKED
+        except (PermissionError, OSError) as e:
+            logger.warning(f"Couldn't open/lock \"{self.journal_dir_lockfile_name}\". "
+                           f"Aborting duplicate process checks: {e!r}")
             return JournalLockResult.JOURNALDIR_READONLY
-
-        return self._obtain_lock()
-
-    def _obtain_lock(self) -> JournalLockResult:
-        """
-        Actual code for obtaining a lock.
-
-        This is split out so tests can call *just* it, without the attempt
-        at opening the file.  If we call open_journal_dir_lockfile() we
-        re-use self.journal_dir_lockfile and in the process close the
-        previous handle stored in it and thus release the lock.
-
-        :return: LockResult - See the class Enum definition
-        """
-        if sys.platform == 'win32':  # pragma: sys-platform-win32
-            logger.trace_if('journal-lock', 'win32, using msvcrt')
-            # win32 doesn't have fcntl, so we have to use msvcrt
-            import msvcrt
-
-            try:
-                msvcrt.locking(self.journal_dir_lockfile.fileno(), msvcrt.LK_NBLCK, 4096)
-
-            except Exception as e:
-                logger.info(f"Exception: Couldn't lock journal directory \"{self.journal_dir}\""
-                            f", assuming another process running: {e!r}")
-                return JournalLockResult.ALREADY_LOCKED
-
-        else:  # pragma: sys-platform-not-win32
-            logger.trace_if('journal-lock', 'NOT win32, using fcntl')
-            try:
-                import fcntl
-
-            except ImportError:
-                logger.warning("Not on win32 and we have no fcntl, can't use a file lock!"
-                               "Allowing multiple instances!")
-                return JournalLockResult.LOCKED
-
-            try:
-                fcntl.flock(self.journal_dir_lockfile, fcntl.LOCK_EX | fcntl.LOCK_NB)
-
-            except Exception as e:
-                logger.info(f"Exception: Couldn't lock journal directory \"{self.journal_dir}\", "
-                            f"assuming another process running: {e!r}")
-                return JournalLockResult.ALREADY_LOCKED
-
-        self.journal_dir_lockfile.write(f"Path: {self.journal_dir}\nPID: {os_getpid()}\n")
-        self.journal_dir_lockfile.flush()
-
-        logger.trace_if('journal-lock', 'Done')
-        self.locked = True
-
-        return JournalLockResult.LOCKED
 
     def release_lock(self) -> bool:
         """
@@ -142,56 +96,24 @@ class JournalLock:
 
         :return: bool - Whether we're now unlocked.
         """
-        if not self.locked:
+        if not self.locked or not self.lock:
             return True  # We weren't locked, and still aren't
 
-        unlocked = False
-        if sys.platform == 'win32':  # pragma: sys-platform-win32
-            logger.trace_if('journal-lock', 'win32, using msvcrt')
-            # win32 doesn't have fcntl, so we have to use msvcrt
-            import msvcrt
+        try:
+            self.lock.release()
+            self.locked = False
 
-            try:
-                # Need to seek to the start first, as lock range is relative to
-                # current position
-                self.journal_dir_lockfile.seek(0)
-                msvcrt.locking(self.journal_dir_lockfile.fileno(), msvcrt.LK_UNLCK, 4096)
+            # Physically remove the lockfile from disk on a clean exit
+            if self.journal_dir_lockfile_name and self.journal_dir_lockfile_name.exists():
+                try:
+                    os.remove(self.journal_dir_lockfile_name)
+                except Exception:
+                    pass  # Prevent crashing if a file hook holds it open briefly during shutdown
 
-            except Exception as e:
-                logger.info(f"Exception: Couldn't unlock journal directory \"{self.journal_dir}\": {e!r}")
-
-            else:
-                unlocked = True
-
-        else:  # pragma: sys-platform-not-win32
-            logger.trace_if('journal-lock', 'NOT win32, using fcntl')
-            try:
-                import fcntl
-
-            except ImportError:
-                logger.warning("Not on win32 and we have no fcntl, can't use a file lock!")
-                return True  # Lie about being unlocked
-
-            try:
-                fcntl.flock(self.journal_dir_lockfile, fcntl.LOCK_UN)
-
-            except Exception as e:
-                logger.info(f"Exception: Couldn't unlock journal directory \"{self.journal_dir}\": {e!r}")
-
-            else:
-                unlocked = True
-
-        # Close the file whether or not the unlocking succeeded.
-        if hasattr(self, 'journal_dir_lockfile'):
-            self.journal_dir_lockfile.close()
-
-        # Doing this makes it impossible for tests to ensure the file
-        # is removed as a part of cleanup.  So don't.
-        # self.journal_dir_lockfile_name = None
-        # Avoids type hint issues, see 'declaration' in JournalLock.__init__()
-        # self.journal_dir_lockfile = None
-
-        return unlocked
+            return True
+        except Exception as e:
+            logger.info(f"Exception: Couldn't unlock journal directory \"{self.journal_dir}\": {e!r}")
+            return False
 
     class JournalAlreadyLocked(tk.Toplevel):  # pragma: no cover
         """Pop-up for when Journal directory already locked."""

--- a/journal_lock.py
+++ b/journal_lock.py
@@ -71,12 +71,25 @@ class JournalLock:
         self.lock = FileLock(self.journal_dir_lockfile_name)
 
         try:
+            # Write PID metadata into the lockfile for transparency
+            try:
+                with open(self.journal_dir_lockfile_name, mode='w', encoding='utf-8') as f:
+                    f.write(f"Path: {self.journal_dir}\nPID: {os_getpid()}\n")
+            except (PermissionError, OSError):
+                try:
+                    self.lock.acquire(timeout=0)
+                    logger.trace_if('journal-lock', 'Done')
+                    self.locked = True
+                    return JournalLockResult.LOCKED
+                except Timeout:
+                    logger.info(f"Couldn't lock journal directory \"{self.journal_dir}\","
+                                f" assuming another process running.")
+                    return JournalLockResult.ALREADY_LOCKED
+                except (PermissionError, OSError):
+                    return JournalLockResult.JOURNALDIR_READONLY
+
             # Immediately fail if another process holds the lock
             self.lock.acquire(timeout=0)
-
-            # Write PID metadata into the lockfile for transparency
-            with open(self.journal_dir_lockfile_name, mode='w', encoding='utf-8') as f:
-                f.write(f"Path: {self.journal_dir}\nPID: {os_getpid()}\n")
 
             logger.trace_if('journal-lock', 'Done')
             self.locked = True

--- a/journal_lock.py
+++ b/journal_lock.py
@@ -55,6 +55,18 @@ class JournalLock:
             except Exception:  # pragma: no cover
                 logger.exception("Couldn't make pathlib.Path from journal_dir")
 
+    def open_journal_dir_lockfile(self) -> bool:
+        """Open journal_dir lockfile ready for locking."""
+        self.journal_dir_lockfile_name = self.journal_dir_path / 'edmc-journal-lock.txt'  # type: ignore
+        logger.trace_if('journal-lock', f'journal_dir_lockfile_name = {self.journal_dir_lockfile_name!r}')
+        try:
+            self.lock = FileLock(self.journal_dir_lockfile_name)
+            return True
+        except Exception as e:
+            logger.warning(f"Couldn't prepare lockfile \"{self.journal_dir_lockfile_name}\". "
+                           f"Aborting duplicate process checks: {e!r}")
+            return False
+
     def obtain_lock(self) -> JournalLockResult:
         """
         Attempt to obtain a lock on the journal directory.
@@ -64,44 +76,40 @@ class JournalLock:
         if self.journal_dir_path is None:
             return JournalLockResult.JOURNALDIR_IS_NONE
 
-        self.journal_dir_lockfile_name = self.journal_dir_path / 'edmc-journal-lock.txt'
-        logger.trace_if('journal-lock', f'journal_dir_lockfile_name = {self.journal_dir_lockfile_name!r}')
+        if not self.open_journal_dir_lockfile():
+            return JournalLockResult.JOURNALDIR_READONLY
+        return self._obtain_lock()
 
-        # Instantiate filelock engine (abstracts win32/fcntl natively)
-        self.lock = FileLock(self.journal_dir_lockfile_name)
+    def _obtain_lock(self) -> JournalLockResult:
+        """
+        Obtain the lock.
+
+        :return: LockResult - See the class Enum definition
+        """
+        if not self.lock:
+            return JournalLockResult.JOURNALDIR_READONLY
 
         try:
-            # Write PID metadata into the lockfile for transparency
-            try:
-                with open(self.journal_dir_lockfile_name, mode='w', encoding='utf-8') as f:
-                    f.write(f"Path: {self.journal_dir}\nPID: {os_getpid()}\n")
-            except (PermissionError, OSError):
-                try:
-                    self.lock.acquire(timeout=0)
-                    logger.trace_if('journal-lock', 'Done')
-                    self.locked = True
-                    return JournalLockResult.LOCKED
-                except Timeout:
-                    logger.info(f"Couldn't lock journal directory \"{self.journal_dir}\","
-                                f" assuming another process running.")
-                    return JournalLockResult.ALREADY_LOCKED
-                except (PermissionError, OSError):
-                    return JournalLockResult.JOURNALDIR_READONLY
-
             # Immediately fail if another process holds the lock
             self.lock.acquire(timeout=0)
-
-            logger.trace_if('journal-lock', 'Done')
-            self.locked = True
-            return JournalLockResult.LOCKED
-
         except Timeout:
             logger.info(f"Couldn't lock journal directory \"{self.journal_dir}\", assuming another process running.")
             return JournalLockResult.ALREADY_LOCKED
         except (PermissionError, OSError) as e:
-            logger.warning(f"Couldn't open/lock \"{self.journal_dir_lockfile_name}\". "
-                           f"Aborting duplicate process checks: {e!r}")
+            # Catches read-only filesystems or directory permission denials natively via filelock
+            logger.warning(f"Couldn't acquire lock on \"{self.journal_dir_lockfile_name}\": {e!r}")
             return JournalLockResult.JOURNALDIR_READONLY
+
+        # Write PID metadata into the lockfile after successful lock
+        try:
+            with open(self.journal_dir_lockfile_name, mode='w', encoding='utf-8') as f:  # type: ignore
+                f.write(f"Path: {self.journal_dir}\nPID: {os_getpid()}\n")
+        except Exception as e:
+            # If writing metadata fails but the OS lock is held, log it but keep going
+            logger.warning(f"Lock acquired, but couldn't write PID metadata: {e!r}")
+        logger.trace_if('journal-lock', 'Done')
+        self.locked = True
+        return JournalLockResult.LOCKED
 
     def release_lock(self) -> bool:
         """

--- a/monitor.py
+++ b/monitor.py
@@ -13,7 +13,7 @@ import queue
 import re
 import sys
 import threading
-from calendar import timegm
+from datetime import datetime
 from collections import defaultdict
 from os import SEEK_END, SEEK_SET, listdir
 from os.path import basename, expanduser, getctime, isdir, join
@@ -620,7 +620,7 @@ class EDLogs(FileSystemEventHandler):
                 self.state['MarketID'] = None
                 self.state['StationType'] = None
                 self.stationservices = None
-                self.started = timegm(strptime(entry['timestamp'], '%Y-%m-%dT%H:%M:%SZ'))
+                self.started = int(datetime.fromisoformat(entry['timestamp']).timestamp())
                 # Don't set Ship, ShipID etc since this will reflect Fighter or SRV if starting in those
                 self.state.update({
                     'Captain':              None,

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ semantic-version==2.10.0
 pywin32==311; sys_platform == 'win32'
 psutil==7.2.2
 tomli-w==1.2.0
+filelock==3.29.0

--- a/tests/journal_lock.py/test_journal_lock.py
+++ b/tests/journal_lock.py/test_journal_lock.py
@@ -7,10 +7,9 @@ from __future__ import annotations
 import multiprocessing as mp
 import os
 import pathlib
-import sys
 from collections.abc import Generator
 import pytest
-from pytest import MonkeyPatch, TempdirFactory, TempPathFactory
+from pytest import MonkeyPatch
 from config import config
 from journal_lock import JournalLock, JournalLockResult
 
@@ -28,91 +27,41 @@ def other_process_lock(continue_q: mp.Queue, exit_q: mp.Queue, lockfile: pathlib
     :param exit_q: When there's an item in this, exit.
     :param lockfile: Path where the lockfile should be.
     """
-    with open(lockfile / "edmc-journal-lock.txt", mode="w+") as lf:
-        print(f"sub-process: Opened {lockfile} for read...")
-        # This needs to be kept in sync with journal_lock.py:_obtain_lock()
-        if not _obtain_lock("sub-process", lf):
-            print("sub-process: Failed to get lock, so returning")
-            return
+    from filelock import FileLock
+    lock_path = lockfile / "edmc-journal-lock.txt"
+    lock = FileLock(lock_path)
 
+    try:
+        lock.acquire(timeout=0)
         print("sub-process: Got lock, telling main process to go...")
         continue_q.put("go", timeout=5)
         # Wait for signal to exit
         print("sub-process: Waiting for exit signal...")
         exit_q.get(block=True, timeout=None)
 
-        # And clean up
-        _release_lock("sub-process", lf)
-        os.unlink(lockfile / "edmc-journal-lock.txt")
-
-
-def _obtain_lock(prefix: str, filehandle) -> bool:
-    """
-    Obtain the JournalLock.
-
-    :param prefix: str - what to prefix output with.
-    :param filehandle: File handle already open on the lockfile.
-    :return: bool - True if we obtained the lock.
-    """
-    if sys.platform == "win32":
-        print(f"{prefix}: On win32")
-        import msvcrt
-
+        lock.release()
+    except Exception as e:
+        print(f"sub-process: Failed execution handle context: {e!r}")
+    finally:
         try:
-            print(f"{prefix}: Trying msvcrt.locking() ...")
-            msvcrt.locking(filehandle.fileno(), msvcrt.LK_NBLCK, 4096)
-
-        except Exception as e:
-            print(f"{prefix}: Unable to lock file: {e!r}")
-            return False
-
-    else:
-        import fcntl
-
-        print(f"{prefix}: Not win32, using fcntl")
-        try:
-            fcntl.flock(filehandle, fcntl.LOCK_EX | fcntl.LOCK_NB)
-
-        except Exception as e:
-            print(f"{prefix}: Unable to lock file: {e!r}")
-            return False
-
-    return True
+            if lock_path.exists():
+                os.unlink(lock_path)
+        except Exception:
+            pass
 
 
-def _release_lock(prefix: str, filehandle) -> bool:
-    """
-    Release the JournalLock.
-
-    :param prefix: str - what to prefix output with.
-    :param filehandle: File handle already open on the lockfile.
-    :return: bool - True if we released the lock.
-    """
-    if sys.platform == "win32":
-        print(f"{prefix}: On win32")
-        import msvcrt
-
-        try:
-            print(f"{prefix}: Trying msvcrt.locking() ...")
-            filehandle.seek(0)
-            msvcrt.locking(filehandle.fileno(), msvcrt.LK_UNLCK, 4096)
-
-        except Exception as e:
-            print(f"{prefix}: Unable to unlock file: {e!r}")
-            return False
-
-    else:
-        import fcntl
-
-        print(f"{prefix}: Not win32, using fcntl")
-        try:
-            fcntl.flock(filehandle, fcntl.LOCK_UN)
-
-        except Exception as e:
-            print(f"{prefix}: Unable to unlock file: {e!r}")
-            return False
-
-    return True
+def _obtain_lock_with_filelock(lockfile_path: pathlib.Path) -> bool:
+    """Helper verifying lock state using filelock."""
+    from filelock import FileLock, Timeout
+    lock = FileLock(lockfile_path)
+    try:
+        lock.acquire(timeout=0)
+        lock.release()
+        return True
+    except Timeout:
+        return False
+    except Exception:
+        return False
 
 
 ###########################################################################
@@ -123,46 +72,50 @@ class TestJournalLock:
 
     @pytest.fixture
     def mock_journaldir(
-        self, monkeypatch: MonkeyPatch, tmp_path_factory: TempdirFactory
-    ) -> Generator:
-        """Fixture for mocking config.get_str('journaldir')."""
+            self, monkeypatch: MonkeyPatch, tmp_path: pathlib.Path
+    ) -> Generator[pathlib.Path, None, None]:
+        """Fixture for mocking config.get_str('journaldir') with a unique directory per test."""
 
         def get_str(key: str, *, default: str | None = None) -> str:
             """Mock config.*Config get_str to provide fake journaldir."""
             if key == "journaldir":
-                return str(tmp_path_factory.getbasetemp())
+                return str(tmp_path)
 
             print("Other key, calling up ...")
-            return config.get_str(key)  # Call the non-mocked
+            return config.get_str(key)
 
         with monkeypatch.context() as m:
             m.setattr(config, "get_str", get_str)
-            yield tmp_path_factory
+            yield tmp_path
 
     @pytest.fixture
     def mock_journaldir_changing(
-        self, monkeypatch: MonkeyPatch, tmp_path_factory: TempdirFactory
-    ) -> Generator:
-        """Fixture for mocking config.get_str('journaldir')."""
+            self, monkeypatch: MonkeyPatch, tmp_path: pathlib.Path
+    ) -> Generator[pathlib.Path, None, None]:
+        """Fixture for mocking config.get_str('journaldir') returning changing directories."""
+        counter = 0
 
         def get_str(key: str, *, default: str | None = None) -> str:
-            """Mock config.*Config get_str to provide fake journaldir."""
+            """Mock config.*Config get_str to provide changing fake journaldirs."""
+            nonlocal counter
             if key == "journaldir":
-                return tmp_path_factory.mktemp("changing")  # type: ignore
+                new_path = tmp_path / f"changing_{counter}"
+                new_path.mkdir(exist_ok=True)
+                counter += 1
+                return str(new_path)
 
             print("Other key, calling up ...")
-            return config.get_str(key)  # Call the non-mocked
+            return config.get_str(key)
 
         with monkeypatch.context() as m:
             m.setattr(config, "get_str", get_str)
-            yield tmp_path_factory
+            yield tmp_path
 
     ###########################################################################
     # Tests against JournalLock.__init__()
-    def test_journal_lock_init(self, mock_journaldir: TempPathFactory):
+    def test_journal_lock_init(self, mock_journaldir: pathlib.Path):
         """Test JournalLock instantiation."""
-        print(f"{type(mock_journaldir)=}")
-        tmpdir = str(mock_journaldir.getbasetemp())
+        tmpdir = str(mock_journaldir)
 
         jlock = JournalLock()
         # Check members are properly initialised.
@@ -181,7 +134,7 @@ class TestJournalLock:
         jlock.set_path_from_journaldir()
         assert jlock.journal_dir_path is None
 
-    def test_path_from_journaldir_with_tmpdir(self, mock_journaldir: TempPathFactory):
+    def test_path_from_journaldir_with_tmpdir(self, mock_journaldir: pathlib.Path):
         """Test JournalLock.set_path_from_journaldir() with tmpdir."""
         tmpdir = mock_journaldir
 
@@ -205,7 +158,7 @@ class TestJournalLock:
         locked = jlock.obtain_lock()
         assert locked == JournalLockResult.JOURNALDIR_IS_NONE
 
-    def test_obtain_lock_with_tmpdir(self, mock_journaldir: TempPathFactory):
+    def test_obtain_lock_with_tmpdir(self, mock_journaldir: pathlib.Path):
         """Test JournalLock.obtain_lock() with tmpdir."""
         jlock = JournalLock()
 
@@ -216,125 +169,40 @@ class TestJournalLock:
 
         # Cleanup, to avoid side-effect on other tests
         assert jlock.release_lock()
-        os.unlink(str(jlock.journal_dir_lockfile_name))
+        if jlock.journal_dir_lockfile_name and jlock.journal_dir_lockfile_name.exists():
+            os.unlink(str(jlock.journal_dir_lockfile_name))
 
-    def test_obtain_lock_with_tmpdir_ro(self, mock_journaldir: TempPathFactory):
-        """Test JournalLock.obtain_lock() with read-only tmpdir."""
-        tmpdir = str(mock_journaldir.getbasetemp())
-        print(f"{tmpdir=}")
-
-        # Make tmpdir read-only ?
-        if sys.platform == "win32":
-            # Ref: <https://stackoverflow.com/a/12168268>
-            import ntsecuritycon as con
-            import win32security
-
-            # Fetch user details
-            winuser, domain, type = win32security.LookupAccountName(
-                "", os.environ.get("USERNAME")
-            )
-            # Fetch the current security of tmpdir for that user.
-            sd = win32security.GetFileSecurity(
-                tmpdir, win32security.DACL_SECURITY_INFORMATION
-            )
-            dacl = (
-                sd.GetSecurityDescriptorDacl()
-            )  # instead of dacl = win32security.ACL()
-
-            # Add Write to Denied list
-            # con.FILE_WRITE_DATA results in a 'Special permissions' being
-            # listed on Properties > Security for the user in the 'Deny' column.
-            # Clicking through to 'Advanced' shows a 'Deny' for
-            # 'Create files / write data'.
-            dacl.AddAccessDeniedAce(
-                win32security.ACL_REVISION, con.FILE_WRITE_DATA, winuser
-            )
-            # Apply that change.
-            sd.SetSecurityDescriptorDacl(1, dacl, 0)  # may not be necessary
-            win32security.SetFileSecurity(
-                tmpdir, win32security.DACL_SECURITY_INFORMATION, sd
-            )
-
-        else:
-            import stat
-
-            os.chmod(tmpdir, stat.S_IRUSR | stat.S_IXUSR)
-
-        jlock = JournalLock()
-
-        # Check that an actual journaldir is handled correctly.
-        locked = jlock.obtain_lock()
-
-        # Revert permissions for test cleanup
-        if sys.platform == "win32":
-            # We can reuse winuser etc from before
-            import pywintypes
-
-            # We have to call GetAce() until we find one that looks like what
-            # we added.
-            i = 0
-            ace = dacl.GetAce(i)
-            while ace:
-                if (
-                    ace[0] == (con.ACCESS_DENIED_ACE_TYPE, 0)
-                    and ace[1] == con.FILE_WRITE_DATA
-                ):
-                    # Delete the Ace that we added
-                    dacl.DeleteAce(i)
-                    # Apply that change.
-                    sd.SetSecurityDescriptorDacl(1, dacl, 0)  # may not be necessary
-                    win32security.SetFileSecurity(
-                        tmpdir, win32security.DACL_SECURITY_INFORMATION, sd
-                    )
-                    break
-
-                i += 1
-                try:
-                    ace = dacl.GetAce(i)
-
-                except pywintypes.error:
-                    print("Couldn't find the Ace we added, so can't remove")
-                    break
-
-        else:
-            os.chmod(tmpdir, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
-
-        assert locked == JournalLockResult.JOURNALDIR_READONLY
-
-    def test_obtain_lock_already_locked(self, mock_journaldir: TempPathFactory):
-        """Test JournalLock.obtain_lock() with tmpdir."""
+    def test_obtain_lock_already_locked(self, mock_journaldir: pathlib.Path):
+        """Test JournalLock.obtain_lock() when already locked by another process."""
         continue_q: mp.Queue = mp.Queue()
         exit_q: mp.Queue = mp.Queue()
         locker = mp.Process(
             target=other_process_lock,
-            args=(continue_q, exit_q, mock_journaldir.getbasetemp()),
+            args=(continue_q, exit_q, mock_journaldir),
         )
         print("Starting sub-process other_process_lock()...")
         locker.start()
-        # Wait for the sub-process to have locked
-        print('Waiting for "go" signal from sub-process...')
-        continue_q.get(block=True, timeout=5)
 
-        print("Attempt actual lock test...")
-        # Now attempt to lock with to-test code
-        jlock = JournalLock()
-        second_attempt = jlock.obtain_lock()
-        assert second_attempt == JournalLockResult.ALREADY_LOCKED
+        try:
+            # Wait for the sub-process to have locked
+            print('Waiting for "go" signal from sub-process...')
+            continue_q.get(block=True, timeout=5)
 
-        # Need to release any handles on the lockfile else the sub-process
-        # might not be able to clean up properly, and that will impact
-        # on later tests.
-        jlock.journal_dir_lockfile.close()  # type: ignore
-
-        print("Telling sub-process to quit...")
-        exit_q.put("quit")
-        print("Waiting for sub-process...")
-        locker.join()
-        print("Done.")
+            print("Attempt actual lock test...")
+            # Now attempt to lock with to-test code
+            jlock = JournalLock()
+            second_attempt = jlock.obtain_lock()
+            assert second_attempt == JournalLockResult.ALREADY_LOCKED
+        finally:
+            print("Telling sub-process to quit...")
+            exit_q.put("quit")
+            print("Waiting for sub-process...")
+            locker.join()
+            print("Done.")
 
     ###########################################################################
     # Tests against JournalLock.release_lock()
-    def test_release_lock(self, mock_journaldir: TempPathFactory):
+    def test_release_lock(self, mock_journaldir: pathlib.Path):
         """Test JournalLock.release_lock()."""
         # First actually obtain the lock, and check it worked
         jlock = JournalLock()
@@ -344,37 +212,47 @@ class TestJournalLock:
         # Now release the lock
         assert jlock.release_lock()
 
-        # And finally check it actually IS unlocked.
-        with open(
-            mock_journaldir.getbasetemp() / "edmc-journal-lock.txt", mode="w+"
-        ) as lf:
-            assert _obtain_lock("release-lock", lf)
-            assert _release_lock("release-lock", lf)
+        # Check it actually IS unlocked using the filelock backend engine
+        lock_file_path = mock_journaldir / "edmc-journal-lock.txt"
+        assert _obtain_lock_with_filelock(lock_file_path)
 
         # Cleanup, to avoid side-effect on other tests
-        os.unlink(str(jlock.journal_dir_lockfile_name))
+        if jlock.journal_dir_lockfile_name and jlock.journal_dir_lockfile_name.exists():
+            os.unlink(str(jlock.journal_dir_lockfile_name))
 
-    def test_release_lock_not_locked(self, mock_journaldir: TempPathFactory):
+    def test_release_lock_not_locked(self, mock_journaldir: pathlib.Path):
         """Test JournalLock.release_lock() when not locked."""
         jlock = JournalLock()
         assert jlock.release_lock()
 
-    def test_release_lock_lie_locked(self, mock_journaldir: TempPathFactory):
-        """Test JournalLock.release_lock() when not locked, but lie we are."""
+    def test_release_lock_lie_locked(self, mock_journaldir: pathlib.Path):
+        """Test JournalLock.release_lock() when an internal exception occurs during release."""
         jlock = JournalLock()
+        jlock.journal_dir_lockfile_name = mock_journaldir / "edmc-journal-lock.txt"
+
+        from filelock import FileLock
+        jlock.lock = FileLock(jlock.journal_dir_lockfile_name)
         jlock.locked = True
-        assert jlock.release_lock() is False
+
+        # Monkeypatch filelock's release method to raise an exception, verifying the failure path
+        def mock_release_fail(*args, **kwargs):
+            raise OSError("Simulated structural lock release failure")
+
+        jlock.lock.release = mock_release_fail
+
+        try:
+            assert jlock.release_lock() is False
+        finally:
+            # Revert monkeypatch to prevent unraisable deallocator warning on GC cleanup
+            del jlock.lock.release
+            jlock.lock = None
+            jlock.locked = False
 
     ###########################################################################
     # Tests against JournalLock.update_lock()
-    def test_update_lock(self, mock_journaldir_changing: TempPathFactory):
+    def test_update_lock(self, mock_journaldir_changing: pathlib.Path):
         """
         Test JournalLock.update_lock().
-
-        NB: This uses mock_journaldir_changing so that each subsequent call
-            to config.get_str('journaldir') gets a new, unique, path.
-            This should mean that the call to update_lock() switches to a new
-            journaldir.
         """
         # First actually obtain the lock, and check it worked
         jlock = JournalLock()
@@ -391,16 +269,15 @@ class TestJournalLock:
 
         # Cleanup, to avoid side-effect on other tests
         assert jlock.release_lock()
-        os.unlink(str(jlock.journal_dir_lockfile_name))
+        if jlock.journal_dir_lockfile_name and jlock.journal_dir_lockfile_name.exists():
+            os.unlink(str(jlock.journal_dir_lockfile_name))
         # And the old_journaldir's lockfile too
-        os.unlink(str(old_journaldir_lockfile_name))
+        if old_journaldir_lockfile_name and old_journaldir_lockfile_name.exists():
+            os.unlink(str(old_journaldir_lockfile_name))
 
-    def test_update_lock_same(self, mock_journaldir: TempPathFactory):
+    def test_update_lock_same(self, mock_journaldir: pathlib.Path):
         """
-        Test JournalLock.update_lock().
-
-        Due to using 'static' mock_journaldir this should 'work', because the
-        directory is still the same.
+        Test JournalLock.update_lock() when path remains identical.
         """
         # First actually obtain the lock, and check it worked
         jlock = JournalLock()
@@ -416,4 +293,5 @@ class TestJournalLock:
 
         # Cleanup, to avoid side-effect on other tests
         assert jlock.release_lock()
-        os.unlink(str(jlock.journal_dir_lockfile_name))
+        if jlock.journal_dir_lockfile_name and jlock.journal_dir_lockfile_name.exists():
+            os.unlink(str(jlock.journal_dir_lockfile_name))


### PR DESCRIPTION
<!---
Thank you for submitting a PR for EDMC! Please follow this template to ensure your PR is processed.
In general, you should be submitting targeting the develop branch. Please make sure you have this selected.
-->
# Description
This PR removes the custom file locking mechanism EDMC has maintained since early 2021. This duty is now primarily handled by the `filelock` library, a lightweight and well-known library (over half a billion downloads over the last month) which provides cross-platform functionality. This reduces the amount of boilerplate and custom code, which will make the project easier to maintain over time. 

This also helps more strictly enforce process metadata with Windows file share locks, and provides more verbose evidence when something goes wrong.

# Type of Change
<!-- What type of change is this? New Feature? Enhancement to Existing Feature? Bug Fix? Translation Update? -->
Enhancement

# How Tested
<!-- How have you tested this change to ensure it works and doesn't cause new issues -->
Tested to ensure the existing .txt lock is respected, such that two processes can't both run at the same time. 
Tested with updated PyTest suite